### PR TITLE
fix: enable semantic release, travis and appveyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+dist: trusty
+sudo: false
+notifications:
+  email: false
+language: node_js
+node_js:
+  - "8"
+  # - "6" # enable once tests are typescriptified
+  # - "4" # enable once tests are typescriptified
+cache:
+  directories:
+    - node_modules
+script:
+  - "npm run lint"
+  - "npm test"
+jobs:
+  include:
+    - stage: npm release
+      node_js: "8"
+      script: skip
+      after_success:
+        - npm run semantic-release
+branches:
+  only:
+    - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+# https://www.appveyor.com/docs/appveyor-yml
+
+# to disable automatic builds
+build: off
+branches:
+  only:
+    - master
+
+init:
+  - git config --global core.autocrlf true
+
+shallow_clone: true
+clone_depth: 1
+
+cache:
+  - node_modules -> package.json
+
+environment:
+  matrix:
+    - nodejs_version: "8"
+    # - nodejs_version: "6" # enable with CLI integration
+    # - nodejs_version: "4" # enable with CLI integration
+
+matrix:
+  fast_finish: true
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
+  - npm install
+
+test_script:
+  - npm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@snyk/lockfile-parser",
-  "version": "1.0.0",
+  "name": "snyk-nodejs-lockfile-parser",
   "description": "Generate a dep tree given a lockfile",
   "main": "dist/lib/index.js",
   "scripts": {
@@ -9,15 +8,16 @@
     "lint": "tslint lib/**/*.ts",
     "build": "tsc",
     "build-watch": "tsc -w",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/snyk/lockfile-parser.git"
+    "url": "https://github.com/snyk/nodejs-lockfile-parser.git"
   },
   "author": "snyk.io",
-  "license": "private",
-  "homepage": "https://github.com/snyk/lockfile-parser#readme",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/snyk/nodejs-lockfile-parser#readme",
   "dependencies": {
     "lodash": "4.17.10",
     "path": "0.12.7"
@@ -29,6 +29,7 @@
     "tap": "github:snyk/node-tap#alternative-runtimes",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",
-    "typescript": "3.0.1"
+    "typescript": "3.0.1",
+    "semantic-release": "^8.2.0"
   }
 }


### PR DESCRIPTION
- [x] Commit history is tidy [ℹ︎]()

### What this does

Adjusting `package.json` for semantic release
* npm package will be called `snyk-nodejs-lockfile-parser`, and will be public

Enabling travis and appveyor configs