### PR TITLE
fix: enable strict compilation and address findings

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,15 +2,10 @@ import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
 import {LockfileParser, Lockfile, ManifestFile, PkgTree,
-  DepType, parseManifestFile} from './parsers';
+  DepType, parseManifestFile, LockfileType} from './parsers';
 import {PackageLockParser} from './parsers/package-lock-parser';
 import {YarnLockParser} from './parsers/yarn-lock-parse';
 import getRuntimeVersion from './get-node-runtime-version';
-
-enum LockfileType {
-  npm = 'npm',
-  yarn = 'yarn',
-}
 
 export {
   buildDepTree,

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -9,7 +9,7 @@ export interface Dep {
 }
 
 export interface ManifestFile {
-  name?: string;
+  name: string;
   dependencies?: {
     [dep: string]: string;
   };
@@ -22,7 +22,7 @@ export interface ManifestFile {
 export interface PkgTree {
   name: string;
   version: string;
-  dependencies?: {
+  dependencies: {
     [dep: string]: PkgTree;
   };
   depType?: DepType;
@@ -33,6 +33,11 @@ export interface PkgTree {
 export enum DepType {
   prod = 'prod',
   dev = 'dev',
+}
+
+export enum LockfileType {
+  npm = 'npm',
+  yarn = 'yarn',
 }
 
 export interface LockfileParser {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true,
+        "strict": true,
+        "noImplicitAny": false // Needed to compile tap
     },
     "include": [
         "./lib/**/*",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎]()
- [ ] Documentation written [ℹ︎]()
- [x] Commit history is tidy [ℹ︎]()

### What this does

Adds strict compilation in order to be compliant with Typescript consumers with strict compilation enabled.

### More information

- [SC-5891](https://snyksec.atlassian.net/browse/SC-5891)
