### PR TITLE
perf: faster package-lock tree creation

### DIFF
--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import * as graphlib from 'graphlib';
 import * as uuid from 'uuid/v4';
+import {setImmediatePromise} from '../set-immediate-promise';
 
 import {LockfileParser, PkgTree, Dep, DepType, ManifestFile,
   getTopLevelDeps, Lockfile, LockfileType} from './';
@@ -114,7 +115,7 @@ export class PackageLockParser implements LockfileParser {
         // if the top level dependency is dev, all children are dev
         depTree.dependencies[dep.name] = dep.dev ?
           this.setDevDepRec(_.cloneDeep(depTrees[depName])) : depTrees[depName];
-        await this.setImmediatePromise();
+        await setImmediatePromise();
       }
     }
     return depTree;
@@ -147,40 +148,40 @@ export class PackageLockParser implements LockfileParser {
   private removeCycle(
     cycle: string[], depMap: DepMap, depGraph: graphlib.Graph): CycleStartMap {
 
+    /* FUNCTION DEFINITION
+    To keep an order of algorithm steps readable, function is defined on-the-fly
+    Arrow function is used for calling `this` without .bind(this) in the end
+    */
+    const acyclicDuplicationRec = (node, traversed, currentCycle, nodeCopy) => {
+      // 2. For every cyclic dependency of entry node...
+      const edgesToProcess = (depGraph.inEdges(node) as graphlib.Edge[])
+      .filter((e) => _.includes(currentCycle, e.v));
+      for (const edge of edgesToProcess) {
+        // ... create a duplicate of the dependency...
+        const child = edge.v;
+        const dependencyCopy = this.cloneNodeWithoutEdges(child, depMap, depGraph);
+        // ...and connect it with the duplicated entry node
+        depGraph.setEdge(dependencyCopy, nodeCopy);
+        // 3.a If edge goes to already-visited dependency, end of cycle is found;
+        if (_.includes(traversed, child)) {
+          // update metadata and do not continue traversing
+          depMap[dependencyCopy].cyclic = true;
+        } else {
+          // 3.b Follow the edge and repeat the process, storing visited dependency-paths
+          acyclicDuplicationRec(child, [...traversed, node], currentCycle, dependencyCopy);
+          // All non-cyclic dependencies of duplicated node need to be updated.
+          this.cloneAcyclicNodeEdges(child, dependencyCopy, cycle, depGraph,
+          {inEdges: true, outEdges: false});
+        }
+      }
+    };
+
     const cycleStarts: CycleStartMap = {};
     // For every node in a cycle:
     for (const start of cycle) {
       // 1. Create a uniqe duplicate of entry node (without edges)
       const clonedNode = this.cloneNodeWithoutEdges(start, depMap, depGraph);
       cycleStarts[start] = clonedNode;
-
-      /* FUNCTION DEFINITION
-        To keep an order of algorithm steps readable, function is defined on-the-fly
-        Arrow function is used for calling `this` without .bind(this) in the end
-      */
-      const acyclicDuplicationRec = (node, traversed, currentCycle, nodeCopy) => {
-        // 2. For every cyclic dependency of entry node...
-        const edgesToProcess = (depGraph.inEdges(node) as graphlib.Edge[])
-          .filter((e) => _.includes(currentCycle, e.v));
-        for (const edge of edgesToProcess) {
-          // ... create a duplicate of the dependency...
-          const child = edge.v;
-          const dependencyCopy = this.cloneNodeWithoutEdges(child, depMap, depGraph);
-          // ...and connect it with the duplicated entry node
-          depGraph.setEdge(dependencyCopy, nodeCopy);
-          // 3.a If edge goes to already-visited dependency, end of cycle is found;
-          if (_.includes(traversed, child)) {
-            // update metadata and do not continue traversing
-            depMap[dependencyCopy].cyclic = true;
-          } else {
-            // 3.b Follow the edge and repeat the process, storing visited dependency-paths
-            acyclicDuplicationRec(child, [...traversed, node], currentCycle, dependencyCopy);
-            // All non-cyclic dependencies of duplicated node need to be updated.
-            this.cloneAcyclicNodeEdges(child, dependencyCopy, cycle, depGraph,
-              {inEdges: true, outEdges: false});
-          }
-        }
-      };
 
       // CALL of previously defined function
       acyclicDuplicationRec(start, [], cycle, clonedNode);
@@ -266,10 +267,6 @@ export class PackageLockParser implements LockfileParser {
     return depName;
   }
 
-  private setImmediatePromise() {
-    return new Promise((resolve) => setImmediate(resolve));
-  }
-
   // Algorithm is based on dynamic programming technique and tries to build
   // "more simple" trees and compose them into bigger ones.
   private async createDepTrees(depMap: DepMap, depGraph): Promise<{[depPath: string]: PkgTree}> {
@@ -296,17 +293,21 @@ export class PackageLockParser implements LockfileParser {
         dep.dependencies[subDep.name] = subDep;
       }
       const pkgTree: PkgTree = {
-        cyclic: dep.cyclic,
         depType: dep.depType,
         dependencies: dep.dependencies,
-        hasDevDependencies: dep.hasDevDependencies,
         name: dep.name,
         version: dep.version,
       };
+      if (dep.cyclic) {
+        pkgTree.cyclic = dep.cyclic;
+      }
+      if (dep.hasDevDependencies) {
+        pkgTree.hasDevDependencies = dep.hasDevDependencies;
+      }
       depTrees[depKey] = pkgTree;
       // Since this code doesn't handle any I/O or network, we need to force
       // event loop to tick while being used in server for request processing
-      await this.setImmediatePromise();
+      await setImmediatePromise();
     }
 
     return depTrees;

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -138,7 +138,7 @@ export class PackageLockParser implements LockfileParser {
     function walkCycleRec(node, traversed, currentCycle, nodeCopy) {
       // 2. For every cyclic dependency of entry node...
       const edgesToProcess = (depGraph.inEdges(node) as graphlib.Edge[])
-        .filter((e) => currentCycle.includes(e.v));
+        .filter((e) => _.includes(currentCycle, e.v));
       for (const edge of edgesToProcess) {
       // ... create a duplicate of the dependency...
         const copyName = edge.v + uuid();
@@ -146,7 +146,7 @@ export class PackageLockParser implements LockfileParser {
         depGraph.setEdge(copyName, nodeCopy);
         // metadata update
         depMap[copyName] = _.cloneDeep(depMap[edge.v]);
-        if (traversed.includes(edge.v)) {
+        if (_.includes(traversed, edge.v)) {
           // 3.a If edge goes to already-visited dependency, end of cycle is found;
           // update metadata and do not continue traversing
           depMap[copyName].cyclic = true;
@@ -156,7 +156,7 @@ export class PackageLockParser implements LockfileParser {
           walkCycleRec(edge.v, [...traversed, node], currentCycle, copyName);
           // All non-cyclic dependencies of duplicated node need to be updated.
           const edgesToCopy = (depGraph.inEdges(edge.v) as graphlib.Edge[])
-            .filter((e) => !currentCycle.includes(e.v));
+            .filter((e) => !_.includes(currentCycle, e.v));
           for (const edgeToCopy of edgesToCopy) {
             depGraph.setEdge(edgeToCopy.v, copyName);
           }

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -228,14 +228,7 @@ export class PackageLockParser implements LockfileParser {
   private async createDepTrees(depMap: DepMap, depGraph): Promise<{[depPath: string]: PkgTree}> {
 
     function setImmediatePromise() {
-      return new Promise((resolve, reject) => {
-        return setImmediate((err) => {
-          if (err) {
-            return reject(err);
-          }
-          resolve();
-        });
-      });
+      return new Promise((resolve) => setImmediate(resolve));
     }
 
     // Graph has to be acyclic
@@ -260,6 +253,8 @@ export class PackageLockParser implements LockfileParser {
       }
       delete dep.requires;
       depTrees[depKey] = {...dep as PkgTree};
+      // Since this code doesn't handle any I/O or network, we need to force
+      // event loop to tick while being used in server for request processing
       await setImmediatePromise();
     }
 

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -1,4 +1,7 @@
 import * as _ from 'lodash';
+import * as graphlib from 'graphlib';
+import * as uuid from 'uuid/v4';
+
 import {LockfileParser, PkgTree, Dep, DepType, ManifestFile,
   getTopLevelDeps, Lockfile, LockfileType} from './';
 import {InvalidUserInputError, OutOfSyncError} from '../errors';
@@ -24,7 +27,17 @@ export interface PackageLockDep {
   dev?: boolean;
 }
 
+interface DepMap {
+  [path: string]: DepMapItem;
+}
+
+interface DepMapItem extends PkgTree {
+  dependenciesPathsToProcess: string[];
+}
+
 export class PackageLockParser implements LockfileParser {
+
+  private pathDelimiter = ',';
 
   public parseLockFile(lockFileContents: string): PackageLock {
     try {
@@ -52,64 +65,214 @@ export class PackageLockParser implements LockfileParser {
       version: manifestFile.version || '',
     };
 
-    const topLevelDeps: Dep[] = getTopLevelDeps(manifestFile, includeDev);
-
     // asked to process empty deps
     if (_.isEmpty(manifestFile.dependencies) && !includeDev) {
       return depTree;
     }
 
+    // prepare a flat map, where dependency path is a key to dependency object
+    // path is an unique identifier for each dependency and corresponds to the
+    // relative path on disc
+    const depMap: DepMap = await this.flattenLockfile(packageLock);
+
+    // all paths are identified, we can create a graph of their dependency
+    const depGraph = this.createGraphOfDependencies(depMap);
+
+    // topological sort will be applied and it requires acyclic graphs, so we
+    // have to remove cycles
+    const cycleStarts = {};
+    if (!graphlib.alg.isAcyclic(depGraph)) {
+      const cycles = graphlib.alg.findCycles(depGraph);
+      for (const cycle of cycles) {
+        removeCycle(cycle);
+      }
+    }
+
+    /* Algorithm for cycle removal:
+      For every node in a cycle:
+        1. Create a duplicate of entry node (without edges)
+        2. For every cyclic dependency of entry node, create a duplicate of
+            the dependency and connect it with the duplicated entry node
+        3.a If edge goes to already-visited dependency, end of cycle is found;
+            update metadata and do not continue traversing
+        3.b Follow the edge and repeat the process, storing visited dependency-paths.
+            All non-cyclic dependencies of duplicated node need to be updated.
+        4. All non-cyclic dependencies or dependants of original node need to be
+          updated to be connected with the duplicated one
+
+      Once completed for all nodes in a cycle, original cyclic nodes can
+      be removed.
+    */
+
+    function removeCycle(cycle) {
+      // For every node in a cycle:
+      for (const start of cycle) {
+        // 1. Create a duplicate of entry node (without edges)
+        const newNode = start + uuid();
+        cycleStarts[start] = newNode;
+        depMap[newNode] = depMap[start];
+        depGraph.setNode(newNode);
+        walkCycleRec(start, [], cycle, newNode);
+        // 4. All non-cyclic dependencies or dependants of original node need to be
+        //   updated to be connected with the duplicated one
+        // dependats
+        const entryEdges = depGraph.outEdges(start).filter((e) => !cycle.includes(e.w));
+        for (const edge of entryEdges) {
+          depGraph.setEdge(newNode, edge.w);
+        }
+        // dependencies
+        const outEdges = depGraph.inEdges(start).filter((e) => !cycle.includes(e.v));
+        for (const edge of outEdges) {
+          depGraph.setEdge(edge.v, newNode);
+        }
+      }
+
+      // Once completed for all nodes in a cycle, original cyclic nodes can
+      // be removed.
+      for (const start of cycle) {
+        depGraph.removeNode(start);
+      }
+    }
+
+    function walkCycleRec(node, traversed, cycle, nodeCopy) {
+      // 2. For every cyclic dependency of entry node, create a duplicate of
+      // the dependency and connect it with the duplicated entry node
+      const edges = depGraph.inEdges(node).filter((e) => cycle.includes(e.v));
+      for (const edge of edges) {
+        let copyName;
+        if (traversed.includes(edge.v)) {
+          // 3.a If edge goes to already-visited dependency, end of cycle is found;
+          // update metadata and do not continue traversing
+          copyName = edge.v + uuid();
+          depGraph.setEdge(copyName, nodeCopy);
+          // metadata update
+          depMap[copyName] = _.cloneDeep(depMap[edge.v]);
+          depMap[copyName].cyclic = true;
+        } else {
+          // 3.b Follow the edge and repeat the process, storing visited dependency-paths
+          copyName = edge.v + uuid();
+          // metadata update
+          depMap[copyName] = _.cloneDeep(depMap[edge.v]);
+          depGraph.setEdge(copyName, nodeCopy);
+          walkCycleRec(edge.v, [...traversed, node], cycle, copyName);
+          // All non-cyclic dependencies of duplicated node need to be updated.
+          const edgesToCopy = depGraph.inEdges(edge.v).filter((e) => !cycle.includes(e.v));
+          for (const edgeToCopy of edgesToCopy) {
+            depGraph.setEdge(edgeToCopy.v, copyName);
+          }
+        }
+      }
+    }
+
+    // transform depMap to a map of PkgTrees
+    const depTreesCache: {[depPath: string]: PkgTree} = await this.createDepTrees(depMap, depGraph);
+
+    // get trees for dependencies from manifest file
+    const topLevelDeps: Dep[] = getTopLevelDeps(manifestFile, includeDev);
     await Promise.all(topLevelDeps.map(async (dep) => {
-      depTree.dependencies[dep.name] = await this.buildSubTreeRecursiveFromPackageLock(
-        dep.name, ['dependencies'], packageLock, [], dep.dev);
+      const depName = cycleStarts[dep.name] ? cycleStarts[dep.name] : dep.name;
+      if (depTreesCache[depName]) {
+        depTree.dependencies[dep.name] = depTreesCache[depName];
+      }
     }));
 
     return depTree;
   }
 
-  private async buildSubTreeRecursiveFromPackageLock(
-    depName: string, lockfilePath: string[], lockFile: PackageLock,
-    depPath: string[], isDev = false): Promise<PkgTree> {
+  private createGraphOfDependencies(depMap: DepMap): any {
+    const depGraph = new graphlib.Graph();
+    for (const depName of Object.keys(depMap)) {
+      depGraph.setNode(depName, depName);
+    }
+    for (const [depPath, dep] of _.entries(depMap)) {
+      for (const depName of dep.dependenciesPathsToProcess) {
+        const subDepPath = this.findDepsPath(depPath, depName, depMap);
+        // direction is from the dependency to the package requiring it
+        depGraph.setEdge(subDepPath, depPath);
+      }
+    }
 
-    const depSubTree: PkgTree = {
-      depType: undefined,
-      dependencies: {},
-      name: depName,
-      version: '', // will be set later or error will be thrown
+    return depGraph;
+  }
+
+  // dependency in package-lock.json v1 can be defined either inside `dependencies`
+  // of other dependency or anywhere upward towards root
+  private findDepsPath(startPath: string, depName: string, depMap: DepMap): string {
+    const depPath = startPath.split(this.pathDelimiter);
+    while (depPath.length) {
+      const currentPath = depPath.concat(depName).toString();
+      if (depMap[currentPath]) {
+        return currentPath;
+      }
+      depPath.pop();
+    }
+    if (!depMap[depName]) {
+      throw new OutOfSyncError(depName, 'npm');
+    }
+
+    return depName;
+  }
+
+  // Algorithm is based on dynamic programming technique and tries to build
+  // "more simple" trees and compose them into bigger ones.
+  private async createDepTrees(depMap: any, depGraph): Promise<{[depPath: string]: PkgTree}> {
+
+    // Graph has to be acyclic
+    if (!graphlib.alg.isAcyclic(depGraph)) {
+      throw new Error('Cycles were not removed from graph.');
+    }
+
+    const depTrees: {[depPath: string]: PkgTree} = {};
+    // topological sort guarantees that all the dependencies, which doesn't require
+    // anything else, will be processed first
+    const depOrder = graphlib.alg.topsort(depGraph);
+
+    while (depOrder.length) {
+      const depKey = depOrder.shift() as string;
+      const dep = depMap[depKey];
+
+      // direction is from the dependency to the package requiring it, so we are
+      // looking for predecessors
+      for (const subDepPath of depGraph.predecessors(depKey)) {
+        const subDep = depTrees[subDepPath];
+        dep.dependencies[subDep.name] = subDep;
+      }
+      delete dep.dependenciesPathsToProcess;
+      depTrees[depKey] = {...dep as PkgTree};
+    }
+
+    // console.log(depTrees);
+
+    return depTrees;
+  }
+
+  private async flattenLockfile(lockfile: PackageLock): Promise<DepMap> {
+    const depQueue: DepMap = {};
+
+    const flattenLockfileRec = async (lockfileDeps: PackageLockDeps, path: string[]) => {
+      await Promise.all(_.entries(lockfileDeps).map(async ([depName, dep]) => {
+        const depNode: DepMapItem = {
+          depType: dep.dev ? DepType.dev : DepType.prod,
+          dependencies: {},
+          dependenciesPathsToProcess: [],
+          name: depName,
+          version: dep.version,
+        };
+
+        if (dep.requires) {
+          depNode.dependenciesPathsToProcess = Object.keys(dep.requires);
+        }
+
+        const depKey: string[] = [...path, depName];
+        depQueue[depKey.join(this.pathDelimiter)] = depNode;
+        if (dep.dependencies) {
+          await flattenLockfileRec(dep.dependencies, depKey);
+        }
+      }));
     };
 
-    // try to get list of deps on the path
-    const deps: PackageLockDeps = _.get(lockFile, lockfilePath);
-    const dep: PackageLockDep = _.get(deps, depName);
-    // If exists and looked-up dep is there
-    if (dep) {
-      // update the tree
-      depSubTree.version = dep.version;
-      depSubTree.depType = (isDev || dep.dev) ? DepType.dev : DepType.prod;
-      // check if we already have a package at particular version in the traversed path
-      const depKey = `${depName}@${dep.version}`;
-      if (depPath.indexOf(depKey) >= 0) {
-        depSubTree.cyclic = true;
-      } else {
-        // if not, add it
-        depPath.push(depKey);
-        // repeat the process for dependencies of looked-up dep
-        const newDeps = dep.requires ? Object.keys(dep.requires) : [];
+    await flattenLockfileRec(lockfile.dependencies || {}, []);
 
-        await Promise.all(newDeps.map(async (subDep) => {
-          depSubTree.dependencies[subDep] = await this.buildSubTreeRecursiveFromPackageLock(
-            subDep, [...lockfilePath, depName, 'dependencies'], lockFile, depPath.slice(), isDev);
-        }));
-      }
-      return depSubTree;
-    } else {
-      // tree was walked to the root and dependency was not found
-      if (!lockfilePath.length) {
-        throw new OutOfSyncError(depName, 'npm');
-      }
-      // dependency was not found on a current path, remove last key (move closer to the root) and try again
-      // visitedDepPaths can be passed by a reference, because traversing up doesn't update it
-      return this.buildSubTreeRecursiveFromPackageLock(depName, lockfilePath.slice(0, -1), lockFile, depPath, isDev);
-    }
+    return depQueue;
   }
 }

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -116,6 +116,8 @@ export class PackageLockParser implements LockfileParser {
         depTree.dependencies[dep.name] = dep.dev ?
           this.setDevDepRec(_.cloneDeep(depTrees[depName])) : depTrees[depName];
         await setImmediatePromise();
+      } else {
+        throw new OutOfSyncError(depName, 'npm');
       }
     }
     return depTree;

--- a/lib/set-immediate-promise.ts
+++ b/lib/set-immediate-promise.ts
@@ -1,0 +1,3 @@
+export function setImmediatePromise() {
+  return new Promise((resolve) => setImmediate(resolve));
+}

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
   "homepage": "https://github.com/snyk/nodejs-lockfile-parser#readme",
   "dependencies": {
     "@yarnpkg/lockfile": "^1.0.2",
+    "graphlib": "^2.1.5",
     "lodash": "4.17.10",
     "source-map-support": "^0.5.7",
-    "tslib": "^1.9.3"
+    "tslib": "^1.9.3",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.116",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@types/graphlib": "^2.1.4",
     "@types/lodash": "^4.14.116",
     "@types/node": "^4.0.47",
+    "@types/uuid": "^3.4.4",
     "tap": "github:snyk/node-tap#alternative-runtimes",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",

--- a/test/lib/fixtures/cyclic-dep-self-reference/cyclic-dep-self-reference-2/package.json
+++ b/test/lib/fixtures/cyclic-dep-self-reference/cyclic-dep-self-reference-2/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cyclic-dep-self-reference-2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cyclic-dep-self-reference": "file:../../cyclic-dep-self-reference"
+  }
+}

--- a/test/lib/fixtures/cyclic-dep-self-reference/package-lock.json
+++ b/test/lib/fixtures/cyclic-dep-self-reference/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "cyclic-dep-self-reference",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "cyclic-dep-self-reference": {
+      "version": "file:",
+      "requires": {
+        "cyclic-dep-self-reference-2": "file:cyclic-dep-self-reference-2"
+      },
+      "dependencies": {
+        "cyclic-dep-self-reference-2": {
+          "version": "file:cyclic-dep-self-reference-2",
+          "requires": {
+            "cyclic-dep-self-reference": "file:"
+          }
+        }
+      }
+    },
+    "cyclic-dep-self-reference-2": {
+      "version": "file:cyclic-dep-self-reference-2",
+      "requires": {
+        "cyclic-dep-self-reference": "file:"
+      }
+    }
+  }
+}

--- a/test/lib/fixtures/cyclic-dep-self-reference/package.json
+++ b/test/lib/fixtures/cyclic-dep-self-reference/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cyclic-dep-self-reference",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "cyclic-dep-self-reference-2": "file:./cyclic-dep-self-reference-2"
+  }
+}

--- a/test/lib/package-lock.ts
+++ b/test/lib/package-lock.ts
@@ -136,6 +136,15 @@ test('Parse npm package-lock.json with cyclic deps', async (t) => {
   t.strictEqual(depTree.dependencies.debug.dependencies.ms.dependencies.debug.cyclic, true, 'Cyclic dependency is found correctly');
 });
 
+test('Parse npm package-lock.json with self-reference cyclic deps', async (t) => {
+  const depTree = await buildDepTreeFromFiles(
+    `${__dirname}/fixtures/cyclic-dep-self-reference/`,
+    'package.json',
+    'package-lock.json',
+  );
+  t.ok(depTree.dependencies, 'Tree is created');
+});
+
 test('Performance: Parse big npm package-lock.json with cyclic deps and dev-deps', async (t) => {
   const depTree = await buildDepTreeFromFiles(
     `${__dirname}/fixtures/cyclic-dep/`,


### PR DESCRIPTION
🚧 **DO NOT MERGE** 🚧

- [x] Tests written and linted [ℹ︎]()
- [ ] Documentation written [ℹ︎]()
- [x] Commit history is tidy [ℹ︎]()

### What this does

Big `package-lock.json` parsing was slow. This PR introduces better parsing algorithm, which speeds up parsing a lot. 

_Instructions on how to run this locally, background context, what to review, questions…_
Proper testing is still needed to be sure that functionality is the same. Tests are passing*, but they can't cover everything. However, it's pretty hard to verify what's right for the output with ~million lines.

\* I am aware about one failing, it's a topic for the discussion about the meaning of `depType` property.

*Before:*
```
$ time parse-nodejs-lockfile > /dev/null
parse-nodejs-lockfile > /dev/null  30.25s user 1.24s system 123% cpu 25.522 total
```
*After:*
```
$ time node ../lockfile-parser/bin > /dev/null
node ../lockfile-parser/bin > /dev/null  0.39s user 0.06s system 103% cpu 0.436 total
```

*30.25s* vs  *0.39s*
