### PR TITLE
fix: Allow package.json to have missing dependency property

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -47,9 +47,7 @@ async function buildDepTree(
   }
 
   const manifestFile: ManifestFile = parseManifestFile(manifestFileContents);
-  if (!manifestFile.dependencies && !includeDev) {
-    throw new Error("No 'dependencies' property in package.json");
-  }
+
   const lockFile: Lockfile = lockfileParser.parseLockFile(lockFileContents);
   return lockfileParser.getDependencyTree(manifestFile, lockFile, includeDev);
 }

--- a/test/lib/fixtures/dev-deps-only/expected-tree-empty.json
+++ b/test/lib/fixtures/dev-deps-only/expected-tree-empty.json
@@ -1,0 +1,6 @@
+{
+  "name": "pkg-dev-deps-only",
+  "version": "0.0.1",
+  "hasDevDependencies": true,
+  "dependencies": {}
+}

--- a/test/lib/package-lock.ts
+++ b/test/lib/package-lock.ts
@@ -115,6 +115,17 @@ test('Parse npm package-lock.json with dev deps only', async (t) => {
   t.deepEqual(depTree, expectedDepTree, 'Tree is created with dev deps only');
 });
 
+test('Parse npm package-lock.json with dev deps only', async (t) => {
+  const expectedDepTreeEmpty = load('dev-deps-only/expected-tree-empty.json');
+  const depTree = await buildDepTreeFromFiles(
+    `${__dirname}/fixtures/dev-deps-only/`,
+    'package.json',
+    'package-lock.json',
+    false,
+  );
+  t.deepEqual(depTree, expectedDepTreeEmpty, 'Tree is created empty');
+});
+
 test('Parse npm package-lock.json with cyclic deps', async (t) => {
   const depTree = await buildDepTreeFromFiles(
     `${__dirname}/fixtures/cyclic-dep-simple/`,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎]()
- [x] Commit history is tidy [ℹ︎]()

### What this does

Even though `dependencies` is a required field for npm, `npm init` doesn't seem to generate this property and users can easily not add the `dependencies` to the file. Return empty tree if this happens and do not error.
### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [SC-6322](https://snyksec.atlassian.net/browse/SC-6322)
