### PR TITLE
feat: export error classes

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,7 +7,7 @@ import {LockfileParser, Lockfile, ManifestFile, PkgTree,
 import {PackageLockParser} from './parsers/package-lock-parser';
 import {YarnLockParser} from './parsers/yarn-lock-parse';
 import getRuntimeVersion from './get-node-runtime-version';
-import {UnsupportedRuntimeError, InvalidUserInputError} from './errors';
+import {UnsupportedRuntimeError, InvalidUserInputError, OutOfSyncError} from './errors';
 
 export {
   buildDepTree,
@@ -15,6 +15,9 @@ export {
   PkgTree,
   DepType,
   LockfileType,
+  UnsupportedRuntimeError,
+  InvalidUserInputError,
+  OutOfSyncError,
 };
 
 async function buildDepTree(


### PR DESCRIPTION
In order to catch/error properly, it will be handy to re-recreate exactly same error from outside world.
- [x] Commit history is tidy [ℹ︎]()

### What this does

Allows catching/stubbing real errors from outside world (handy for testing different reactions by consumers of lockfile parser.