### PR TITLE
Perf/yarn parsing update

### DIFF
--- a/lib/event-loop-spinner.ts
+++ b/lib/event-loop-spinner.ts
@@ -1,0 +1,13 @@
+export class EventLoopSpinner {
+  private lastSpin: number;
+  constructor(private thresholdMs: number = 100) {
+    this.lastSpin = Date.now();
+  }
+  public isStarving(): boolean {
+    return (Date.now() - this.lastSpin) > this.thresholdMs;
+  }
+  public async spin() {
+    this.lastSpin = Date.now();
+    return new Promise((resolve) => setImmediate(resolve));
+  }
+}

--- a/lib/parsers/yarn-lock-parse.ts
+++ b/lib/parsers/yarn-lock-parse.ts
@@ -79,14 +79,14 @@ export class YarnLockParser implements LockfileParser {
       return depTree;
     }
 
-    await Promise.all(topLevelDeps.map(async (dep) => {
-    if (/^file:/.test(dep.version)) {
-      depTree.dependencies[dep.name] = createPkgTreeFromDep(dep);
-    } else {
-      depTree.dependencies[dep.name] = await this.buildSubTreeRecursiveFromYarnLock(
-        dep, yarnLock, [], strict);
+    for (const dep of topLevelDeps) {
+      if (/^file:/.test(dep.version)) {
+        depTree.dependencies[dep.name] = createPkgTreeFromDep(dep);
+      } else {
+        depTree.dependencies[dep.name] = await this.buildSubTreeRecursiveFromYarnLock(
+          dep, yarnLock, [], strict);
       }
-    }));
+    }
 
     return depTree;
   }
@@ -123,7 +123,7 @@ export class YarnLockParser implements LockfileParser {
       depPath.push(depKey);
       const newDeps = _.entries({...dep.dependencies, ...dep.optionalDependencies});
 
-      await Promise.all(newDeps.map(async ([name, version]) => {
+      for (const [name, version] of newDeps) {
         const newDep: Dep = {
           dev: searchedDep.dev,
           name,
@@ -131,7 +131,7 @@ export class YarnLockParser implements LockfileParser {
         };
         depSubTree.dependencies[name] = await this.buildSubTreeRecursiveFromYarnLock(
           newDep, lockFile, [...depPath]);
-      }));
+      }
     }
 
     return depSubTree;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎]()
- [ ] Documentation written [ℹ︎]()
- [x] Commit history is tidy [ℹ︎]()

### What this does

Once used in a webservice, blocking and event loop for a long time is a bad pattern preventing requests to be processed in a desired pace. This PR updates a package to allow event loop to tick during the parsing process. 
