### PR TITLE
feat: lockfile parser must always return `depTree.name`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,7 +23,7 @@ export {
 async function buildDepTree(
   manifestFileContents: string, lockFileContents: string,
   includeDev = false, lockfileType?: LockfileType,
-  strict: boolean = true): Promise<PkgTree> {
+  strict: boolean = true, manifestFilePath: string = 'package.json'): Promise<PkgTree> {
 
   if (!lockfileType) {
     lockfileType = LockfileType.npm;
@@ -51,6 +51,9 @@ async function buildDepTree(
   }
 
   const manifestFile: ManifestFile = parseManifestFile(manifestFileContents);
+  if (!manifestFile.name) {
+      manifestFile.name = manifestFilePath;
+  }
 
   const lockFile: Lockfile = lockfileParser.parseLockFile(lockFileContents);
   return lockfileParser.getDependencyTree(manifestFile, lockFile, includeDev, strict);
@@ -88,6 +91,7 @@ async function buildDepTreeFromFiles(
   const manifestFileContents = fs.readFileSync(manifestFileFullPath, 'utf-8');
   const lockFileContents = fs.readFileSync(lockFileFullPath, 'utf-8');
 
+  // note: currenty we path manifestFilePath just a file name, so we can use the param as is
   return await buildDepTree(manifestFileContents, lockFileContents, includeDev,
-    lockFileType, strict);
+    lockFileType, strict, manifestFilePath);
 }

--- a/test/lib/package-lock.ts
+++ b/test/lib/package-lock.ts
@@ -80,7 +80,7 @@ test('Parse npm package-lock.json with missing package name', async (t) => {
   );
 
   t.false(_.isEmpty(depTree.dependencies));
-  t.equals(depTree.name, undefined);
+  t.equals(depTree.name, 'package.json');
 });
 
 test('Parse npm package-lock.json with empty dependencies and includeDev = false', async (t) => {

--- a/test/lib/yarn.ts
+++ b/test/lib/yarn.ts
@@ -120,7 +120,7 @@ if (getRuntimeVersion() < 6) {
     );
 
     t.false(_.isEmpty(depTree.dependencies));
-    t.equals(depTree.name, undefined);
+    t.equals(depTree.name, 'package.json');
   });
 
   test('Parse yarn.lock with empty dependencies and includeDev = false', async (t) => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎]()
- [ ] Documentation written [ℹ︎]()
- [x] Commit history is tidy [ℹ︎]()

### What this does
When package name is missing use manifest filename instead

### More information
https://snyksec.atlassian.net/browse/SC-6758### Screenshots