### PR TITLE
feat: add tree size in the output

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -30,6 +30,7 @@ export interface PkgTree {
   hasDevDependencies?: boolean;
   cyclic?: boolean;
   missingLockFileEntry?: boolean;
+  size?: number;
 }
 
 export enum DepType {

--- a/test/lib/fixtures/dev-deps-only/expected-tree-empty.json
+++ b/test/lib/fixtures/dev-deps-only/expected-tree-empty.json
@@ -1,5 +1,6 @@
 {
   "name": "pkg-dev-deps-only",
+  "size": 1,
   "version": "0.0.1",
   "hasDevDependencies": true,
   "dependencies": {}

--- a/test/lib/fixtures/dev-deps-only/expected-tree.json
+++ b/test/lib/fixtures/dev-deps-only/expected-tree.json
@@ -1,5 +1,6 @@
 {
   "name": "pkg-dev-deps-only",
+  "size": 3,
   "version": "0.0.1",
   "hasDevDependencies": true,
   "dependencies": {

--- a/test/lib/fixtures/external-tarball/expected-tree.json
+++ b/test/lib/fixtures/external-tarball/expected-tree.json
@@ -98,5 +98,6 @@
   },
   "hasDevDependencies": false,
   "name": "external-tarball",
+  "size": 16,
   "version": ""
 }

--- a/test/lib/fixtures/file-as-version/expected-tree.json
+++ b/test/lib/fixtures/file-as-version/expected-tree.json
@@ -22,5 +22,6 @@
   },
   "hasDevDependencies": false,
   "name": "pkg-dev-deps-only",
+  "size": 4,
   "version": "0.0.1"
 }

--- a/test/lib/fixtures/git-ssh-url-deps/expected-tree.json
+++ b/test/lib/fixtures/git-ssh-url-deps/expected-tree.json
@@ -98,5 +98,6 @@
   },
   "hasDevDependencies": false,
   "name": "git-ssh-url-deps",
+  "size": 16,
   "version": ""
 }

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
@@ -5854,5 +5854,6 @@
   },
   "hasDevDependencies": true,
   "name": "goof",
-  "version": "0.0.3"
+  "version": "0.0.3",
+  "size": 914
 }

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
@@ -1,6 +1,7 @@
 {
   "name": "goof",
   "version": "0.0.3",
+  "size": 910,
   "hasDevDependencies": true,
   "dependencies": {
     "adm-zip": {

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps-yarn.json
@@ -11450,5 +11450,6 @@
   },
   "hasDevDependencies": true,
   "name": "goof",
-  "version": "0.0.3"
+  "version": "0.0.3",
+  "size": 1795
 }

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
@@ -11425,5 +11425,6 @@
   },
   "hasDevDependencies": true,
   "name": "goof",
-  "version": "0.0.3"
+  "version": "0.0.3",
+  "size": 1791
 }

--- a/test/lib/fixtures/missing-deps/expected-tree.json
+++ b/test/lib/fixtures/missing-deps/expected-tree.json
@@ -1,5 +1,6 @@
 {
   "name": "pkg-missing-deps",
+  "size": 1,
   "version": "1.0.0",
   "hasDevDependencies": false,
   "dependencies": {}

--- a/test/lib/fixtures/out-of-sync-tree/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync-tree/expected-tree.json
@@ -188,5 +188,6 @@
   },
   "hasDevDependencies": true,
   "name": "out-of-sync-small",
+  "size": 30,
   "version": "1.0.0"
 }

--- a/test/lib/fixtures/out-of-sync/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync/expected-tree.json
@@ -38,5 +38,6 @@
   },
   "hasDevDependencies": true,
   "name": "trucolor",
+  "size": 6,
   "version": "0.7.1"
 }

--- a/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
+++ b/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
@@ -1,5 +1,6 @@
 {
   "name": "goof",
+  "size": 17,
   "version": "0.0.3",
   "hasDevDependencies": true,
   "dependencies": {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎]()
- [ ] Documentation written [ℹ︎]()
- [x] Commit history is tidy [ℹ︎]()

### What this does

We want to know how many dependencies totally in the tree. It's useful for debug purposes when, for example, we want to measure why so much time we spend on parsing.
