### PR TITLE
fix: bump vulnerable lodash 4.17.10 to ^4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@yarnpkg/lockfile": "^1.0.2",
     "graphlib": "^2.1.5",
-    "lodash": "4.17.10",
+    "lodash": "^4.17.11",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"


### PR DESCRIPTION
fixes these vulns:
* https://dev.snyk.io/vuln/SNYK-JS-LODASH-73638
* https://dev.snyk.io/vuln/SNYK-JS-LODASH-73639
