### PR TITLE
feat: Allow us to identify yarn workspaces in package.json

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,8 +2,16 @@ import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as _ from 'lodash';
-import {LockfileParser, Lockfile, ManifestFile, PkgTree,
-  DepType, parseManifestFile, LockfileType} from './parsers';
+import {
+  LockfileParser,
+  Lockfile,
+  ManifestFile,
+  PkgTree,
+  DepType,
+  parseManifestFile,
+  LockfileType,
+  getYarnWorkspaces,
+} from './parsers';
 import {PackageLockParser} from './parsers/package-lock-parser';
 import {YarnLockParser} from './parsers/yarn-lock-parse';
 import getRuntimeVersion from './get-node-runtime-version';
@@ -12,6 +20,8 @@ import {UnsupportedRuntimeError, InvalidUserInputError, OutOfSyncError} from './
 export {
   buildDepTree,
   buildDepTreeFromFiles,
+  getYarnWorkspacesFromFiles,
+  getYarnWorkspaces,
   PkgTree,
   DepType,
   LockfileType,
@@ -93,4 +103,18 @@ async function buildDepTreeFromFiles(
 
   return await buildDepTree(manifestFileContents, lockFileContents, includeDev,
     lockFileType, strict, manifestFilePath);
+}
+
+function getYarnWorkspacesFromFiles(root, manifestFilePath: string): string [] | false {
+  if (!root || !manifestFilePath) {
+    throw new Error('Missing required parameters for getYarnWorkspacesFromFiles()');
+  }
+  const manifestFileFullPath = path.resolve(root, manifestFilePath);
+  if (!fs.existsSync(manifestFileFullPath)) {
+    throw new InvalidUserInputError('Target file package.json not found at ' +
+      `location: ${manifestFileFullPath}`);
+  }
+  const manifestFileContents = fs.readFileSync(manifestFileFullPath, 'utf-8');
+
+  return getYarnWorkspaces(manifestFileContents);
 }

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -11,6 +11,8 @@ export interface Dep {
 
 export interface ManifestFile {
   name: string;
+  private?: string;
+  workspaces?: string[];
   dependencies?: {
     [dep: string]: string;
   };
@@ -91,4 +93,17 @@ export function createPkgTreeFromDep(dep: Dep): PkgTree {
   };
 
   return pkgTree;
+}
+
+export function getYarnWorkspaces(targetFile: string): string [] | false {
+  try {
+    const packageJson: ManifestFile = parseManifestFile(targetFile);
+    if (!!packageJson.workspaces && !!packageJson.private) {
+      return [...packageJson.workspaces];
+    }
+    return false;
+  } catch (e) {
+    throw new InvalidUserInputError('package.json parsing failed with ' +
+      `error ${e.message}`);
+  }
 }

--- a/test/lib/fixtures/yarn-workspace/package.json
+++ b/test/lib/fixtures/yarn-workspace/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "jest",
+  "devDependencies": {
+    "chalk": "^2.0.1"
+  },
+  "workspaces": [
+    "packages/*",
+    "libs/*"
+  ]
+}

--- a/test/lib/yarn.ts
+++ b/test/lib/yarn.ts
@@ -4,7 +4,7 @@
 // tslint:disable:max-line-length
 // tslint:disable:object-literal-key-quotes
 import {test} from 'tap';
-import {buildDepTreeFromFiles} from '../../lib';
+import {buildDepTreeFromFiles, getYarnWorkspacesFromFiles} from '../../lib';
 import getRuntimeVersion from '../../lib/get-node-runtime-version';
 import * as fs from 'fs';
 import * as _ from 'lodash';
@@ -216,3 +216,19 @@ if (getRuntimeVersion() < 6) {
     t.deepEqual(depTree, expectedDepTree, 'Tree generated as expected');
   });
 }
+
+test('Identify package.json as a yarn workspace', async (t) => {
+  const workspaces = getYarnWorkspacesFromFiles(
+    `${__dirname}/fixtures/yarn-workspace/`,
+    'package.json',
+  );
+  t.deepEqual(workspaces, [ 'packages/*', 'libs/*' ], 'Workspaces identified as expected');
+});
+
+test('identify package.json as Not a workspace project', async (t) => {
+  const workspaces = getYarnWorkspacesFromFiles(
+    `${__dirname}/fixtures/external-tarball/`,
+    'package.json',
+  );
+  t.is(workspaces, false, 'Not a yarn workspace');
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎]()
- [ ] Documentation written [ℹ︎]()
- [x] Commit history is tidy [ℹ︎]()

### What this does
Identify if a `package.json` is a yarn workspace, we can start using this to log/treat/process these projects differenly