### PR TITLE
feat: Collect node version as targetRuntime

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -31,8 +31,10 @@ export interface PkgTree {
   dependencies: {
     [dep: string]: PkgTree;
   };
+  meta?: {
+    nodeVersion: string;
+  };
   depType?: DepType;
-  targetRuntime?: string;
   hasDevDependencies?: boolean;
   cyclic?: boolean;
   missingLockFileEntry?: boolean;

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -12,6 +12,9 @@ export interface Dep {
 export interface ManifestFile {
   name: string;
   private?: string;
+  engines?: {
+    node?: string;
+  };
   workspaces?: string[];
   dependencies?: {
     [dep: string]: string;
@@ -29,6 +32,7 @@ export interface PkgTree {
     [dep: string]: PkgTree;
   };
   depType?: DepType;
+  targetRuntime?: string;
   hasDevDependencies?: boolean;
   cyclic?: boolean;
   missingLockFileEntry?: boolean;

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -79,10 +79,10 @@ export class PackageLockParser implements LockfileParser {
       version: manifestFile.version || '',
     };
 
-    const targetRuntime = _.get(manifestFile, 'engines.node');
+    const nodeVersion = _.get(manifestFile, 'engines.node');
 
-    if (targetRuntime) {
-      depTree.targetRuntime = targetRuntime;
+    if (nodeVersion) {
+      _.set(depTree, 'meta.nodeVersion', nodeVersion);
     }
 
     // asked to process empty deps

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -79,6 +79,12 @@ export class PackageLockParser implements LockfileParser {
       version: manifestFile.version || '',
     };
 
+    const targetRuntime = _.get(manifestFile, 'engines.node');
+
+    if (targetRuntime) {
+      depTree.targetRuntime = targetRuntime;
+    }
+
     // asked to process empty deps
     if (_.isEmpty(manifestFile.dependencies) && !includeDev) {
       return depTree;

--- a/lib/parsers/yarn-lock-parse.ts
+++ b/lib/parsers/yarn-lock-parse.ts
@@ -79,9 +79,9 @@ export class YarnLockParser implements LockfileParser {
       version: manifestFile.version || '',
     };
 
-    const targetRuntime = _.get(manifestFile, 'engines.node');
-    if (targetRuntime) {
-      depTree.targetRuntime = targetRuntime;
+    const nodeVersion = _.get(manifestFile, 'engines.node');
+    if (nodeVersion) {
+      _.set(depTree, 'meta.nodeVersion', nodeVersion);
     }
 
     const topLevelDeps: Dep[] = getTopLevelDeps(manifestFile, includeDev);

--- a/lib/parsers/yarn-lock-parse.ts
+++ b/lib/parsers/yarn-lock-parse.ts
@@ -79,6 +79,11 @@ export class YarnLockParser implements LockfileParser {
       version: manifestFile.version || '',
     };
 
+    const targetRuntime = _.get(manifestFile, 'engines.node');
+    if (targetRuntime) {
+      depTree.targetRuntime = targetRuntime;
+    }
+
     const topLevelDeps: Dep[] = getTopLevelDeps(manifestFile, includeDev);
 
     // asked to process empty deps

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
@@ -5855,5 +5855,6 @@
   "hasDevDependencies": true,
   "name": "goof",
   "version": "0.0.3",
-  "size": 914
+  "size": 914,
+  "targetRuntime": "6.14.1"
 }

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
@@ -5856,5 +5856,7 @@
   "name": "goof",
   "version": "0.0.3",
   "size": 914,
-  "targetRuntime": "6.14.1"
+  "meta": {
+    "nodeVersion": "6.14.1"
+  }
 }

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
@@ -2,6 +2,7 @@
   "name": "goof",
   "version": "0.0.3",
   "size": 910,
+  "targetRuntime": "6.14.1",
   "hasDevDependencies": true,
   "dependencies": {
     "adm-zip": {

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
@@ -2,7 +2,9 @@
   "name": "goof",
   "version": "0.0.3",
   "size": 910,
-  "targetRuntime": "6.14.1",
+  "meta": {
+    "nodeVersion": "6.14.1"
+  },
   "hasDevDependencies": true,
   "dependencies": {
     "adm-zip": {

--- a/test/lib/fixtures/goof/dep-tree-original.json
+++ b/test/lib/fixtures/goof/dep-tree-original.json
@@ -4,6 +4,7 @@
   "license": "none",
   "depType": "extraneous",
   "hasDevDependencies": true,
+  "targetRuntime": "6.14.1",
   "full": "goof@0.0.3",
   "__filename": "/Users/mila/dev/snyk/goof/package.json",
   "dependencies": {

--- a/test/lib/fixtures/goof/dep-tree-original.json
+++ b/test/lib/fixtures/goof/dep-tree-original.json
@@ -4,7 +4,9 @@
   "license": "none",
   "depType": "extraneous",
   "hasDevDependencies": true,
-  "targetRuntime": "6.14.1",
+  "meta": {
+    "nodeVersion": "6.14.1"
+  },
   "full": "goof@0.0.3",
   "__filename": "/Users/mila/dev/snyk/goof/package.json",
   "dependencies": {

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps-yarn.json
@@ -11452,5 +11452,7 @@
   "name": "goof",
   "version": "0.0.3",
   "size": 1795,
-  "targetRuntime": "6.14.1"
+  "meta": {
+    "nodeVersion": "6.14.1"
+  }
 }

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps-yarn.json
@@ -11451,5 +11451,6 @@
   "hasDevDependencies": true,
   "name": "goof",
   "version": "0.0.3",
-  "size": 1795
+  "size": 1795,
+  "targetRuntime": "6.14.1"
 }

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
@@ -11427,5 +11427,7 @@
   "name": "goof",
   "version": "0.0.3",
   "size": 1791,
-  "targetRuntime": "6.14.1"
+  "meta": {
+    "nodeVersion": "6.14.1"
+  }
 }

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
@@ -11426,5 +11426,6 @@
   "hasDevDependencies": true,
   "name": "goof",
   "version": "0.0.3",
-  "size": 1791
+  "size": 1791,
+  "targetRuntime": "6.14.1"
 }

--- a/test/lib/fixtures/out-of-sync/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync/expected-tree.json
@@ -40,5 +40,7 @@
   "name": "trucolor",
   "size": 6,
   "version": "0.7.1",
-  "targetRuntime": ">=8.0"
+  "meta": {
+    "nodeVersion": ">=8.0"
+  }
 }

--- a/test/lib/fixtures/out-of-sync/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync/expected-tree.json
@@ -39,5 +39,6 @@
   "hasDevDependencies": true,
   "name": "trucolor",
   "size": 6,
-  "version": "0.7.1"
+  "version": "0.7.1",
+  "targetRuntime": ">=8.0"
 }

--- a/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
+++ b/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
@@ -3,7 +3,9 @@
   "size": 17,
   "version": "0.0.3",
   "hasDevDependencies": true,
-  "targetRuntime": "10.8.0",
+  "meta":{
+    "nodeVersion": "10.8.0"
+  },
   "dependencies": {
     "body-parser": {
       "name": "body-parser",

--- a/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
+++ b/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
@@ -3,6 +3,7 @@
   "size": 17,
   "version": "0.0.3",
   "hasDevDependencies": true,
+  "targetRuntime": "10.8.0",
   "dependencies": {
     "body-parser": {
       "name": "body-parser",


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-dotnet/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

Start collecting the node version as targetRuntime to be displayed in registry & used for FIX later on to make sure we execute on a similar enviroment.

Further down the line also needed to show node vulns & filter vulns that affect only certain version of node.

*Not used by anything yet, will need to raise a PR in Registry to display it + CLI to start sending it*

### More information

- [BST-559](https://snyksec.atlassian.net/browse/BST-559)
