### PR TITLE
Fix/move to depgraph to fix performance

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -28,7 +28,7 @@ export interface ManifestFile {
 export interface PkgTree {
   name: string;
   version: string;
-  dependencies: {
+  dependencies?: {
     [dep: string]: PkgTree;
   };
   meta?: {
@@ -37,10 +37,10 @@ export interface PkgTree {
   labels?: {
      scope?: Scope;
      pruned?: 'cyclic';
+     missingLockFileEntry?: boolean;
   };
   hasDevDependencies?: boolean;
   cyclic?: boolean;
-  missingLockFileEntry?: boolean;
   size?: number;
 }
 
@@ -95,7 +95,6 @@ export function getTopLevelDeps(targetFile: ManifestFile, includeDev: boolean): 
 
 export function createPkgTreeFromDep(dep: Dep): PkgTree {
   const pkgTree: PkgTree = {
-    dependencies: {},
     labels: {
        scope: dep.dev ? Scope.dev : Scope.prod,
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/graphlib": "^2.1.4",
     "@types/lodash": "^4.14.136",
-    "@types/node": "^4.0.47",
+    "@types/node": "^6.14.7",
     "@types/uuid": "^3.4.4",
     "tap": "^12.6.1",
     "tslint": "5.11.0",

--- a/test/lib/fixtures/dev-deps-only/expected-tree-empty.json
+++ b/test/lib/fixtures/dev-deps-only/expected-tree-empty.json
@@ -2,6 +2,5 @@
   "name": "pkg-dev-deps-only",
   "size": 1,
   "version": "0.0.1",
-  "hasDevDependencies": true,
-  "dependencies": {}
+  "hasDevDependencies": true
 }

--- a/test/lib/fixtures/dev-deps-only/expected-tree.json
+++ b/test/lib/fixtures/dev-deps-only/expected-tree.json
@@ -16,8 +16,7 @@
           "version": "2.0.0",
           "labels": {
             "scope": "dev"
-          },
-          "dependencies": {}
+          }
         }
       }
     }

--- a/test/lib/fixtures/external-tarball/expected-tree.json
+++ b/test/lib/fixtures/external-tarball/expected-tree.json
@@ -9,7 +9,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bytes",
           "version": "1.0.0"
         },
@@ -17,7 +16,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.0.1"
         },
@@ -25,7 +23,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "iconv-lite",
           "version": "0.4.4"
         },
@@ -33,7 +30,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "media-typer",
           "version": "0.3.0"
         },
@@ -41,7 +37,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "qs",
           "version": "2.2.4"
         },
@@ -54,7 +49,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.0.5"
             }
@@ -71,7 +65,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "bytes",
               "version": "1.0.0"
             },
@@ -79,7 +72,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "iconv-lite",
               "version": "0.4.4"
             }
@@ -96,7 +88,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "media-typer",
               "version": "0.3.0"
             },
@@ -109,7 +100,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.12.0"
                 }

--- a/test/lib/fixtures/file-as-version/expected-tree.json
+++ b/test/lib/fixtures/file-as-version/expected-tree.json
@@ -9,7 +9,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ms",
           "version": "2.0.0"
         }
@@ -21,7 +20,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "shared",
       "version": "file:./some-file"
     }

--- a/test/lib/fixtures/git-ssh-url-deps/expected-tree.json
+++ b/test/lib/fixtures/git-ssh-url-deps/expected-tree.json
@@ -9,7 +9,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bytes",
           "version": "1.0.0"
         },
@@ -17,7 +16,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.0.1"
         },
@@ -25,7 +23,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "iconv-lite",
           "version": "0.4.4"
         },
@@ -33,7 +30,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "media-typer",
           "version": "0.3.0"
         },
@@ -41,7 +37,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "qs",
           "version": "2.2.4"
         },
@@ -54,7 +49,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.0.5"
             }
@@ -71,7 +65,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "bytes",
               "version": "1.0.0"
             },
@@ -79,7 +72,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "iconv-lite",
               "version": "0.4.4"
             }
@@ -96,7 +88,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "media-typer",
               "version": "0.3.0"
             },
@@ -109,7 +100,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.12.0"
                 }

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
@@ -4,7 +4,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "dustjs-linkedin",
       "version": "2.5.0"
     },
@@ -12,7 +11,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "dustjs-helpers",
       "version": "1.5.0"
     },
@@ -20,7 +18,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "ejs",
       "version": "1.0.0"
     },
@@ -28,7 +25,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "jquery",
       "version": "2.2.4"
     },
@@ -36,7 +32,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "marked",
       "version": "0.3.5"
     },
@@ -44,7 +39,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "moment",
       "version": "2.15.1"
     },
@@ -52,7 +46,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "ms",
       "version": "0.7.3"
     },
@@ -60,7 +53,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "optional",
       "version": "0.1.4"
     },
@@ -68,7 +60,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "stream-buffers",
       "version": "3.0.2"
     },
@@ -76,7 +67,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "adm-zip",
       "version": "0.4.7"
     },
@@ -84,7 +74,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "file-type",
       "version": "8.1.0"
     },
@@ -97,7 +86,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie",
           "version": "0.1.2"
         },
@@ -105,7 +93,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie-signature",
           "version": "1.0.5"
         }
@@ -122,7 +109,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bluebird",
           "version": "3.5.1"
         }
@@ -139,7 +125,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ejs",
           "version": "0.8.8"
         }
@@ -156,7 +141,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ms",
           "version": "0.6.2"
         }
@@ -173,7 +157,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "methods",
           "version": "1.1.2"
         },
@@ -181,7 +164,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "parseurl",
           "version": "1.3.2"
         },
@@ -189,7 +171,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "vary",
           "version": "1.1.2"
         },
@@ -202,7 +183,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "2.0.0"
             }
@@ -223,7 +203,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.1.2"
         },
@@ -231,7 +210,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "on-headers",
           "version": "1.0.1"
         },
@@ -244,7 +222,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             }
@@ -261,7 +238,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "2.0.0"
             }
@@ -278,7 +254,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.1.1"
             }
@@ -299,7 +274,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "inherits",
           "version": "1.0.2"
         },
@@ -307,7 +281,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ini",
           "version": "1.1.0"
         },
@@ -315,7 +288,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mkdirp",
           "version": "0.3.5"
         },
@@ -323,7 +295,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "once",
           "version": "1.1.1"
         },
@@ -331,7 +302,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "osenv",
           "version": "0.0.3"
         },
@@ -339,7 +309,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "semver",
           "version": "1.1.4"
         },
@@ -352,7 +321,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ini",
               "version": "1.3.5"
             },
@@ -360,7 +328,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "proto-list",
               "version": "1.2.4"
             }
@@ -377,7 +344,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "abbrev",
               "version": "1.0.7"
             }
@@ -398,7 +364,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bytes",
           "version": "1.0.0"
         },
@@ -406,7 +371,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.0.1"
         },
@@ -414,7 +378,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "iconv-lite",
           "version": "0.4.4"
         },
@@ -422,7 +385,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "media-typer",
           "version": "0.3.0"
         },
@@ -430,7 +392,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "qs",
           "version": "2.2.4"
         },
@@ -443,7 +404,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.0.5"
             }
@@ -460,7 +420,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "bytes",
               "version": "1.0.0"
             },
@@ -468,7 +427,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "iconv-lite",
               "version": "0.4.4"
             }
@@ -485,7 +443,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "media-typer",
               "version": "0.3.0"
             },
@@ -498,7 +455,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.12.0"
                 }
@@ -523,7 +479,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ports",
           "version": "1.1.0"
         },
@@ -531,7 +486,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "underscore",
           "version": "1.8.3"
         },
@@ -544,7 +498,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "esprima",
               "version": "4.0.1"
             },
@@ -557,7 +510,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "sprintf-js",
                   "version": "1.0.3"
                 }
@@ -582,7 +534,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "escape-html",
           "version": "1.0.1"
         },
@@ -595,7 +546,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "negotiator",
               "version": "0.4.9"
             },
@@ -608,7 +558,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.12.0"
                 }
@@ -633,7 +582,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "fd",
           "version": "0.0.3"
         },
@@ -641,7 +589,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mime",
           "version": "1.2.11"
         },
@@ -649,7 +596,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "negotiator",
           "version": "0.2.8"
         },
@@ -662,7 +608,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "lru-cache",
               "version": "2.3.1"
             }
@@ -674,7 +619,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "graceful-fs",
           "version": "1.2.3"
         }
@@ -691,7 +635,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "content-disposition",
           "version": "0.5.0"
         },
@@ -699,7 +642,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "content-type",
           "version": "1.0.4"
         },
@@ -707,7 +649,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie",
           "version": "0.1.2"
         },
@@ -715,7 +656,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie-signature",
           "version": "1.0.6"
         },
@@ -723,7 +663,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.0.1"
         },
@@ -731,7 +670,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "escape-html",
           "version": "1.0.1"
         },
@@ -739,7 +677,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "fresh",
           "version": "0.2.4"
         },
@@ -747,7 +684,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "merge-descriptors",
           "version": "1.0.0"
         },
@@ -755,7 +691,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "methods",
           "version": "1.1.2"
         },
@@ -763,7 +698,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "parseurl",
           "version": "1.3.2"
         },
@@ -771,7 +705,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "path-to-regexp",
           "version": "0.1.3"
         },
@@ -779,7 +712,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "qs",
           "version": "2.4.2"
         },
@@ -787,7 +719,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "range-parser",
           "version": "1.0.3"
         },
@@ -795,7 +726,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "utils-merge",
           "version": "1.0.0"
         },
@@ -803,7 +733,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "vary",
           "version": "1.0.1"
         },
@@ -816,7 +745,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "0.7.1"
             }
@@ -833,7 +761,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "crc",
               "version": "3.2.1"
             }
@@ -850,7 +777,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.1.0"
             }
@@ -867,7 +793,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "forwarded",
               "version": "0.1.2"
             },
@@ -875,7 +800,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ipaddr.js",
               "version": "1.0.5"
             }
@@ -892,7 +816,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "negotiator",
               "version": "0.5.3"
             },
@@ -905,7 +828,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.35.0"
                 }
@@ -926,7 +848,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -939,7 +860,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -956,7 +876,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ee-first",
                   "version": "1.1.0"
                 }
@@ -977,7 +896,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "depd",
               "version": "1.0.1"
             },
@@ -985,7 +903,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "destroy",
               "version": "1.0.3"
             },
@@ -993,7 +910,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -1001,7 +917,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "fresh",
               "version": "0.2.4"
             },
@@ -1009,7 +924,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "mime",
               "version": "1.3.4"
             },
@@ -1017,7 +931,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "0.7.1"
             },
@@ -1025,7 +938,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "range-parser",
               "version": "1.0.3"
             },
@@ -1038,7 +950,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -1055,7 +966,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "crc",
                   "version": "3.2.1"
                 }
@@ -1072,7 +982,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ee-first",
                   "version": "1.1.0"
                 }
@@ -1093,7 +1002,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "media-typer",
               "version": "0.3.0"
             },
@@ -1106,7 +1014,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.35.0"
                 }
@@ -1127,7 +1034,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -1135,7 +1041,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "parseurl",
               "version": "1.3.2"
             },
@@ -1143,7 +1048,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "utils-merge",
               "version": "1.0.0"
             },
@@ -1156,7 +1060,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "depd",
                   "version": "1.0.1"
                 },
@@ -1164,7 +1067,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "destroy",
                   "version": "1.0.3"
                 },
@@ -1172,7 +1074,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "escape-html",
                   "version": "1.0.1"
                 },
@@ -1180,7 +1081,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "fresh",
                   "version": "0.2.4"
                 },
@@ -1188,7 +1088,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime",
                   "version": "1.3.4"
                 },
@@ -1196,7 +1095,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 },
@@ -1204,7 +1102,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "range-parser",
                   "version": "1.0.3"
                 },
@@ -1217,7 +1114,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ms",
                       "version": "0.7.1"
                     }
@@ -1234,7 +1130,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "crc",
                       "version": "3.2.1"
                     }
@@ -1251,7 +1146,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ee-first",
                       "version": "1.1.0"
                     }
@@ -1280,7 +1174,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "async",
           "version": "0.9.0"
         },
@@ -1288,7 +1181,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bson",
           "version": "0.4.23"
         },
@@ -1296,7 +1188,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "hooks-fixed",
           "version": "1.1.0"
         },
@@ -1304,7 +1195,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "kareem",
           "version": "1.0.1"
         },
@@ -1312,7 +1202,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mpath",
           "version": "0.1.1"
         },
@@ -1320,7 +1209,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mpromise",
           "version": "0.5.4"
         },
@@ -1328,7 +1216,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ms",
           "version": "0.7.1"
         },
@@ -1336,7 +1223,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "muri",
           "version": "1.0.0"
         },
@@ -1344,7 +1230,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "regexp-clone",
           "version": "0.0.1"
         },
@@ -1352,7 +1237,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "sliced",
           "version": "0.0.5"
         },
@@ -1365,7 +1249,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "bluebird",
               "version": "2.9.26"
             },
@@ -1373,7 +1256,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "regexp-clone",
               "version": "0.0.1"
             },
@@ -1381,7 +1263,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "sliced",
               "version": "0.0.5"
             },
@@ -1394,7 +1275,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -1415,7 +1295,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "es6-promise",
               "version": "2.1.1"
             },
@@ -1428,7 +1307,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -1436,7 +1314,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -1444,7 +1321,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "0.0.1"
                 },
@@ -1452,7 +1328,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "string_decoder",
                   "version": "0.10.31"
                 }
@@ -1469,7 +1344,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "bson",
                   "version": "0.4.23"
                 },
@@ -1482,7 +1356,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "nan",
                       "version": "2.10.0"
                     }
@@ -1511,7 +1384,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "streamifier",
           "version": "0.1.1"
         },
@@ -1534,7 +1406,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -1542,7 +1413,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -1550,7 +1420,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "0.0.1"
                     },
@@ -1558,7 +1427,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "string_decoder",
                       "version": "0.10.31"
                     }
@@ -1575,7 +1443,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "streamsearch",
                       "version": "0.1.2"
                     },
@@ -1588,7 +1455,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "core-util-is",
                           "version": "1.0.2"
                         },
@@ -1596,7 +1462,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -1604,7 +1469,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isarray",
                           "version": "0.0.1"
                         },
@@ -1612,7 +1476,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "string_decoder",
                           "version": "0.10.31"
                         }
@@ -1641,7 +1504,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "graceful-fs",
               "version": "4.1.4"
             },
@@ -1654,7 +1516,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "graceful-fs",
                   "version": "4.1.11"
                 }
@@ -1676,7 +1537,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "fs.realpath",
                       "version": "1.0.0"
                     },
@@ -1684,7 +1544,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.1"
                     },
@@ -1692,7 +1551,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "path-is-absolute",
                       "version": "1.0.0"
                     },
@@ -1705,7 +1563,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -1722,7 +1579,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         },
@@ -1735,7 +1591,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -1761,7 +1616,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "1.0.0"
                             },
@@ -1769,7 +1623,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -1806,7 +1659,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bluebird",
           "version": "3.5.1"
         },
@@ -1814,7 +1666,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "clean-yaml-object",
           "version": "0.1.0"
         },
@@ -1822,7 +1673,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "deeper",
           "version": "2.1.0"
         },
@@ -1830,7 +1680,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "isexe",
           "version": "1.1.2"
         },
@@ -1838,7 +1687,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "only-shallow",
           "version": "1.2.0"
         },
@@ -1846,7 +1694,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "opener",
           "version": "1.4.3"
         },
@@ -1854,7 +1701,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "signal-exit",
           "version": "2.1.2"
         },
@@ -1862,7 +1708,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "stack-utils",
           "version": "0.4.0"
         },
@@ -1870,7 +1715,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "supports-color",
           "version": "1.3.1"
         },
@@ -1878,7 +1722,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "tmatch",
           "version": "2.0.1"
         },
@@ -1891,7 +1734,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "esprima",
               "version": "4.0.1"
             },
@@ -1904,7 +1746,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "sprintf-js",
                   "version": "1.0.3"
                 }
@@ -1925,7 +1766,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "core-util-is",
               "version": "1.0.2"
             },
@@ -1933,7 +1773,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -1941,7 +1780,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "1.0.0"
             },
@@ -1949,7 +1787,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "process-nextick-args",
               "version": "2.0.0"
             },
@@ -1957,7 +1794,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             },
@@ -1965,7 +1801,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "util-deprecate",
               "version": "1.0.2"
             },
@@ -1978,7 +1813,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -1999,7 +1833,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "signal-exit",
               "version": "2.1.2"
             },
@@ -2012,7 +1845,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isexe",
                   "version": "1.1.2"
                 }
@@ -2034,7 +1866,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "pseudomap",
                       "version": "1.0.2"
                     },
@@ -2042,7 +1873,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "yallist",
                       "version": "2.0.0"
                     }
@@ -2059,7 +1889,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -2084,7 +1913,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "fs.realpath",
               "version": "1.0.0"
             },
@@ -2092,7 +1920,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.1"
             },
@@ -2100,7 +1927,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "path-is-absolute",
               "version": "1.0.0"
             },
@@ -2113,7 +1939,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 }
@@ -2130,7 +1955,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 },
@@ -2143,7 +1967,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -2169,7 +1992,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "balanced-match",
                       "version": "1.0.0"
                     },
@@ -2177,7 +1999,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "concat-map",
                       "version": "0.0.1"
                     }
@@ -2202,7 +2023,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "events-to-array",
               "version": "1.1.2"
             },
@@ -2210,7 +2030,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2223,7 +2042,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "4.0.1"
                 },
@@ -2236,7 +2054,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -2257,7 +2074,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2265,7 +2081,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2273,7 +2088,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2281,7 +2095,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2289,7 +2102,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2297,7 +2109,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2310,7 +2121,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2335,7 +2145,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "lcov-parse",
               "version": "0.0.10"
             },
@@ -2343,7 +2152,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "log-driver",
               "version": "1.2.5"
             },
@@ -2351,7 +2159,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "minimist",
               "version": "1.2.0"
             },
@@ -2364,7 +2171,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "2.7.3"
                 },
@@ -2377,7 +2183,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -2398,7 +2203,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws-sign2",
                   "version": "0.6.0"
                 },
@@ -2406,7 +2210,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws4",
                   "version": "1.7.0"
                 },
@@ -2414,7 +2217,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "caseless",
                   "version": "0.11.0"
                 },
@@ -2422,7 +2224,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "extend",
                   "version": "3.0.2"
                 },
@@ -2430,7 +2231,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "forever-agent",
                   "version": "0.6.1"
                 },
@@ -2438,7 +2238,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "is-typedarray",
                   "version": "1.0.0"
                 },
@@ -2446,7 +2245,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isstream",
                   "version": "0.1.2"
                 },
@@ -2454,7 +2252,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "json-stringify-safe",
                   "version": "5.0.1"
                 },
@@ -2462,7 +2259,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "oauth-sign",
                   "version": "0.8.2"
                 },
@@ -2470,7 +2266,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "qs",
                   "version": "6.3.2"
                 },
@@ -2478,7 +2273,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "stringstream",
                   "version": "0.0.6"
                 },
@@ -2486,7 +2280,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "tunnel-agent",
                   "version": "0.4.3"
                 },
@@ -2494,7 +2287,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "uuid",
                   "version": "3.3.2"
                 },
@@ -2507,7 +2299,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "delayed-stream",
                       "version": "1.0.0"
                     }
@@ -2524,7 +2315,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "mime-db",
                       "version": "1.35.0"
                     }
@@ -2541,7 +2331,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "punycode",
                       "version": "1.4.1"
                     }
@@ -2558,7 +2347,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "asynckit",
                       "version": "0.4.0"
                     },
@@ -2571,7 +2359,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "delayed-stream",
                           "version": "1.0.0"
                         }
@@ -2588,7 +2375,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "mime-db",
                           "version": "1.35.0"
                         }
@@ -2609,7 +2395,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "commander",
                       "version": "2.16.0"
                     },
@@ -2622,7 +2407,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -2639,7 +2423,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-styles",
                           "version": "2.2.1"
                         },
@@ -2647,7 +2430,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "escape-string-regexp",
                           "version": "1.0.5"
                         },
@@ -2655,7 +2437,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "supports-color",
                           "version": "2.0.0"
                         },
@@ -2668,7 +2449,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.1.1"
                             }
@@ -2685,7 +2465,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.1.1"
                             }
@@ -2706,7 +2485,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "generate-function",
                           "version": "2.0.0"
                         },
@@ -2714,7 +2492,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-my-ip-valid",
                           "version": "1.0.0"
                         },
@@ -2722,7 +2499,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "jsonpointer",
                           "version": "4.0.1"
                         },
@@ -2730,7 +2506,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "xtend",
                           "version": "4.0.1"
                         },
@@ -2743,7 +2518,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-property",
                               "version": "1.0.2"
                             }
@@ -2768,7 +2542,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "hoek",
                       "version": "2.16.3"
                     },
@@ -2781,7 +2554,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "2.16.3"
                         }
@@ -2798,7 +2570,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "2.16.3"
                         }
@@ -2820,7 +2591,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hoek",
                               "version": "2.16.3"
                             }
@@ -2845,7 +2615,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "assert-plus",
                       "version": "0.2.0"
                     },
@@ -2858,7 +2627,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "assert-plus",
                           "version": "1.0.0"
                         },
@@ -2866,7 +2634,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "extsprintf",
                           "version": "1.3.0"
                         },
@@ -2874,7 +2641,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "json-schema",
                           "version": "0.2.3"
                         },
@@ -2887,7 +2653,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             },
@@ -2895,7 +2660,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "core-util-is",
                               "version": "1.0.2"
                             },
@@ -2903,7 +2667,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "extsprintf",
                               "version": "1.3.0"
                             }
@@ -2924,7 +2687,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "asn1",
                           "version": "0.2.3"
                         },
@@ -2932,7 +2694,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "assert-plus",
                           "version": "1.0.0"
                         },
@@ -2940,7 +2701,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "safer-buffer",
                           "version": "2.1.2"
                         },
@@ -2953,7 +2713,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             }
@@ -2970,7 +2729,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             }
@@ -2982,7 +2740,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "jsbn",
                           "version": "0.1.1"
                         },
@@ -2990,7 +2747,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "tweetnacl",
                           "version": "0.14.5"
                         },
@@ -3003,7 +2759,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "tweetnacl",
                               "version": "0.14.5"
                             }
@@ -3020,7 +2775,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "jsbn",
                               "version": "0.1.1"
                             },
@@ -3028,7 +2782,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "safer-buffer",
                               "version": "2.1.2"
                             }
@@ -3071,7 +2824,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "deep-equal",
                       "version": "0.1.2"
                     },
@@ -3079,7 +2831,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "defined",
                       "version": "0.0.0"
                     },
@@ -3087,7 +2838,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3095,7 +2845,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "jsonify",
                       "version": "0.0.0"
                     },
@@ -3103,7 +2852,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "through",
                       "version": "2.3.8"
                     },
@@ -3116,7 +2864,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "through",
                           "version": "2.3.8"
                         }
@@ -3133,7 +2880,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "through",
                           "version": "2.3.8"
                         }
@@ -3150,7 +2896,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "duplexer",
                           "version": "0.1.1"
                         }
@@ -3175,7 +2920,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "caseless",
                   "version": "0.6.0"
                 },
@@ -3183,7 +2927,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "forever-agent",
                   "version": "0.5.2"
                 },
@@ -3191,7 +2934,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "json-stringify-safe",
                   "version": "5.0.1"
                 },
@@ -3199,7 +2941,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-types",
                   "version": "1.0.2"
                 },
@@ -3207,7 +2948,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "node-uuid",
                   "version": "1.4.8"
                 },
@@ -3215,7 +2955,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "qs",
                   "version": "1.2.2"
                 },
@@ -3223,7 +2962,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "tunnel-agent",
                   "version": "0.4.3"
                 },
@@ -3241,7 +2979,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "core-util-is",
                           "version": "1.0.2"
                         },
@@ -3249,7 +2986,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -3257,7 +2993,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isarray",
                           "version": "0.0.1"
                         },
@@ -3265,7 +3000,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "string_decoder",
                           "version": "0.10.31"
                         }
@@ -3281,7 +3015,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws-sign2",
                   "version": "0.5.0"
                 },
@@ -3289,7 +3022,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "oauth-sign",
                   "version": "0.4.0"
                 },
@@ -3297,7 +3029,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "stringstream",
                   "version": "0.0.6"
                 },
@@ -3310,7 +3041,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "asn1",
                       "version": "0.1.11"
                     },
@@ -3318,7 +3048,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "assert-plus",
                       "version": "0.1.5"
                     },
@@ -3326,7 +3055,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ctype",
                       "version": "0.5.3"
                     }
@@ -3343,7 +3071,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "psl",
                       "version": "1.1.28"
                     },
@@ -3351,7 +3078,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "punycode",
                       "version": "1.4.1"
                     }
@@ -3368,7 +3094,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "async",
                       "version": "0.9.0"
                     },
@@ -3376,7 +3101,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "mime",
                       "version": "1.2.11"
                     },
@@ -3389,7 +3113,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "delayed-stream",
                           "version": "0.0.5"
                         }
@@ -3410,7 +3133,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "hoek",
                       "version": "0.9.1"
                     },
@@ -3423,7 +3145,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "0.9.1"
                         }
@@ -3440,7 +3161,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "0.9.1"
                         }
@@ -3462,7 +3182,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hoek",
                               "version": "0.9.1"
                             }
@@ -3495,7 +3214,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "color-support",
               "version": "1.1.3"
             },
@@ -3503,7 +3221,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "diff",
               "version": "1.4.0"
             },
@@ -3511,7 +3228,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-string-regexp",
               "version": "1.0.5"
             },
@@ -3524,7 +3240,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -3541,7 +3256,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "4.0.1"
                 },
@@ -3554,7 +3268,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -3575,7 +3288,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "punycode",
                   "version": "1.4.1"
                 },
@@ -3588,7 +3300,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ansi-regex",
                       "version": "2.1.1"
                     }
@@ -3609,7 +3320,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "fs.realpath",
                   "version": "1.0.0"
                 },
@@ -3617,7 +3327,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.1"
                 },
@@ -3625,7 +3334,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "path-is-absolute",
                   "version": "1.0.0"
                 },
@@ -3638,7 +3346,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -3655,7 +3362,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     },
@@ -3668,7 +3374,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -3694,7 +3399,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "balanced-match",
                           "version": "1.0.0"
                         },
@@ -3702,7 +3406,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "concat-map",
                           "version": "0.0.1"
                         }
@@ -3727,7 +3430,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "events-to-array",
                   "version": "1.1.2"
                 },
@@ -3735,7 +3437,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -3748,7 +3449,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "4.0.1"
                     },
@@ -3761,7 +3461,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "sprintf-js",
                           "version": "1.0.3"
                         }
@@ -3782,7 +3481,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3790,7 +3488,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3798,7 +3495,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3806,7 +3502,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3814,7 +3509,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3822,7 +3516,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3835,7 +3528,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3860,7 +3552,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -3868,7 +3559,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -3876,7 +3566,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "0.0.1"
                 },
@@ -3884,7 +3573,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "string_decoder",
                   "version": "0.10.31"
                 }
@@ -3905,7 +3593,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "arrify",
               "version": "1.0.1"
             },
@@ -3913,7 +3600,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "convert-source-map",
               "version": "1.2.0"
             },
@@ -3921,7 +3607,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "resolve-from",
               "version": "2.0.0"
             },
@@ -3929,7 +3614,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "signal-exit",
               "version": "3.0.0"
             },
@@ -3937,7 +3621,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "source-map",
               "version": "0.5.6"
             },
@@ -3950,7 +3633,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "md5-o-matic",
                   "version": "0.1.1"
                 }
@@ -3967,7 +3649,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "minimist",
                   "version": "0.0.8"
                 }
@@ -3989,7 +3670,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "md5-o-matic",
                       "version": "0.1.1"
                     }
@@ -4006,7 +3686,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -4023,7 +3702,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "graceful-fs",
                       "version": "4.1.4"
                     },
@@ -4031,7 +3709,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "imurmurhash",
                       "version": "0.1.4"
                     },
@@ -4039,7 +3716,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "slide",
                       "version": "1.1.6"
                     }
@@ -4065,7 +3741,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-utf8",
                       "version": "0.2.1"
                     }
@@ -4096,7 +3771,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-utf8",
                           "version": "0.2.1"
                         }
@@ -4126,7 +3800,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "pinkie",
                       "version": "2.0.4"
                     }
@@ -4148,7 +3821,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -4173,7 +3845,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "signal-exit",
                   "version": "2.1.2"
                 },
@@ -4186,7 +3857,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -4208,7 +3878,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pseudomap",
                           "version": "1.0.2"
                         },
@@ -4216,7 +3885,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "yallist",
                           "version": "2.0.0"
                         }
@@ -4233,7 +3901,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isexe",
                           "version": "1.1.2"
                         }
@@ -4258,7 +3925,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.1"
                 },
@@ -4266,7 +3932,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "path-is-absolute",
                   "version": "1.0.0"
                 },
@@ -4279,7 +3944,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -4296,7 +3960,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     },
@@ -4309,7 +3972,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -4335,7 +3997,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "balanced-match",
                           "version": "0.4.1"
                         },
@@ -4343,7 +4004,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "concat-map",
                           "version": "0.0.1"
                         }
@@ -4378,7 +4038,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -4400,7 +4059,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -4434,7 +4092,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "fs.realpath",
                       "version": "1.0.0"
                     },
@@ -4442,7 +4099,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.1"
                     },
@@ -4450,7 +4106,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "path-is-absolute",
                       "version": "1.0.0"
                     },
@@ -4463,7 +4118,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -4480,7 +4134,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         },
@@ -4493,7 +4146,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -4519,7 +4171,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "1.0.0"
                             },
@@ -4527,7 +4178,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -4556,7 +4206,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "commondir",
                   "version": "1.0.1"
                 },
@@ -4569,7 +4218,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -4596,7 +4244,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -4618,7 +4265,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -4651,7 +4297,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "os-homedir",
                   "version": "1.0.1"
                 },
@@ -4659,7 +4304,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "signal-exit",
                   "version": "2.1.2"
                 },
@@ -4672,7 +4316,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -4689,7 +4332,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -4706,7 +4348,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "signal-exit",
                       "version": "2.1.2"
                     },
@@ -4719,7 +4360,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isexe",
                           "version": "1.1.2"
                         }
@@ -4741,7 +4381,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pseudomap",
                               "version": "1.0.2"
                             },
@@ -4749,7 +4388,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "yallist",
                               "version": "2.0.0"
                             }
@@ -4766,7 +4404,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "isexe",
                               "version": "1.1.2"
                             }
@@ -4796,7 +4433,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "fs.realpath",
                           "version": "1.0.0"
                         },
@@ -4804,7 +4440,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.1"
                         },
@@ -4812,7 +4447,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "path-is-absolute",
                           "version": "1.0.0"
                         },
@@ -4825,7 +4459,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -4842,7 +4475,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             },
@@ -4855,7 +4487,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wrappy",
                                   "version": "1.0.2"
                                 }
@@ -4881,7 +4512,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "balanced-match",
                                   "version": "1.0.0"
                                 },
@@ -4889,7 +4519,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "concat-map",
                                   "version": "0.0.1"
                                 }
@@ -4922,7 +4551,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "camelcase",
                   "version": "3.0.0"
                 },
@@ -4930,7 +4558,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "decamelize",
                   "version": "1.2.0"
                 },
@@ -4938,7 +4565,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "require-main-filename",
                   "version": "1.0.1"
                 },
@@ -4946,7 +4572,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "set-blocking",
                   "version": "1.0.0"
                 },
@@ -4954,7 +4579,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "window-size",
                   "version": "0.2.0"
                 },
@@ -4962,7 +4586,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "y18n",
                   "version": "3.2.1"
                 },
@@ -4975,7 +4598,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.keys",
                       "version": "4.0.7"
                     },
@@ -4983,7 +4605,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.rest",
                       "version": "4.0.3"
                     }
@@ -5005,7 +4626,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "invert-kv",
                           "version": "1.0.0"
                         }
@@ -5031,7 +4651,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "number-is-nan",
                           "version": "1.0.0"
                         }
@@ -5048,7 +4667,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "number-is-nan",
                           "version": "1.0.0"
                         }
@@ -5065,7 +4683,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-regex",
                           "version": "2.1.1"
                         }
@@ -5086,7 +4703,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "camelcase",
                       "version": "2.1.1"
                     },
@@ -5099,7 +4715,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "lodash.keys",
                           "version": "4.0.7"
                         },
@@ -5107,7 +4722,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "lodash.rest",
                           "version": "4.0.3"
                         }
@@ -5133,7 +4747,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-regex",
                           "version": "2.1.1"
                         }
@@ -5155,7 +4768,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "number-is-nan",
                               "version": "1.0.0"
                             }
@@ -5172,7 +4784,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "number-is-nan",
                               "version": "1.0.0"
                             }
@@ -5189,7 +4800,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.1.1"
                             }
@@ -5220,7 +4830,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "number-is-nan",
                                   "version": "1.0.0"
                                 }
@@ -5237,7 +4846,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "number-is-nan",
                                   "version": "1.0.0"
                                 }
@@ -5254,7 +4862,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "ansi-regex",
                                   "version": "2.1.1"
                                 }
@@ -5283,7 +4890,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "object-assign",
                       "version": "4.1.0"
                     },
@@ -5291,7 +4897,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "symbol",
                       "version": "0.2.3"
                     },
@@ -5309,7 +4914,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -5331,7 +4935,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -5356,7 +4959,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "graceful-fs",
                           "version": "4.1.4"
                         },
@@ -5364,7 +4966,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pify",
                           "version": "2.3.0"
                         },
@@ -5377,7 +4978,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -5394,7 +4994,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-utf8",
                               "version": "0.2.1"
                             }
@@ -5416,7 +5015,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-arrayish",
                                   "version": "0.2.1"
                                 }
@@ -5455,7 +5053,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -5477,7 +5074,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -5507,7 +5103,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -5515,7 +5110,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -5528,7 +5122,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -5549,7 +5142,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -5557,7 +5149,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -5570,7 +5161,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -5587,7 +5177,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-utf8",
                                   "version": "0.2.1"
                                 }
@@ -5609,7 +5198,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-arrayish",
                                       "version": "0.2.1"
                                     }
@@ -5634,7 +5222,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hosted-git-info",
                               "version": "2.1.5"
                             },
@@ -5642,7 +5229,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "semver",
                               "version": "5.1.0"
                             },
@@ -5655,7 +5241,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "builtin-modules",
                                   "version": "1.1.1"
                                 }
@@ -5677,7 +5262,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -5694,7 +5278,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-exceptions",
                                       "version": "1.0.4"
                                     },
@@ -5702,7 +5285,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -5739,7 +5321,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "array-unique",
                   "version": "0.2.1"
                 },
@@ -5747,7 +5328,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "filename-regex",
                   "version": "2.0.0"
                 },
@@ -5755,7 +5335,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "is-extglob",
                   "version": "1.0.0"
                 },
@@ -5763,7 +5342,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "normalize-path",
                   "version": "2.0.1"
                 },
@@ -5776,7 +5354,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "arr-flatten",
                       "version": "1.0.1"
                     }
@@ -5793,7 +5370,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-posix-bracket",
                       "version": "0.1.1"
                     }
@@ -5810,7 +5386,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     }
@@ -5827,7 +5402,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     }
@@ -5844,7 +5418,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-buffer",
                       "version": "1.1.3"
                     }
@@ -5861,7 +5434,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extendable",
                       "version": "0.1.1"
                     },
@@ -5874,7 +5446,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "for-in",
                           "version": "0.1.5"
                         }
@@ -5895,7 +5466,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-primitive",
                       "version": "2.0.0"
                     },
@@ -5908,7 +5478,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-primitive",
                           "version": "2.0.0"
                         }
@@ -5929,7 +5498,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-dotfile",
                       "version": "1.0.2"
                     },
@@ -5937,7 +5505,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     },
@@ -5950,7 +5517,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -5972,7 +5538,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-extglob",
                               "version": "1.0.0"
                             }
@@ -5994,7 +5559,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-extglob",
                                   "version": "1.0.0"
                                 }
@@ -6023,7 +5587,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "preserve",
                       "version": "0.2.0"
                     },
@@ -6031,7 +5594,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "repeat-element",
                       "version": "1.1.2"
                     },
@@ -6049,7 +5611,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "repeat-element",
                               "version": "1.1.2"
                             },
@@ -6057,7 +5618,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "repeat-string",
                               "version": "1.5.4"
                             },
@@ -6070,7 +5630,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "isarray",
                                   "version": "1.0.0"
                                 }
@@ -6092,7 +5651,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-buffer",
                                       "version": "1.1.3"
                                     }
@@ -6118,7 +5676,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-buffer",
                                       "version": "1.1.3"
                                     }
@@ -6140,7 +5697,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -6181,7 +5737,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "arrify",
                   "version": "1.0.1"
                 },
@@ -6189,7 +5744,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "require-main-filename",
                   "version": "1.0.1"
                 },
@@ -6202,7 +5756,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.keys",
                       "version": "4.0.7"
                     },
@@ -6210,7 +5763,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.rest",
                       "version": "4.0.3"
                     }
@@ -6237,7 +5789,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -6259,7 +5810,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -6289,7 +5839,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -6297,7 +5846,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -6310,7 +5858,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -6331,7 +5878,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -6339,7 +5885,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -6352,7 +5897,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -6369,7 +5913,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-utf8",
                                   "version": "0.2.1"
                                 }
@@ -6391,7 +5934,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-arrayish",
                                       "version": "0.2.1"
                                     }
@@ -6416,7 +5958,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hosted-git-info",
                               "version": "2.1.5"
                             },
@@ -6424,7 +5965,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "semver",
                               "version": "5.1.0"
                             },
@@ -6437,7 +5977,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "builtin-modules",
                                   "version": "1.1.1"
                                 }
@@ -6459,7 +5998,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -6476,7 +6014,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-exceptions",
                                       "version": "1.0.4"
                                     },
@@ -6484,7 +6021,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -6517,7 +6053,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "array-unique",
                       "version": "0.2.1"
                     },
@@ -6525,7 +6060,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "filename-regex",
                       "version": "2.0.0"
                     },
@@ -6533,7 +6067,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     },
@@ -6541,7 +6074,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "normalize-path",
                       "version": "2.0.1"
                     },
@@ -6554,7 +6086,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "arr-flatten",
                           "version": "1.0.1"
                         }
@@ -6571,7 +6102,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-posix-bracket",
                           "version": "0.1.1"
                         }
@@ -6588,7 +6118,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -6605,7 +6134,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -6622,7 +6150,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-buffer",
                           "version": "1.1.3"
                         }
@@ -6639,7 +6166,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extendable",
                           "version": "0.1.1"
                         },
@@ -6652,7 +6178,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "for-in",
                               "version": "0.1.5"
                             }
@@ -6673,7 +6198,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-primitive",
                           "version": "2.0.0"
                         },
@@ -6686,7 +6210,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-primitive",
                               "version": "2.0.0"
                             }
@@ -6707,7 +6230,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-dotfile",
                           "version": "1.0.2"
                         },
@@ -6715,7 +6237,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         },
@@ -6728,7 +6249,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-extglob",
                               "version": "1.0.0"
                             }
@@ -6750,7 +6270,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-extglob",
                                   "version": "1.0.0"
                                 }
@@ -6772,7 +6291,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-extglob",
                                       "version": "1.0.0"
                                     }
@@ -6801,7 +6319,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "preserve",
                           "version": "0.2.0"
                         },
@@ -6809,7 +6326,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "repeat-element",
                           "version": "1.1.2"
                         },
@@ -6827,7 +6343,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "repeat-element",
                                   "version": "1.1.2"
                                 },
@@ -6835,7 +6350,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "repeat-string",
                                   "version": "1.5.4"
                                 },
@@ -6848,7 +6362,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "isarray",
                                       "version": "1.0.0"
                                     }
@@ -6870,7 +6383,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -6896,7 +6408,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -6918,7 +6429,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }
@@ -6963,7 +6473,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "abbrev",
                   "version": "1.0.7"
                 },
@@ -6971,7 +6480,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "async",
                   "version": "1.5.2"
                 },
@@ -6979,7 +6487,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "2.7.2"
                 },
@@ -6987,7 +6494,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "resolve",
                   "version": "1.1.7"
                 },
@@ -6995,7 +6501,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wordwrap",
                   "version": "1.0.0"
                 },
@@ -7008,7 +6513,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -7025,7 +6529,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "abbrev",
                       "version": "1.0.7"
                     }
@@ -7042,7 +6545,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -7059,7 +6561,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "has-flag",
                       "version": "1.0.0"
                     }
@@ -7076,7 +6577,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -7093,7 +6593,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "2.7.3"
                     },
@@ -7106,7 +6605,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "sprintf-js",
                           "version": "1.0.3"
                         }
@@ -7137,7 +6635,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "0.4.1"
                             },
@@ -7145,7 +6642,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -7166,7 +6662,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.1"
                         },
@@ -7174,7 +6669,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "path-is-absolute",
                           "version": "1.0.0"
                         },
@@ -7187,7 +6681,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -7204,7 +6697,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             },
@@ -7217,7 +6709,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wrappy",
                                   "version": "1.0.2"
                                 }
@@ -7243,7 +6734,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "balanced-match",
                                   "version": "0.4.1"
                                 },
@@ -7251,7 +6741,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "concat-map",
                                   "version": "0.0.1"
                                 }
@@ -7280,7 +6769,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "2.7.2"
                     },
@@ -7288,7 +6776,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "estraverse",
                       "version": "1.9.3"
                     },
@@ -7296,7 +6783,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esutils",
                       "version": "2.0.2"
                     },
@@ -7309,7 +6795,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "deep-is",
                           "version": "0.1.3"
                         },
@@ -7317,7 +6802,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "fast-levenshtein",
                           "version": "1.1.3"
                         },
@@ -7325,7 +6809,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "prelude-ls",
                           "version": "1.1.2"
                         },
@@ -7333,7 +6816,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wordwrap",
                           "version": "1.0.0"
                         },
@@ -7346,7 +6828,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "prelude-ls",
                               "version": "1.1.2"
                             }
@@ -7363,7 +6844,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "prelude-ls",
                               "version": "1.1.2"
                             },
@@ -7376,7 +6856,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "prelude-ls",
                                   "version": "1.1.2"
                                 }
@@ -7401,7 +6880,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "amdefine",
                           "version": "1.0.0"
                         }
@@ -7422,7 +6900,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "async",
                       "version": "1.5.2"
                     },
@@ -7435,7 +6912,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "minimist",
                           "version": "0.0.10"
                         },
@@ -7443,7 +6919,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wordwrap",
                           "version": "0.0.3"
                         }
@@ -7460,7 +6935,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "amdefine",
                           "version": "1.0.0"
                         }
@@ -7477,7 +6951,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "async",
                           "version": "0.2.10"
                         },
@@ -7485,7 +6958,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "source-map",
                           "version": "0.5.6"
                         },
@@ -7493,7 +6965,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "uglify-to-browserify",
                           "version": "1.0.2"
                         },
@@ -7506,7 +6977,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "camelcase",
                               "version": "1.2.1"
                             },
@@ -7514,7 +6984,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "decamelize",
                               "version": "1.2.0"
                             },
@@ -7522,7 +6991,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "window-size",
                               "version": "0.1.0"
                             },
@@ -7535,7 +7003,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wordwrap",
                                   "version": "0.0.2"
                                 },
@@ -7548,7 +7015,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "lazy-cache",
                                       "version": "1.0.4"
                                     },
@@ -7561,7 +7027,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "longest",
                                           "version": "1.0.1"
                                         },
@@ -7569,7 +7034,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "repeat-string",
                                           "version": "1.5.4"
                                         },
@@ -7582,7 +7046,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }
@@ -7612,7 +7075,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "longest",
                                           "version": "1.0.1"
                                         },
@@ -7620,7 +7082,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "repeat-string",
                                           "version": "1.5.4"
                                         },
@@ -7633,7 +7094,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
@@ -12,9 +12,7 @@
       "version": "0.4.7",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "body-parser": {
       "name": "body-parser",
       "version": "1.9.0",
@@ -27,33 +25,26 @@
           "version": "1.0.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
+          }
         },
         "depd": {
           "name": "depd",
           "version": "1.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "iconv-lite": {
           "name": "iconv-lite",
           "version": "0.4.4",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "media-typer": {
           "name": "media-typer",
           "version": "0.3.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "on-finished": {
           "name": "on-finished",
           "version": "2.1.0",
@@ -66,9 +57,7 @@
               "version": "1.0.5",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "qs": {
@@ -76,9 +65,7 @@
           "version": "2.2.4",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "raw-body": {
           "name": "raw-body",
           "version": "1.3.0",
@@ -91,17 +78,13 @@
               "version": "1.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "iconv-lite": {
               "name": "iconv-lite",
               "version": "0.4.4",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "type-is": {
@@ -116,9 +99,7 @@
               "version": "0.3.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "mime-types": {
               "name": "mime-types",
               "version": "2.0.14",
@@ -131,9 +112,7 @@
                   "version": "1.12.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             }
           }
@@ -166,9 +145,7 @@
                   "version": "1.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "esprima": {
@@ -176,9 +153,7 @@
               "version": "4.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "ports": {
@@ -186,17 +161,13 @@
           "version": "1.1.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "underscore": {
           "name": "underscore",
           "version": "1.8.3",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "consolidate": {
@@ -211,9 +182,7 @@
           "version": "3.5.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "cookie-parser": {
@@ -228,17 +197,13 @@
           "version": "0.1.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "cookie-signature": {
           "name": "cookie-signature",
           "version": "1.0.5",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "dustjs-helpers": {
@@ -246,25 +211,19 @@
       "version": "1.5.0",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "dustjs-linkedin": {
       "name": "dustjs-linkedin",
       "version": "2.5.0",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "ejs": {
       "name": "ejs",
       "version": "1.0.0",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "ejs-locals": {
       "name": "ejs-locals",
       "version": "1.0.2",
@@ -277,9 +236,7 @@
           "version": "0.8.8",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "errorhandler": {
@@ -308,9 +265,7 @@
                   "version": "1.12.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "negotiator": {
@@ -318,9 +273,7 @@
               "version": "0.4.9",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "escape-html": {
@@ -328,9 +281,7 @@
           "version": "1.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "express": {
@@ -359,9 +310,7 @@
                   "version": "1.35.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "negotiator": {
@@ -369,9 +318,7 @@
               "version": "0.5.3",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "content-disposition": {
@@ -379,33 +326,25 @@
           "version": "0.5.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "content-type": {
           "name": "content-type",
           "version": "1.0.4",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "cookie": {
           "name": "cookie",
           "version": "0.1.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "cookie-signature": {
           "name": "cookie-signature",
           "version": "1.0.6",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "debug": {
           "name": "debug",
           "version": "2.2.0",
@@ -418,9 +357,7 @@
               "version": "0.7.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "depd": {
@@ -428,17 +365,13 @@
           "version": "1.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "escape-html": {
           "name": "escape-html",
           "version": "1.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "etag": {
           "name": "etag",
           "version": "1.6.0",
@@ -451,9 +384,7 @@
               "version": "3.2.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "finalhandler": {
@@ -475,9 +406,7 @@
                   "version": "0.7.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "escape-html": {
@@ -485,9 +414,7 @@
               "version": "1.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "on-finished": {
               "name": "on-finished",
               "version": "2.2.1",
@@ -500,9 +427,7 @@
                   "version": "1.1.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             }
           }
@@ -512,25 +437,19 @@
           "version": "0.2.4",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "merge-descriptors": {
           "name": "merge-descriptors",
           "version": "1.0.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "methods": {
           "name": "methods",
           "version": "1.1.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "on-finished": {
           "name": "on-finished",
           "version": "2.2.1",
@@ -543,9 +462,7 @@
               "version": "1.1.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "parseurl": {
@@ -553,17 +470,13 @@
           "version": "1.3.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "path-to-regexp": {
           "name": "path-to-regexp",
           "version": "0.1.3",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "proxy-addr": {
           "name": "proxy-addr",
           "version": "1.0.10",
@@ -576,17 +489,13 @@
               "version": "0.1.2",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "ipaddr.js": {
               "name": "ipaddr.js",
               "version": "1.0.5",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "qs": {
@@ -594,17 +503,13 @@
           "version": "2.4.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "range-parser": {
           "name": "range-parser",
           "version": "1.0.3",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "send": {
           "name": "send",
           "version": "0.12.3",
@@ -624,9 +529,7 @@
                   "version": "0.7.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "depd": {
@@ -634,25 +537,19 @@
               "version": "1.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "destroy": {
               "name": "destroy",
               "version": "1.0.3",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "escape-html": {
               "name": "escape-html",
               "version": "1.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "etag": {
               "name": "etag",
               "version": "1.6.0",
@@ -665,9 +562,7 @@
                   "version": "3.2.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "fresh": {
@@ -675,25 +570,19 @@
               "version": "0.2.4",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "mime": {
               "name": "mime",
               "version": "1.3.4",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "ms": {
               "name": "ms",
               "version": "0.7.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "on-finished": {
               "name": "on-finished",
               "version": "2.2.1",
@@ -706,9 +595,7 @@
                   "version": "1.1.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "range-parser": {
@@ -716,9 +603,7 @@
               "version": "1.0.3",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "serve-static": {
@@ -733,17 +618,13 @@
               "version": "1.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "parseurl": {
               "name": "parseurl",
               "version": "1.3.2",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "send": {
               "name": "send",
               "version": "0.12.3",
@@ -763,9 +644,7 @@
                       "version": "0.7.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "depd": {
@@ -773,25 +652,19 @@
                   "version": "1.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "destroy": {
                   "name": "destroy",
                   "version": "1.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "escape-html": {
                   "name": "escape-html",
                   "version": "1.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "etag": {
                   "name": "etag",
                   "version": "1.6.0",
@@ -804,9 +677,7 @@
                       "version": "3.2.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "fresh": {
@@ -814,25 +685,19 @@
                   "version": "0.2.4",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "mime": {
                   "name": "mime",
                   "version": "1.3.4",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "ms": {
                   "name": "ms",
                   "version": "0.7.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "on-finished": {
                   "name": "on-finished",
                   "version": "2.2.1",
@@ -845,9 +710,7 @@
                       "version": "1.1.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "range-parser": {
@@ -855,9 +718,7 @@
                   "version": "1.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "utils-merge": {
@@ -865,9 +726,7 @@
               "version": "1.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "type-is": {
@@ -882,9 +741,7 @@
               "version": "0.3.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "mime-types": {
               "name": "mime-types",
               "version": "2.1.19",
@@ -897,9 +754,7 @@
                   "version": "1.35.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             }
           }
@@ -909,17 +764,13 @@
           "version": "1.0.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "vary": {
           "name": "vary",
           "version": "1.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "express-fileupload": {
@@ -962,33 +813,25 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "inherits": {
                           "name": "inherits",
                           "version": "2.0.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "isarray": {
                           "name": "isarray",
                           "version": "0.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "string_decoder": {
                           "name": "string_decoder",
                           "version": "0.10.31",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "streamsearch": {
@@ -996,9 +839,7 @@
                       "version": "0.1.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "readable-stream": {
@@ -1013,33 +854,25 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "inherits": {
                       "name": "inherits",
                       "version": "2.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "isarray": {
                       "name": "isarray",
                       "version": "0.0.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "string_decoder": {
                       "name": "string_decoder",
                       "version": "0.10.31",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -1058,9 +891,7 @@
               "version": "4.1.11",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "jsonfile": {
               "name": "jsonfile",
               "version": "2.4.0",
@@ -1073,9 +904,7 @@
                   "version": "4.1.11",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "rimraf": {
@@ -1097,9 +926,7 @@
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "inflight": {
                       "name": "inflight",
                       "version": "1.0.6",
@@ -1119,9 +946,7 @@
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "wrappy": {
@@ -1129,9 +954,7 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "inherits": {
@@ -1139,9 +962,7 @@
                       "version": "2.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "minimatch": {
                       "name": "minimatch",
                       "version": "3.0.4",
@@ -1161,17 +982,13 @@
                               "version": "1.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "concat-map": {
                               "name": "concat-map",
                               "version": "0.0.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -1188,9 +1005,7 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "path-is-absolute": {
@@ -1198,9 +1013,7 @@
                       "version": "1.0.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -1212,9 +1025,7 @@
           "version": "0.1.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "file-type": {
@@ -1222,9 +1033,7 @@
       "version": "8.1.0",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "humanize-ms": {
       "name": "humanize-ms",
       "version": "1.0.1",
@@ -1237,9 +1046,7 @@
           "version": "0.6.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "jquery": {
@@ -1247,17 +1054,13 @@
       "version": "2.2.4",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "marked": {
       "name": "marked",
       "version": "0.3.5",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "method-override": {
       "name": "method-override",
       "version": "3.0.0",
@@ -1277,9 +1080,7 @@
               "version": "2.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "methods": {
@@ -1287,25 +1088,19 @@
           "version": "1.1.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "parseurl": {
           "name": "parseurl",
           "version": "1.3.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "vary": {
           "name": "vary",
           "version": "1.1.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "moment": {
@@ -1313,9 +1108,7 @@
       "version": "2.15.1",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "mongoose": {
       "name": "mongoose",
       "version": "4.2.4",
@@ -1328,33 +1121,25 @@
           "version": "0.9.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "bson": {
           "name": "bson",
           "version": "0.4.23",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "hooks-fixed": {
           "name": "hooks-fixed",
           "version": "1.1.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "kareem": {
           "name": "kareem",
           "version": "1.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "mongodb": {
           "name": "mongodb",
           "version": "2.0.46",
@@ -1367,9 +1152,7 @@
               "version": "2.1.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "mongodb-core": {
               "name": "mongodb-core",
               "version": "1.2.19",
@@ -1382,9 +1165,7 @@
                   "version": "0.4.23",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "kerberos": {
                   "name": "kerberos",
                   "version": "0.0.24",
@@ -1397,9 +1178,7 @@
                       "version": "2.10.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -1416,33 +1195,25 @@
                   "version": "1.0.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "inherits": {
                   "name": "inherits",
                   "version": "2.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "isarray": {
                   "name": "isarray",
                   "version": "0.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "string_decoder": {
                   "name": "string_decoder",
                   "version": "0.10.31",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             }
           }
@@ -1452,17 +1223,13 @@
           "version": "0.1.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "mpromise": {
           "name": "mpromise",
           "version": "0.5.4",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "mquery": {
           "name": "mquery",
           "version": "1.6.3",
@@ -1475,9 +1242,7 @@
               "version": "2.9.26",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "debug": {
               "name": "debug",
               "version": "2.2.0",
@@ -1490,9 +1255,7 @@
                   "version": "0.7.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "regexp-clone": {
@@ -1500,17 +1263,13 @@
               "version": "0.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "sliced": {
               "name": "sliced",
               "version": "0.0.5",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "ms": {
@@ -1518,33 +1277,25 @@
           "version": "0.7.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "muri": {
           "name": "muri",
           "version": "1.0.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "regexp-clone": {
           "name": "regexp-clone",
           "version": "0.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "sliced": {
           "name": "sliced",
           "version": "0.0.5",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "morgan": {
@@ -1566,9 +1317,7 @@
               "version": "5.1.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "debug": {
@@ -1583,9 +1332,7 @@
               "version": "2.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "depd": {
@@ -1593,9 +1340,7 @@
           "version": "1.1.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "on-finished": {
           "name": "on-finished",
           "version": "2.3.0",
@@ -1608,9 +1353,7 @@
               "version": "1.1.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "on-headers": {
@@ -1618,9 +1361,7 @@
           "version": "1.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "ms": {
@@ -1628,9 +1369,7 @@
       "version": "0.7.3",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "npmconf": {
       "name": "npmconf",
       "version": "0.0.24",
@@ -1650,17 +1389,13 @@
               "version": "1.3.5",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "proto-list": {
               "name": "proto-list",
               "version": "1.2.4",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "inherits": {
@@ -1668,25 +1403,19 @@
           "version": "1.0.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "ini": {
           "name": "ini",
           "version": "1.1.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "mkdirp": {
           "name": "mkdirp",
           "version": "0.3.5",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "nopt": {
           "name": "nopt",
           "version": "2.2.1",
@@ -1699,9 +1428,7 @@
               "version": "1.1.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "once": {
@@ -1709,25 +1436,19 @@
           "version": "1.1.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "osenv": {
           "name": "osenv",
           "version": "0.0.3",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "semver": {
           "name": "semver",
           "version": "1.1.4",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "optional": {
@@ -1735,9 +1456,7 @@
       "version": "0.1.4",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "st": {
       "name": "st",
       "version": "0.2.4",
@@ -1757,9 +1476,7 @@
               "version": "2.3.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "fd": {
@@ -1767,33 +1484,25 @@
           "version": "0.0.3",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "graceful-fs": {
           "name": "graceful-fs",
           "version": "1.2.3",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "mime": {
           "name": "mime",
           "version": "1.2.11",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "negotiator": {
           "name": "negotiator",
           "version": "0.2.8",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     },
     "stream-buffers": {
@@ -1801,9 +1510,7 @@
       "version": "3.0.2",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    },
+      }},
     "tap": {
       "name": "tap",
       "version": "5.8.0",
@@ -1816,17 +1523,13 @@
           "version": "3.5.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "clean-yaml-object": {
           "name": "clean-yaml-object",
           "version": "0.1.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "codecov.io": {
           "name": "codecov.io",
           "version": "0.1.6",
@@ -1846,9 +1549,7 @@
                   "version": "0.5.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "bl": {
                   "name": "bl",
                   "version": "0.9.5",
@@ -1868,33 +1569,25 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "inherits": {
                           "name": "inherits",
                           "version": "2.0.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "isarray": {
                           "name": "isarray",
                           "version": "0.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "string_decoder": {
                           "name": "string_decoder",
                           "version": "0.10.31",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -1904,17 +1597,13 @@
                   "version": "0.6.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "forever-agent": {
                   "name": "forever-agent",
                   "version": "0.5.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "form-data": {
                   "name": "form-data",
                   "version": "0.1.4",
@@ -1927,9 +1616,7 @@
                       "version": "0.9.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "combined-stream": {
                       "name": "combined-stream",
                       "version": "0.0.7",
@@ -1942,9 +1629,7 @@
                           "version": "0.0.5",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "mime": {
@@ -1952,9 +1637,7 @@
                       "version": "1.2.11",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "hawk": {
@@ -1976,9 +1659,7 @@
                           "version": "0.9.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "cryptiles": {
@@ -2000,9 +1681,7 @@
                               "version": "0.9.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -2012,9 +1691,7 @@
                       "version": "0.9.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "sntp": {
                       "name": "sntp",
                       "version": "0.2.4",
@@ -2027,9 +1704,7 @@
                           "version": "0.9.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -2046,25 +1721,19 @@
                       "version": "0.1.11",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "assert-plus": {
                       "name": "assert-plus",
                       "version": "0.1.5",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "ctype": {
                       "name": "ctype",
                       "version": "0.5.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "json-stringify-safe": {
@@ -2072,49 +1741,37 @@
                   "version": "5.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "mime-types": {
                   "name": "mime-types",
                   "version": "1.0.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "node-uuid": {
                   "name": "node-uuid",
                   "version": "1.4.8",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "oauth-sign": {
                   "name": "oauth-sign",
                   "version": "0.4.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "qs": {
                   "name": "qs",
                   "version": "1.2.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "stringstream": {
                   "name": "stringstream",
                   "version": "0.0.6",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "tough-cookie": {
                   "name": "tough-cookie",
                   "version": "2.4.3",
@@ -2127,17 +1784,13 @@
                       "version": "1.1.28",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "punycode": {
                       "name": "punycode",
                       "version": "1.4.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "tunnel-agent": {
@@ -2145,9 +1798,7 @@
                   "version": "0.4.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "urlgrey": {
@@ -2169,33 +1820,25 @@
                       "version": "0.1.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "defined": {
                       "name": "defined",
                       "version": "0.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "inherits": {
                       "name": "inherits",
                       "version": "2.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "jsonify": {
                       "name": "jsonify",
                       "version": "0.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "resumer": {
                       "name": "resumer",
                       "version": "0.0.0",
@@ -2208,9 +1851,7 @@
                           "version": "2.3.8",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "split": {
@@ -2225,9 +1866,7 @@
                           "version": "2.3.8",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "stream-combiner": {
@@ -2242,9 +1881,7 @@
                           "version": "0.1.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "through": {
@@ -2252,9 +1889,7 @@
                       "version": "2.3.8",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -2287,9 +1922,7 @@
                       "version": "1.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "esprima": {
@@ -2297,9 +1930,7 @@
                   "version": "2.7.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "lcov-parse": {
@@ -2307,25 +1938,19 @@
               "version": "0.0.10",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "log-driver": {
               "name": "log-driver",
               "version": "1.2.5",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "minimist": {
               "name": "minimist",
               "version": "1.2.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "request": {
               "name": "request",
               "version": "2.79.0",
@@ -2338,25 +1963,19 @@
                   "version": "0.6.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "aws4": {
                   "name": "aws4",
                   "version": "1.7.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "caseless": {
                   "name": "caseless",
                   "version": "0.11.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "combined-stream": {
                   "name": "combined-stream",
                   "version": "1.0.6",
@@ -2369,9 +1988,7 @@
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "extend": {
@@ -2379,17 +1996,13 @@
                   "version": "3.0.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "forever-agent": {
                   "name": "forever-agent",
                   "version": "0.6.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "form-data": {
                   "name": "form-data",
                   "version": "2.1.4",
@@ -2402,9 +2015,7 @@
                       "version": "0.4.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "combined-stream": {
                       "name": "combined-stream",
                       "version": "1.0.6",
@@ -2417,9 +2028,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "mime-types": {
@@ -2434,9 +2043,7 @@
                           "version": "1.35.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -2460,17 +2067,13 @@
                           "version": "2.2.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "escape-string-regexp": {
                           "name": "escape-string-regexp",
                           "version": "1.0.5",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "has-ansi": {
                           "name": "has-ansi",
                           "version": "2.0.0",
@@ -2483,9 +2086,7 @@
                               "version": "2.1.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "strip-ansi": {
@@ -2500,9 +2101,7 @@
                               "version": "2.1.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "supports-color": {
@@ -2510,9 +2109,7 @@
                           "version": "2.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "commander": {
@@ -2520,9 +2117,7 @@
                       "version": "2.16.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "is-my-json-valid": {
                       "name": "is-my-json-valid",
                       "version": "2.17.2",
@@ -2535,9 +2130,7 @@
                           "version": "2.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "generate-object-property": {
                           "name": "generate-object-property",
                           "version": "1.2.0",
@@ -2550,9 +2143,7 @@
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "is-my-ip-valid": {
@@ -2560,25 +2151,19 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "jsonpointer": {
                           "name": "jsonpointer",
                           "version": "4.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "xtend": {
                           "name": "xtend",
                           "version": "4.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "pinkie-promise": {
@@ -2593,9 +2178,7 @@
                           "version": "2.0.4",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -2619,9 +2202,7 @@
                           "version": "2.16.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "cryptiles": {
@@ -2643,9 +2224,7 @@
                               "version": "2.16.3",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -2655,9 +2234,7 @@
                       "version": "2.16.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "sntp": {
                       "name": "sntp",
                       "version": "1.0.9",
@@ -2670,9 +2247,7 @@
                           "version": "2.16.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -2689,9 +2264,7 @@
                       "version": "0.2.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "jsprim": {
                       "name": "jsprim",
                       "version": "1.4.1",
@@ -2704,25 +2277,19 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "extsprintf": {
                           "name": "extsprintf",
                           "version": "1.3.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "json-schema": {
                           "name": "json-schema",
                           "version": "0.2.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "verror": {
                           "name": "verror",
                           "version": "1.10.0",
@@ -2735,25 +2302,19 @@
                               "version": "1.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "core-util-is": {
                               "name": "core-util-is",
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "extsprintf": {
                               "name": "extsprintf",
                               "version": "1.3.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -2770,17 +2331,13 @@
                           "version": "0.2.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "assert-plus": {
                           "name": "assert-plus",
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "bcrypt-pbkdf": {
                           "name": "bcrypt-pbkdf",
                           "version": "1.0.2",
@@ -2793,9 +2350,7 @@
                               "version": "0.14.5",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "dashdash": {
@@ -2810,9 +2365,7 @@
                               "version": "1.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "ecc-jsbn": {
@@ -2827,17 +2380,13 @@
                               "version": "0.1.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "safer-buffer": {
                               "name": "safer-buffer",
                               "version": "2.1.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "getpass": {
@@ -2852,9 +2401,7 @@
                               "version": "1.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "jsbn": {
@@ -2862,25 +2409,19 @@
                           "version": "0.1.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "safer-buffer": {
                           "name": "safer-buffer",
                           "version": "2.1.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "tweetnacl": {
                           "name": "tweetnacl",
                           "version": "0.14.5",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -2890,25 +2431,19 @@
                   "version": "1.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "isstream": {
                   "name": "isstream",
                   "version": "0.1.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "json-stringify-safe": {
                   "name": "json-stringify-safe",
                   "version": "5.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "mime-types": {
                   "name": "mime-types",
                   "version": "2.1.19",
@@ -2921,9 +2456,7 @@
                       "version": "1.35.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "oauth-sign": {
@@ -2931,25 +2464,19 @@
                   "version": "0.8.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "qs": {
                   "name": "qs",
                   "version": "6.3.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "stringstream": {
                   "name": "stringstream",
                   "version": "0.0.6",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "tough-cookie": {
                   "name": "tough-cookie",
                   "version": "2.3.4",
@@ -2962,9 +2489,7 @@
                       "version": "1.4.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "tunnel-agent": {
@@ -2972,17 +2497,13 @@
                   "version": "0.4.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "uuid": {
                   "name": "uuid",
                   "version": "3.3.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             }
           }
@@ -2992,9 +2513,7 @@
           "version": "2.1.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "foreground-child": {
           "name": "foreground-child",
           "version": "1.5.6",
@@ -3021,17 +2540,13 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "yallist": {
                       "name": "yallist",
                       "version": "2.1.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "which": {
@@ -3046,9 +2561,7 @@
                       "version": "2.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -3058,9 +2571,7 @@
               "version": "3.0.2",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "glob": {
@@ -3075,9 +2586,7 @@
               "version": "1.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "inflight": {
               "name": "inflight",
               "version": "1.0.6",
@@ -3097,9 +2606,7 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "wrappy": {
@@ -3107,9 +2614,7 @@
                   "version": "1.0.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "inherits": {
@@ -3117,9 +2622,7 @@
               "version": "2.0.3",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "minimatch": {
               "name": "minimatch",
               "version": "3.0.4",
@@ -3139,17 +2642,13 @@
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "concat-map": {
                       "name": "concat-map",
                       "version": "0.0.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -3166,9 +2665,7 @@
                   "version": "1.0.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "path-is-absolute": {
@@ -3176,9 +2673,7 @@
               "version": "1.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "isexe": {
@@ -3186,9 +2681,7 @@
           "version": "1.1.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "js-yaml": {
           "name": "js-yaml",
           "version": "3.11.0",
@@ -3208,9 +2701,7 @@
                   "version": "1.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "esprima": {
@@ -3218,9 +2709,7 @@
               "version": "4.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "nyc": {
@@ -3256,9 +2745,7 @@
                           "version": "0.2.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -3270,9 +2757,7 @@
               "version": "1.0.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "caching-transform": {
               "name": "caching-transform",
               "version": "1.0.1",
@@ -3292,9 +2777,7 @@
                       "version": "0.1.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "mkdirp": {
@@ -3309,9 +2792,7 @@
                       "version": "0.0.8",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "write-file-atomic": {
@@ -3326,25 +2807,19 @@
                       "version": "4.1.4",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "imurmurhash": {
                       "name": "imurmurhash",
                       "version": "0.1.4",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "slide": {
                       "name": "slide",
                       "version": "1.1.6",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -3354,9 +2829,7 @@
               "version": "1.2.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "default-require-extensions": {
               "name": "default-require-extensions",
               "version": "1.0.0",
@@ -3376,9 +2849,7 @@
                       "version": "0.2.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -3395,9 +2866,7 @@
                   "version": "1.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "mkdirp": {
                   "name": "mkdirp",
                   "version": "0.5.1",
@@ -3410,9 +2879,7 @@
                       "version": "0.0.8",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "pkg-dir": {
@@ -3448,9 +2915,7 @@
                                   "version": "2.0.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -3467,9 +2932,7 @@
                               "version": "2.0.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -3504,9 +2967,7 @@
                           "version": "2.0.4",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -3523,9 +2984,7 @@
                       "version": "2.0.4",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -3556,17 +3015,13 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "yallist": {
                           "name": "yallist",
                           "version": "2.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "which": {
@@ -3581,9 +3036,7 @@
                           "version": "1.1.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -3593,9 +3046,7 @@
                   "version": "2.1.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "which": {
                   "name": "which",
                   "version": "1.2.10",
@@ -3608,9 +3059,7 @@
                       "version": "1.1.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -3641,9 +3090,7 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "wrappy": {
@@ -3651,9 +3098,7 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "inherits": {
@@ -3661,9 +3106,7 @@
                   "version": "2.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "minimatch": {
                   "name": "minimatch",
                   "version": "3.0.0",
@@ -3683,17 +3126,13 @@
                           "version": "0.4.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "concat-map": {
                           "name": "concat-map",
                           "version": "0.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -3710,9 +3149,7 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "path-is-absolute": {
@@ -3720,9 +3157,7 @@
                   "version": "1.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "istanbul": {
@@ -3737,17 +3172,13 @@
                   "version": "1.0.7",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "async": {
                   "name": "async",
                   "version": "1.5.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "escodegen": {
                   "name": "escodegen",
                   "version": "1.8.0",
@@ -3760,25 +3191,19 @@
                       "version": "2.7.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "estraverse": {
                       "name": "estraverse",
                       "version": "1.9.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "esutils": {
                       "name": "esutils",
                       "version": "2.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "optionator": {
                       "name": "optionator",
                       "version": "0.8.1",
@@ -3791,17 +3216,13 @@
                           "version": "0.1.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "fast-levenshtein": {
                           "name": "fast-levenshtein",
                           "version": "1.1.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "levn": {
                           "name": "levn",
                           "version": "0.3.0",
@@ -3814,9 +3235,7 @@
                               "version": "1.1.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "type-check": {
                               "name": "type-check",
                               "version": "0.3.2",
@@ -3829,9 +3248,7 @@
                                   "version": "1.1.2",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -3841,9 +3258,7 @@
                           "version": "1.1.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "type-check": {
                           "name": "type-check",
                           "version": "0.3.2",
@@ -3856,9 +3271,7 @@
                               "version": "1.1.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "wordwrap": {
@@ -3866,9 +3279,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "source-map": {
@@ -3883,9 +3294,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -3895,9 +3304,7 @@
                   "version": "2.7.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "fileset": {
                   "name": "fileset",
                   "version": "0.2.1",
@@ -3931,9 +3338,7 @@
                                   "version": "1.0.2",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "wrappy": {
@@ -3941,9 +3346,7 @@
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "inherits": {
@@ -3951,9 +3354,7 @@
                           "version": "2.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "minimatch": {
                           "name": "minimatch",
                           "version": "2.0.10",
@@ -3973,17 +3374,13 @@
                                   "version": "0.4.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                },
+                                  }},
                                 "concat-map": {
                                   "name": "concat-map",
                                   "version": "0.0.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -4000,9 +3397,7 @@
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "path-is-absolute": {
@@ -4010,9 +3405,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "minimatch": {
@@ -4034,17 +3427,13 @@
                               "version": "0.4.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "concat-map": {
                               "name": "concat-map",
                               "version": "0.0.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -4063,9 +3452,7 @@
                       "version": "1.5.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "optimist": {
                       "name": "optimist",
                       "version": "0.6.1",
@@ -4078,17 +3465,13 @@
                           "version": "0.0.10",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "wordwrap": {
                           "name": "wordwrap",
                           "version": "0.0.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "source-map": {
@@ -4103,9 +3486,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "uglify-js": {
@@ -4120,25 +3501,19 @@
                           "version": "0.2.10",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "source-map": {
                           "name": "source-map",
                           "version": "0.5.6",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "uglify-to-browserify": {
                           "name": "uglify-to-browserify",
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "yargs": {
                           "name": "yargs",
                           "version": "3.10.0",
@@ -4151,9 +3526,7 @@
                               "version": "1.2.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "cliui": {
                               "name": "cliui",
                               "version": "2.1.0",
@@ -4187,9 +3560,7 @@
                                               "version": "1.1.3",
                                               "labels": {
                                                 "scope": "prod"
-                                              },
-                                              "dependencies": {}
-                                            }
+                                              }}
                                           }
                                         },
                                         "longest": {
@@ -4197,17 +3568,13 @@
                                           "version": "1.0.1",
                                           "labels": {
                                             "scope": "prod"
-                                          },
-                                          "dependencies": {}
-                                        },
+                                          }},
                                         "repeat-string": {
                                           "name": "repeat-string",
                                           "version": "1.5.4",
                                           "labels": {
                                             "scope": "prod"
-                                          },
-                                          "dependencies": {}
-                                        }
+                                          }}
                                       }
                                     },
                                     "lazy-cache": {
@@ -4215,9 +3582,7 @@
                                       "version": "1.0.4",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 },
                                 "right-align": {
@@ -4246,9 +3611,7 @@
                                               "version": "1.1.3",
                                               "labels": {
                                                 "scope": "prod"
-                                              },
-                                              "dependencies": {}
-                                            }
+                                              }}
                                           }
                                         },
                                         "longest": {
@@ -4256,17 +3619,13 @@
                                           "version": "1.0.1",
                                           "labels": {
                                             "scope": "prod"
-                                          },
-                                          "dependencies": {}
-                                        },
+                                          }},
                                         "repeat-string": {
                                           "name": "repeat-string",
                                           "version": "1.5.4",
                                           "labels": {
                                             "scope": "prod"
-                                          },
-                                          "dependencies": {}
-                                        }
+                                          }}
                                       }
                                     }
                                   }
@@ -4276,9 +3635,7 @@
                                   "version": "0.0.2",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "decamelize": {
@@ -4286,17 +3643,13 @@
                               "version": "1.2.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "window-size": {
                               "name": "window-size",
                               "version": "0.1.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -4322,9 +3675,7 @@
                           "version": "1.0.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "esprima": {
@@ -4332,9 +3683,7 @@
                       "version": "2.7.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "mkdirp": {
@@ -4349,9 +3698,7 @@
                       "version": "0.0.8",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "nopt": {
@@ -4366,9 +3713,7 @@
                       "version": "1.0.7",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "once": {
@@ -4383,9 +3728,7 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "resolve": {
@@ -4393,9 +3736,7 @@
                   "version": "1.1.7",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "supports-color": {
                   "name": "supports-color",
                   "version": "3.1.2",
@@ -4408,9 +3749,7 @@
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "which": {
@@ -4425,9 +3764,7 @@
                       "version": "1.1.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "wordwrap": {
@@ -4435,9 +3772,7 @@
                   "version": "1.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "md5-hex": {
@@ -4452,9 +3787,7 @@
                   "version": "0.1.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "micromatch": {
@@ -4476,9 +3809,7 @@
                       "version": "1.0.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "array-unique": {
@@ -4486,9 +3817,7 @@
                   "version": "0.2.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "braces": {
                   "name": "braces",
                   "version": "1.8.5",
@@ -4529,9 +3858,7 @@
                                       "version": "1.1.3",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 }
                               }
@@ -4548,9 +3875,7 @@
                                   "version": "1.0.0",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "randomatic": {
@@ -4579,9 +3904,7 @@
                                           "version": "1.1.3",
                                           "labels": {
                                             "scope": "prod"
-                                          },
-                                          "dependencies": {}
-                                        }
+                                          }}
                                       }
                                     }
                                   }
@@ -4598,9 +3921,7 @@
                                       "version": "1.1.3",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 }
                               }
@@ -4610,17 +3931,13 @@
                               "version": "1.1.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "repeat-string": {
                               "name": "repeat-string",
                               "version": "1.5.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -4630,17 +3947,13 @@
                       "version": "0.2.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "repeat-element": {
                       "name": "repeat-element",
                       "version": "1.1.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "expand-brackets": {
@@ -4655,9 +3968,7 @@
                       "version": "0.1.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "extglob": {
@@ -4672,9 +3983,7 @@
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "filename-regex": {
@@ -4682,17 +3991,13 @@
                   "version": "2.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "is-extglob": {
                   "name": "is-extglob",
                   "version": "1.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "is-glob": {
                   "name": "is-glob",
                   "version": "2.0.1",
@@ -4705,9 +4010,7 @@
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "kind-of": {
@@ -4722,9 +4025,7 @@
                       "version": "1.1.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "normalize-path": {
@@ -4732,9 +4033,7 @@
                   "version": "2.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "object.omit": {
                   "name": "object.omit",
                   "version": "2.0.0",
@@ -4754,9 +4053,7 @@
                           "version": "0.1.5",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "is-extendable": {
@@ -4764,9 +4061,7 @@
                       "version": "0.1.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "parse-glob": {
@@ -4802,9 +4097,7 @@
                                   "version": "1.0.0",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -4821,9 +4114,7 @@
                               "version": "1.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -4833,17 +4124,13 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "is-extglob": {
                       "name": "is-extglob",
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "is-glob": {
                       "name": "is-glob",
                       "version": "2.0.1",
@@ -4856,9 +4143,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -4882,9 +4167,7 @@
                           "version": "2.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "is-primitive": {
@@ -4892,9 +4175,7 @@
                       "version": "2.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -4911,9 +4192,7 @@
                   "version": "0.0.8",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "pkg-up": {
@@ -4949,9 +4228,7 @@
                               "version": "2.0.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -4968,9 +4245,7 @@
                           "version": "2.0.4",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -4982,9 +4257,7 @@
               "version": "2.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "rimraf": {
               "name": "rimraf",
               "version": "2.5.2",
@@ -5018,9 +4291,7 @@
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "wrappy": {
@@ -5028,9 +4299,7 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "inherits": {
@@ -5038,9 +4307,7 @@
                       "version": "2.0.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "minimatch": {
                       "name": "minimatch",
                       "version": "3.0.0",
@@ -5060,17 +4327,13 @@
                               "version": "0.4.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "concat-map": {
                               "name": "concat-map",
                               "version": "0.0.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -5087,9 +4350,7 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "path-is-absolute": {
@@ -5097,9 +4358,7 @@
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -5109,17 +4368,13 @@
               "version": "3.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "source-map": {
               "name": "source-map",
               "version": "0.5.6",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "spawn-wrap": {
               "name": "spawn-wrap",
               "version": "1.2.3",
@@ -5153,17 +4408,13 @@
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "yallist": {
                               "name": "yallist",
                               "version": "2.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "which": {
@@ -5178,9 +4429,7 @@
                               "version": "1.1.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -5190,9 +4439,7 @@
                       "version": "2.1.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "which": {
                       "name": "which",
                       "version": "1.2.10",
@@ -5205,9 +4452,7 @@
                           "version": "1.1.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -5224,9 +4469,7 @@
                       "version": "0.0.8",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "os-homedir": {
@@ -5234,9 +4477,7 @@
                   "version": "1.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "rimraf": {
                   "name": "rimraf",
                   "version": "2.5.2",
@@ -5270,9 +4511,7 @@
                                   "version": "1.0.2",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "wrappy": {
@@ -5280,9 +4519,7 @@
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "inherits": {
@@ -5290,9 +4527,7 @@
                           "version": "2.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "minimatch": {
                           "name": "minimatch",
                           "version": "3.0.0",
@@ -5312,17 +4547,13 @@
                                   "version": "0.4.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                },
+                                  }},
                                 "concat-map": {
                                   "name": "concat-map",
                                   "version": "0.0.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -5339,9 +4570,7 @@
                               "version": "1.0.2",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "path-is-absolute": {
@@ -5349,9 +4578,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -5361,9 +4588,7 @@
                   "version": "2.1.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "which": {
                   "name": "which",
                   "version": "1.2.10",
@@ -5376,9 +4601,7 @@
                       "version": "1.1.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -5395,9 +4618,7 @@
                   "version": "1.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "lodash.assign": {
                   "name": "lodash.assign",
                   "version": "4.0.9",
@@ -5410,17 +4631,13 @@
                       "version": "4.0.7",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "lodash.rest": {
                       "name": "lodash.rest",
                       "version": "4.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "micromatch": {
@@ -5442,9 +4659,7 @@
                           "version": "1.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "array-unique": {
@@ -5452,9 +4667,7 @@
                       "version": "0.2.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "braces": {
                       "name": "braces",
                       "version": "1.8.5",
@@ -5495,9 +4708,7 @@
                                           "version": "1.1.3",
                                           "labels": {
                                             "scope": "prod"
-                                          },
-                                          "dependencies": {}
-                                        }
+                                          }}
                                       }
                                     }
                                   }
@@ -5514,9 +4725,7 @@
                                       "version": "1.0.0",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 },
                                 "randomatic": {
@@ -5545,9 +4754,7 @@
                                               "version": "1.1.3",
                                               "labels": {
                                                 "scope": "prod"
-                                              },
-                                              "dependencies": {}
-                                            }
+                                              }}
                                           }
                                         }
                                       }
@@ -5564,9 +4771,7 @@
                                           "version": "1.1.3",
                                           "labels": {
                                             "scope": "prod"
-                                          },
-                                          "dependencies": {}
-                                        }
+                                          }}
                                       }
                                     }
                                   }
@@ -5576,17 +4781,13 @@
                                   "version": "1.1.2",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                },
+                                  }},
                                 "repeat-string": {
                                   "name": "repeat-string",
                                   "version": "1.5.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -5596,17 +4797,13 @@
                           "version": "0.2.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "repeat-element": {
                           "name": "repeat-element",
                           "version": "1.1.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "expand-brackets": {
@@ -5621,9 +4818,7 @@
                           "version": "0.1.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "extglob": {
@@ -5638,9 +4833,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "filename-regex": {
@@ -5648,17 +4841,13 @@
                       "version": "2.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "is-extglob": {
                       "name": "is-extglob",
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "is-glob": {
                       "name": "is-glob",
                       "version": "2.0.1",
@@ -5671,9 +4860,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "kind-of": {
@@ -5688,9 +4875,7 @@
                           "version": "1.1.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "normalize-path": {
@@ -5698,9 +4883,7 @@
                       "version": "2.0.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "object.omit": {
                       "name": "object.omit",
                       "version": "2.0.0",
@@ -5720,9 +4903,7 @@
                               "version": "0.1.5",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "is-extendable": {
@@ -5730,9 +4911,7 @@
                           "version": "0.1.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "parse-glob": {
@@ -5768,9 +4947,7 @@
                                       "version": "1.0.0",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 }
                               }
@@ -5787,9 +4964,7 @@
                                   "version": "1.0.0",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -5799,17 +4974,13 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "is-extglob": {
                           "name": "is-extglob",
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "is-glob": {
                           "name": "is-glob",
                           "version": "2.0.1",
@@ -5822,9 +4993,7 @@
                               "version": "1.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -5848,9 +5017,7 @@
                               "version": "2.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "is-primitive": {
@@ -5858,9 +5025,7 @@
                           "version": "2.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -5898,9 +5063,7 @@
                                   "version": "2.0.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -5917,9 +5080,7 @@
                               "version": "2.0.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -5943,9 +5104,7 @@
                               "version": "4.1.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "parse-json": {
                               "name": "parse-json",
                               "version": "2.2.0",
@@ -5965,9 +5124,7 @@
                                       "version": "0.2.1",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 }
                               }
@@ -5977,9 +5134,7 @@
                               "version": "2.3.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "pinkie-promise": {
                               "name": "pinkie-promise",
                               "version": "2.0.1",
@@ -5992,9 +5147,7 @@
                                   "version": "2.0.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "strip-bom": {
@@ -6009,9 +5162,7 @@
                                   "version": "0.2.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -6028,9 +5179,7 @@
                               "version": "2.1.5",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "is-builtin-module": {
                               "name": "is-builtin-module",
                               "version": "1.0.0",
@@ -6043,9 +5192,7 @@
                                   "version": "1.1.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "semver": {
@@ -6053,9 +5200,7 @@
                               "version": "5.1.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "validate-npm-package-license": {
                               "name": "validate-npm-package-license",
                               "version": "3.0.1",
@@ -6075,9 +5220,7 @@
                                       "version": "1.2.1",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 },
                                 "spdx-expression-parse": {
@@ -6092,17 +5235,13 @@
                                       "version": "1.0.4",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    },
+                                      }},
                                     "spdx-license-ids": {
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 }
                               }
@@ -6121,17 +5260,13 @@
                               "version": "4.1.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "pify": {
                               "name": "pify",
                               "version": "2.3.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "pinkie-promise": {
                               "name": "pinkie-promise",
                               "version": "2.0.1",
@@ -6144,9 +5279,7 @@
                                   "version": "2.0.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -6160,9 +5293,7 @@
                   "version": "1.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "yargs": {
@@ -6177,9 +5308,7 @@
                   "version": "3.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "cliui": {
                   "name": "cliui",
                   "version": "3.2.0",
@@ -6206,9 +5335,7 @@
                               "version": "1.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "is-fullwidth-code-point": {
@@ -6223,9 +5350,7 @@
                               "version": "1.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "strip-ansi": {
@@ -6240,9 +5365,7 @@
                               "version": "2.0.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -6259,9 +5382,7 @@
                           "version": "2.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "wrap-ansi": {
@@ -6290,9 +5411,7 @@
                                   "version": "1.0.0",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "is-fullwidth-code-point": {
@@ -6307,9 +5426,7 @@
                                   "version": "1.0.0",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "strip-ansi": {
@@ -6324,9 +5441,7 @@
                                   "version": "2.0.0",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -6340,9 +5455,7 @@
                   "version": "1.2.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "lodash.assign": {
                   "name": "lodash.assign",
                   "version": "4.0.9",
@@ -6355,17 +5468,13 @@
                       "version": "4.0.7",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "lodash.rest": {
                       "name": "lodash.rest",
                       "version": "4.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "os-locale": {
@@ -6387,9 +5496,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -6427,9 +5534,7 @@
                                   "version": "2.0.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -6446,9 +5551,7 @@
                               "version": "2.0.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -6465,9 +5568,7 @@
                           "version": "4.1.4",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "parse-json": {
                           "name": "parse-json",
                           "version": "2.2.0",
@@ -6487,9 +5588,7 @@
                                   "version": "0.2.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -6499,9 +5598,7 @@
                           "version": "2.3.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "pinkie-promise": {
                           "name": "pinkie-promise",
                           "version": "2.0.1",
@@ -6514,9 +5611,7 @@
                               "version": "2.0.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         },
                         "strip-bom": {
@@ -6531,9 +5626,7 @@
                               "version": "0.2.1",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -6543,17 +5636,13 @@
                       "version": "4.1.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "symbol": {
                       "name": "symbol",
                       "version": "0.2.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "read-pkg-up": {
@@ -6589,9 +5678,7 @@
                                   "version": "2.0.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -6608,9 +5695,7 @@
                               "version": "2.0.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            }
+                              }}
                           }
                         }
                       }
@@ -6634,9 +5719,7 @@
                               "version": "4.1.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "parse-json": {
                               "name": "parse-json",
                               "version": "2.2.0",
@@ -6656,9 +5739,7 @@
                                       "version": "0.2.1",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 }
                               }
@@ -6668,9 +5749,7 @@
                               "version": "2.3.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "pinkie-promise": {
                               "name": "pinkie-promise",
                               "version": "2.0.1",
@@ -6683,9 +5762,7 @@
                                   "version": "2.0.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "strip-bom": {
@@ -6700,9 +5777,7 @@
                                   "version": "0.2.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -6719,9 +5794,7 @@
                               "version": "2.1.5",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "is-builtin-module": {
                               "name": "is-builtin-module",
                               "version": "1.0.0",
@@ -6734,9 +5807,7 @@
                                   "version": "1.1.1",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             },
                             "semver": {
@@ -6744,9 +5815,7 @@
                               "version": "5.1.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "validate-npm-package-license": {
                               "name": "validate-npm-package-license",
                               "version": "3.0.1",
@@ -6766,9 +5835,7 @@
                                       "version": "1.2.1",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 },
                                 "spdx-expression-parse": {
@@ -6783,17 +5850,13 @@
                                       "version": "1.0.4",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    },
+                                      }},
                                     "spdx-license-ids": {
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1",
                                       "labels": {
                                         "scope": "prod"
-                                      },
-                                      "dependencies": {}
-                                    }
+                                      }}
                                   }
                                 }
                               }
@@ -6812,17 +5875,13 @@
                               "version": "4.1.4",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "pify": {
                               "name": "pify",
                               "version": "2.3.0",
                               "labels": {
                                 "scope": "prod"
-                              },
-                              "dependencies": {}
-                            },
+                              }},
                             "pinkie-promise": {
                               "name": "pinkie-promise",
                               "version": "2.0.1",
@@ -6835,9 +5894,7 @@
                                   "version": "2.0.4",
                                   "labels": {
                                     "scope": "prod"
-                                  },
-                                  "dependencies": {}
-                                }
+                                  }}
                               }
                             }
                           }
@@ -6851,17 +5908,13 @@
                   "version": "1.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "set-blocking": {
                   "name": "set-blocking",
                   "version": "1.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "string-width": {
                   "name": "string-width",
                   "version": "1.0.1",
@@ -6881,9 +5934,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "is-fullwidth-code-point": {
@@ -6898,9 +5949,7 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "strip-ansi": {
@@ -6915,9 +5964,7 @@
                           "version": "2.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -6927,17 +5974,13 @@
                   "version": "0.2.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "y18n": {
                   "name": "y18n",
                   "version": "3.2.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "yargs-parser": {
                   "name": "yargs-parser",
                   "version": "2.4.0",
@@ -6950,9 +5993,7 @@
                       "version": "2.1.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "lodash.assign": {
                       "name": "lodash.assign",
                       "version": "4.0.9",
@@ -6965,17 +6006,13 @@
                           "version": "4.0.7",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "lodash.rest": {
                           "name": "lodash.rest",
                           "version": "4.0.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -6989,17 +6026,13 @@
           "version": "1.2.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "opener": {
           "name": "opener",
           "version": "1.4.3",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "readable-stream": {
           "name": "readable-stream",
           "version": "2.3.6",
@@ -7012,41 +6045,31 @@
               "version": "1.0.2",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "inherits": {
               "name": "inherits",
               "version": "2.0.3",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "isarray": {
               "name": "isarray",
               "version": "1.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "process-nextick-args": {
               "name": "process-nextick-args",
               "version": "2.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "safe-buffer": {
               "name": "safe-buffer",
               "version": "5.1.1",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "string_decoder": {
               "name": "string_decoder",
               "version": "1.1.1",
@@ -7059,9 +6082,7 @@
                   "version": "5.1.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "util-deprecate": {
@@ -7069,9 +6090,7 @@
               "version": "1.0.2",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "signal-exit": {
@@ -7079,25 +6098,19 @@
           "version": "2.1.2",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "stack-utils": {
           "name": "stack-utils",
           "version": "0.4.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "supports-color": {
           "name": "supports-color",
           "version": "1.3.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "tap-mocha-reporter": {
           "name": "tap-mocha-reporter",
           "version": "0.0.27",
@@ -7110,9 +6123,7 @@
               "version": "1.1.3",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "debug": {
               "name": "debug",
               "version": "2.2.0",
@@ -7125,9 +6136,7 @@
                   "version": "0.7.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "diff": {
@@ -7135,17 +6144,13 @@
               "version": "1.4.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "escape-string-regexp": {
               "name": "escape-string-regexp",
               "version": "1.0.5",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "glob": {
               "name": "glob",
               "version": "7.1.2",
@@ -7158,9 +6163,7 @@
                   "version": "1.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "inflight": {
                   "name": "inflight",
                   "version": "1.0.6",
@@ -7180,9 +6183,7 @@
                           "version": "1.0.2",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "wrappy": {
@@ -7190,9 +6191,7 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "inherits": {
@@ -7200,9 +6199,7 @@
                   "version": "2.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "minimatch": {
                   "name": "minimatch",
                   "version": "3.0.4",
@@ -7222,17 +6219,13 @@
                           "version": "1.0.0",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        },
+                          }},
                         "concat-map": {
                           "name": "concat-map",
                           "version": "0.0.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     }
                   }
@@ -7249,9 +6242,7 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "path-is-absolute": {
@@ -7259,9 +6250,7 @@
                   "version": "1.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "js-yaml": {
@@ -7283,9 +6272,7 @@
                       "version": "1.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "esprima": {
@@ -7293,9 +6280,7 @@
                   "version": "4.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "readable-stream": {
@@ -7310,33 +6295,25 @@
                   "version": "1.0.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "inherits": {
                   "name": "inherits",
                   "version": "2.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "isarray": {
                   "name": "isarray",
                   "version": "0.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "string_decoder": {
                   "name": "string_decoder",
                   "version": "0.10.31",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "tap-parser": {
@@ -7351,17 +6328,13 @@
                   "version": "1.1.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "inherits": {
                   "name": "inherits",
                   "version": "2.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "js-yaml": {
                   "name": "js-yaml",
                   "version": "3.11.0",
@@ -7381,9 +6354,7 @@
                           "version": "1.0.3",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "esprima": {
@@ -7391,9 +6362,7 @@
                       "version": "4.0.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "readable-stream": {
@@ -7408,41 +6377,31 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "inherits": {
                       "name": "inherits",
                       "version": "2.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "isarray": {
                       "name": "isarray",
                       "version": "1.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "process-nextick-args": {
                       "name": "process-nextick-args",
                       "version": "2.0.0",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "safe-buffer": {
                       "name": "safe-buffer",
                       "version": "5.1.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    },
+                      }},
                     "string_decoder": {
                       "name": "string_decoder",
                       "version": "1.1.1",
@@ -7455,9 +6414,7 @@
                           "version": "5.1.1",
                           "labels": {
                             "scope": "prod"
-                          },
-                          "dependencies": {}
-                        }
+                          }}
                       }
                     },
                     "util-deprecate": {
@@ -7465,9 +6422,7 @@
                       "version": "1.0.2",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -7484,9 +6439,7 @@
                   "version": "1.4.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "strip-ansi": {
                   "name": "strip-ansi",
                   "version": "3.0.1",
@@ -7499,9 +6452,7 @@
                       "version": "2.1.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 }
               }
@@ -7520,17 +6471,13 @@
               "version": "1.1.2",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "inherits": {
               "name": "inherits",
               "version": "2.0.3",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "js-yaml": {
               "name": "js-yaml",
               "version": "3.11.0",
@@ -7550,9 +6497,7 @@
                       "version": "1.0.3",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "esprima": {
@@ -7560,9 +6505,7 @@
                   "version": "4.0.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             },
             "readable-stream": {
@@ -7577,41 +6520,31 @@
                   "version": "1.0.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "inherits": {
                   "name": "inherits",
                   "version": "2.0.3",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "isarray": {
                   "name": "isarray",
                   "version": "1.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "process-nextick-args": {
                   "name": "process-nextick-args",
                   "version": "2.0.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "safe-buffer": {
                   "name": "safe-buffer",
                   "version": "5.1.1",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                },
+                  }},
                 "string_decoder": {
                   "name": "string_decoder",
                   "version": "1.1.1",
@@ -7624,9 +6557,7 @@
                       "version": "5.1.1",
                       "labels": {
                         "scope": "prod"
-                      },
-                      "dependencies": {}
-                    }
+                      }}
                   }
                 },
                 "util-deprecate": {
@@ -7634,9 +6565,7 @@
                   "version": "1.0.2",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             }
           }
@@ -7646,9 +6575,7 @@
           "version": "2.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        }
+          }}
       }
     }
   }

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps-yarn.json
@@ -4,7 +4,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "dustjs-linkedin",
       "version": "2.5.0"
     },
@@ -12,7 +11,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "dustjs-helpers",
       "version": "1.5.0"
     },
@@ -20,7 +18,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "ejs",
       "version": "1.0.0"
     },
@@ -28,7 +25,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "jquery",
       "version": "2.2.4"
     },
@@ -36,7 +32,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "marked",
       "version": "0.3.5"
     },
@@ -44,7 +39,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "moment",
       "version": "2.15.1"
     },
@@ -52,7 +46,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "ms",
       "version": "0.7.3"
     },
@@ -60,7 +53,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "optional",
       "version": "0.1.4"
     },
@@ -68,7 +60,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "stream-buffers",
       "version": "3.0.2"
     },
@@ -76,7 +67,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "adm-zip",
       "version": "0.4.7"
     },
@@ -84,7 +74,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "file-type",
       "version": "8.1.0"
     },
@@ -97,7 +86,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie",
           "version": "0.1.2"
         },
@@ -105,7 +93,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie-signature",
           "version": "1.0.5"
         }
@@ -122,7 +109,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bluebird",
           "version": "3.5.1"
         }
@@ -139,7 +125,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ejs",
           "version": "0.8.8"
         }
@@ -156,7 +141,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ms",
           "version": "0.6.2"
         }
@@ -173,7 +157,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "methods",
           "version": "1.1.2"
         },
@@ -181,7 +164,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "parseurl",
           "version": "1.3.2"
         },
@@ -189,7 +171,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "vary",
           "version": "1.1.2"
         },
@@ -202,7 +183,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "2.0.0"
             }
@@ -223,7 +203,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.1.2"
         },
@@ -231,7 +210,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "on-headers",
           "version": "1.0.1"
         },
@@ -244,7 +222,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             }
@@ -261,7 +238,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "2.0.0"
             }
@@ -278,7 +254,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.1.1"
             }
@@ -299,7 +274,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "inherits",
           "version": "1.0.2"
         },
@@ -307,7 +281,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ini",
           "version": "1.1.0"
         },
@@ -315,7 +288,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mkdirp",
           "version": "0.3.5"
         },
@@ -323,7 +295,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "once",
           "version": "1.1.1"
         },
@@ -331,7 +302,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "osenv",
           "version": "0.0.3"
         },
@@ -339,7 +309,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "semver",
           "version": "1.1.4"
         },
@@ -352,7 +321,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ini",
               "version": "1.3.5"
             },
@@ -360,7 +328,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "proto-list",
               "version": "1.2.4"
             }
@@ -377,7 +344,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "abbrev",
               "version": "1.0.7"
             }
@@ -398,7 +364,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "fd",
           "version": "0.0.3"
         },
@@ -406,7 +371,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mime",
           "version": "1.2.11"
         },
@@ -414,7 +378,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "negotiator",
           "version": "0.2.8"
         },
@@ -422,7 +385,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "graceful-fs",
           "version": "1.2.3"
         },
@@ -435,7 +397,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "lru-cache",
               "version": "2.3.1"
             }
@@ -456,7 +417,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bytes",
           "version": "1.0.0"
         },
@@ -464,7 +424,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.0.1"
         },
@@ -472,7 +431,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "iconv-lite",
           "version": "0.4.4"
         },
@@ -480,7 +438,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "media-typer",
           "version": "0.3.0"
         },
@@ -488,7 +445,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "qs",
           "version": "2.2.4"
         },
@@ -501,7 +457,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.0.5"
             }
@@ -518,7 +473,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "bytes",
               "version": "1.0.0"
             },
@@ -526,7 +480,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "iconv-lite",
               "version": "0.4.4"
             }
@@ -543,7 +496,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "media-typer",
               "version": "0.3.0"
             },
@@ -556,7 +508,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.12.0"
                 }
@@ -581,7 +532,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ports",
           "version": "1.1.0"
         },
@@ -589,7 +539,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "underscore",
           "version": "1.8.3"
         },
@@ -602,7 +551,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "esprima",
               "version": "4.0.1"
             },
@@ -615,7 +563,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "sprintf-js",
                   "version": "1.0.3"
                 }
@@ -640,7 +587,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "escape-html",
           "version": "1.0.1"
         },
@@ -653,7 +599,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "negotiator",
               "version": "0.4.9"
             },
@@ -666,7 +611,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.12.0"
                 }
@@ -691,7 +635,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "content-disposition",
           "version": "0.5.0"
         },
@@ -699,7 +642,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "content-type",
           "version": "1.0.4"
         },
@@ -707,7 +649,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie",
           "version": "0.1.2"
         },
@@ -715,7 +656,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie-signature",
           "version": "1.0.6"
         },
@@ -723,7 +663,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.0.1"
         },
@@ -731,7 +670,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "escape-html",
           "version": "1.0.1"
         },
@@ -739,7 +677,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "fresh",
           "version": "0.2.4"
         },
@@ -747,7 +684,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "merge-descriptors",
           "version": "1.0.0"
         },
@@ -755,7 +691,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "methods",
           "version": "1.1.2"
         },
@@ -763,7 +698,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "parseurl",
           "version": "1.3.2"
         },
@@ -771,7 +705,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "path-to-regexp",
           "version": "0.1.3"
         },
@@ -779,7 +712,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "qs",
           "version": "2.4.2"
         },
@@ -787,7 +719,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "range-parser",
           "version": "1.0.3"
         },
@@ -795,7 +726,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "utils-merge",
           "version": "1.0.0"
         },
@@ -803,7 +733,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "vary",
           "version": "1.0.1"
         },
@@ -816,7 +745,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "0.7.1"
             }
@@ -833,7 +761,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "crc",
               "version": "3.2.1"
             }
@@ -850,7 +777,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.1.0"
             }
@@ -867,7 +793,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "forwarded",
               "version": "0.1.2"
             },
@@ -875,7 +800,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ipaddr.js",
               "version": "1.0.5"
             }
@@ -892,7 +816,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "negotiator",
               "version": "0.5.3"
             },
@@ -905,7 +828,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.35.0"
                 }
@@ -926,7 +848,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -939,7 +860,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -956,7 +876,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ee-first",
                   "version": "1.1.0"
                 }
@@ -977,7 +896,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "depd",
               "version": "1.0.1"
             },
@@ -985,7 +903,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "destroy",
               "version": "1.0.3"
             },
@@ -993,7 +910,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -1001,7 +917,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "fresh",
               "version": "0.2.4"
             },
@@ -1009,7 +924,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "mime",
               "version": "1.3.4"
             },
@@ -1017,7 +931,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "0.7.1"
             },
@@ -1025,7 +938,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "range-parser",
               "version": "1.0.3"
             },
@@ -1038,7 +950,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -1055,7 +966,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "crc",
                   "version": "3.2.1"
                 }
@@ -1072,7 +982,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ee-first",
                   "version": "1.1.0"
                 }
@@ -1093,7 +1002,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "media-typer",
               "version": "0.3.0"
             },
@@ -1106,7 +1014,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.35.0"
                 }
@@ -1127,7 +1034,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -1135,7 +1041,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "parseurl",
               "version": "1.3.2"
             },
@@ -1143,7 +1048,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "utils-merge",
               "version": "1.0.0"
             },
@@ -1156,7 +1060,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "depd",
                   "version": "1.0.1"
                 },
@@ -1164,7 +1067,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "destroy",
                   "version": "1.0.3"
                 },
@@ -1172,7 +1074,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "escape-html",
                   "version": "1.0.1"
                 },
@@ -1180,7 +1081,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "fresh",
                   "version": "0.2.4"
                 },
@@ -1188,7 +1088,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime",
                   "version": "1.3.4"
                 },
@@ -1196,7 +1095,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 },
@@ -1204,7 +1102,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "range-parser",
                   "version": "1.0.3"
                 },
@@ -1217,7 +1114,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ms",
                       "version": "0.7.1"
                     }
@@ -1234,7 +1130,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "crc",
                       "version": "3.2.1"
                     }
@@ -1251,7 +1146,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ee-first",
                       "version": "1.1.0"
                     }
@@ -1280,7 +1174,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "async",
           "version": "0.9.0"
         },
@@ -1288,7 +1181,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bson",
           "version": "0.4.23"
         },
@@ -1296,7 +1188,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "hooks-fixed",
           "version": "1.1.0"
         },
@@ -1304,7 +1195,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "kareem",
           "version": "1.0.1"
         },
@@ -1312,7 +1202,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mpath",
           "version": "0.1.1"
         },
@@ -1320,7 +1209,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mpromise",
           "version": "0.5.4"
         },
@@ -1328,7 +1216,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ms",
           "version": "0.7.1"
         },
@@ -1336,7 +1223,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "muri",
           "version": "1.0.0"
         },
@@ -1344,7 +1230,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "regexp-clone",
           "version": "0.0.1"
         },
@@ -1352,7 +1237,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "sliced",
           "version": "0.0.5"
         },
@@ -1365,7 +1249,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "bluebird",
               "version": "2.9.26"
             },
@@ -1373,7 +1256,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "regexp-clone",
               "version": "0.0.1"
             },
@@ -1381,7 +1263,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "sliced",
               "version": "0.0.5"
             },
@@ -1394,7 +1275,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -1415,7 +1295,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "es6-promise",
               "version": "2.1.1"
             },
@@ -1428,7 +1307,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -1436,7 +1314,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -1444,7 +1321,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "0.0.1"
                 },
@@ -1452,7 +1328,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "string_decoder",
                   "version": "0.10.31"
                 }
@@ -1469,7 +1344,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "bson",
                   "version": "0.4.23"
                 },
@@ -1482,7 +1356,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "nan",
                       "version": "2.10.0"
                     }
@@ -1511,7 +1384,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "streamifier",
           "version": "0.1.1"
         },
@@ -1534,7 +1406,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -1542,7 +1413,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -1550,7 +1420,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "0.0.1"
                     },
@@ -1558,7 +1427,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "string_decoder",
                       "version": "0.10.31"
                     }
@@ -1575,7 +1443,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "streamsearch",
                       "version": "0.1.2"
                     },
@@ -1588,7 +1455,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "core-util-is",
                           "version": "1.0.2"
                         },
@@ -1596,7 +1462,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -1604,7 +1469,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isarray",
                           "version": "0.0.1"
                         },
@@ -1612,7 +1476,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "string_decoder",
                           "version": "0.10.31"
                         }
@@ -1641,7 +1504,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "graceful-fs",
               "version": "4.1.4"
             },
@@ -1654,7 +1516,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "graceful-fs",
                   "version": "4.1.11"
                 }
@@ -1676,7 +1537,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "fs.realpath",
                       "version": "1.0.0"
                     },
@@ -1684,7 +1544,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.1"
                     },
@@ -1692,7 +1551,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "path-is-absolute",
                       "version": "1.0.0"
                     },
@@ -1705,7 +1563,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -1722,7 +1579,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         },
@@ -1735,7 +1591,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -1761,7 +1616,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "1.0.0"
                             },
@@ -1769,7 +1623,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -1806,7 +1659,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "cached-path-relative",
           "version": "1.0.1"
         },
@@ -1814,7 +1666,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "constants-browserify",
           "version": "1.0.0"
         },
@@ -1822,7 +1673,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "defined",
           "version": "1.0.0"
         },
@@ -1830,7 +1680,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "domain-browser",
           "version": "1.1.7"
         },
@@ -1838,7 +1687,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "events",
           "version": "1.1.1"
         },
@@ -1846,7 +1694,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "htmlescape",
           "version": "1.1.1"
         },
@@ -1854,7 +1701,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "https-browserify",
           "version": "0.0.1"
         },
@@ -1862,7 +1708,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "inherits",
           "version": "2.0.3"
         },
@@ -1870,7 +1715,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "os-browserify",
           "version": "0.1.2"
         },
@@ -1878,7 +1722,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "path-browserify",
           "version": "0.0.1"
         },
@@ -1886,7 +1729,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "process",
           "version": "0.11.10"
         },
@@ -1894,7 +1736,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "punycode",
           "version": "1.4.1"
         },
@@ -1902,7 +1743,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "querystring-es3",
           "version": "0.2.1"
         },
@@ -1910,7 +1750,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "string_decoder",
           "version": "0.10.31"
         },
@@ -1918,7 +1757,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "tty-browserify",
           "version": "0.0.1"
         },
@@ -1926,7 +1764,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "xtend",
           "version": "4.0.1"
         },
@@ -1939,7 +1776,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "jsonparse",
               "version": "1.3.1"
             },
@@ -1947,7 +1783,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "through",
               "version": "2.3.8"
             }
@@ -1964,7 +1799,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "resolve",
               "version": "1.1.7"
             }
@@ -1981,7 +1815,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "pako",
               "version": "0.2.9"
             }
@@ -1998,7 +1831,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "base64-js",
               "version": "1.3.0"
             },
@@ -2006,7 +1838,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "ieee754",
               "version": "1.1.12"
             },
@@ -2014,7 +1845,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "1.0.0"
             }
@@ -2031,7 +1861,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "date-now",
               "version": "0.1.4"
             }
@@ -2048,7 +1877,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "function-bind",
               "version": "1.1.1"
             }
@@ -2065,7 +1893,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "path-platform",
               "version": "0.11.15"
             }
@@ -2082,7 +1909,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "path-parse",
               "version": "1.0.5"
             }
@@ -2099,7 +1925,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "array-filter",
               "version": "0.0.1"
             },
@@ -2107,7 +1932,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "array-map",
               "version": "0.0.0"
             },
@@ -2115,7 +1939,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "array-reduce",
               "version": "0.0.0"
             },
@@ -2123,7 +1946,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "jsonify",
               "version": "0.0.0"
             }
@@ -2140,7 +1962,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "minimist",
               "version": "1.2.0"
             }
@@ -2157,7 +1978,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "process",
               "version": "0.11.10"
             }
@@ -2174,7 +1994,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "punycode",
               "version": "1.3.2"
             },
@@ -2182,7 +2001,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "querystring",
               "version": "0.2.0"
             }
@@ -2199,7 +2017,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             }
@@ -2216,7 +2033,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "indexof",
               "version": "0.0.1"
             }
@@ -2238,7 +2054,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.1"
                 }
@@ -2259,7 +2074,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2267,7 +2081,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "typedarray",
               "version": "0.0.6"
             },
@@ -2280,7 +2093,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2288,7 +2100,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2296,7 +2107,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2304,7 +2114,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "1.0.7"
                 },
@@ -2312,7 +2121,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "string_decoder",
                   "version": "0.10.31"
                 },
@@ -2320,7 +2128,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 }
@@ -2341,7 +2148,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "core-util-is",
               "version": "1.0.2"
             },
@@ -2349,7 +2155,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2357,7 +2162,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "1.0.0"
             },
@@ -2365,7 +2169,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "process-nextick-args",
               "version": "2.0.0"
             },
@@ -2373,7 +2176,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             },
@@ -2381,7 +2183,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "util-deprecate",
               "version": "1.0.2"
             },
@@ -2394,7 +2195,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -2420,7 +2220,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonify",
                   "version": "0.0.0"
                 }
@@ -2437,7 +2236,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2445,7 +2243,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -2471,7 +2268,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2479,7 +2275,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2487,7 +2282,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2495,7 +2289,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2503,7 +2296,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2511,7 +2303,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2524,7 +2315,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2549,7 +2339,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "fs.realpath",
               "version": "1.0.0"
             },
@@ -2557,7 +2346,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.1"
             },
@@ -2565,7 +2353,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "path-is-absolute",
               "version": "1.0.0"
             },
@@ -2578,7 +2365,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 }
@@ -2595,7 +2381,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 },
@@ -2608,7 +2393,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -2634,7 +2418,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "balanced-match",
                       "version": "1.0.0"
                     },
@@ -2642,7 +2425,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "concat-map",
                       "version": "0.0.1"
                     }
@@ -2672,7 +2454,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2680,7 +2461,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2688,7 +2468,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2696,7 +2475,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2704,7 +2482,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2712,7 +2489,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2725,7 +2501,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2750,7 +2525,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2763,7 +2537,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2771,7 +2544,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2779,7 +2551,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2787,7 +2558,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2795,7 +2565,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2803,7 +2572,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2816,7 +2584,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2841,7 +2608,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "builtin-status-codes",
               "version": "3.0.0"
             },
@@ -2849,7 +2615,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2857,7 +2622,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "to-arraybuffer",
               "version": "1.0.1"
             },
@@ -2865,7 +2629,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "xtend",
               "version": "4.0.1"
             },
@@ -2878,7 +2641,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2886,7 +2648,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2894,7 +2655,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2902,7 +2662,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2910,7 +2669,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2918,7 +2676,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2931,7 +2688,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2961,7 +2717,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "acorn",
                   "version": "5.7.1"
                 },
@@ -2969,7 +2724,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -2982,7 +2736,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "acorn",
                       "version": "5.7.1"
                     }
@@ -3007,7 +2760,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "xtend",
               "version": "4.0.1"
             },
@@ -3020,7 +2772,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -3028,7 +2779,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -3036,7 +2786,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -3044,7 +2793,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -3052,7 +2800,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -3060,7 +2807,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -3073,7 +2819,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -3098,7 +2843,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "defined",
               "version": "1.0.0"
             },
@@ -3106,7 +2850,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             },
@@ -3114,7 +2857,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "umd",
               "version": "3.0.3"
             },
@@ -3127,7 +2869,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonparse",
                   "version": "1.3.1"
                 },
@@ -3135,7 +2876,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "through",
                   "version": "2.3.8"
                 }
@@ -3152,7 +2892,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "convert-source-map",
                   "version": "1.1.3"
                 },
@@ -3160,7 +2899,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "lodash.memoize",
                   "version": "3.0.4"
                 },
@@ -3168,7 +2906,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "source-map",
                   "version": "0.5.7"
                 },
@@ -3181,7 +2918,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "source-map",
                       "version": "0.5.7"
                     }
@@ -3202,7 +2938,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3215,7 +2950,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3223,7 +2957,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3231,7 +2964,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3239,7 +2971,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3247,7 +2978,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3255,7 +2985,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3268,7 +2997,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3302,7 +3030,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonparse",
                   "version": "1.3.1"
                 },
@@ -3310,7 +3037,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "through",
                   "version": "2.3.8"
                 }
@@ -3327,7 +3053,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "minimist",
                   "version": "1.2.0"
                 }
@@ -3349,7 +3074,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "jsonify",
                       "version": "0.0.0"
                     }
@@ -3366,7 +3090,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3374,7 +3097,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -3395,7 +3117,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3408,7 +3129,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3416,7 +3136,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3424,7 +3143,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3432,7 +3150,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3440,7 +3157,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3448,7 +3164,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3461,7 +3176,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3490,7 +3204,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "is-buffer",
               "version": "1.1.6"
             },
@@ -3498,7 +3211,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "path-is-absolute",
               "version": "1.0.1"
             },
@@ -3506,7 +3218,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "process",
               "version": "0.11.10"
             },
@@ -3514,7 +3225,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "xtend",
               "version": "4.0.1"
             },
@@ -3527,7 +3237,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonparse",
                   "version": "1.3.1"
                 },
@@ -3535,7 +3244,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "through",
                   "version": "2.3.8"
                 }
@@ -3552,7 +3260,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "acorn",
                   "version": "5.7.1"
                 },
@@ -3560,7 +3267,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3573,7 +3279,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "acorn",
                       "version": "5.7.1"
                     }
@@ -3594,7 +3299,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "convert-source-map",
                   "version": "1.1.3"
                 },
@@ -3602,7 +3306,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "lodash.memoize",
                   "version": "3.0.4"
                 },
@@ -3610,7 +3313,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "source-map",
                   "version": "0.5.7"
                 },
@@ -3623,7 +3325,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "source-map",
                       "version": "0.5.7"
                     }
@@ -3644,7 +3345,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "buffer-from",
                   "version": "1.1.0"
                 },
@@ -3652,7 +3352,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -3660,7 +3359,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "typedarray",
                   "version": "0.0.6"
                 },
@@ -3673,7 +3371,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3681,7 +3378,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3689,7 +3385,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3697,7 +3392,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3705,7 +3399,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3713,7 +3406,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3726,7 +3418,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3751,7 +3442,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3764,7 +3454,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3772,7 +3461,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3780,7 +3468,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3788,7 +3475,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3796,7 +3482,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3804,7 +3489,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3817,7 +3501,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3842,7 +3525,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "get-assigned-identifiers",
                   "version": "1.2.0"
                 },
@@ -3850,7 +3532,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "simple-concat",
                   "version": "1.0.0"
                 },
@@ -3858,7 +3539,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3871,7 +3551,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "acorn",
                       "version": "5.7.1"
                     },
@@ -3879,7 +3558,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "xtend",
                       "version": "4.0.1"
                     },
@@ -3892,7 +3570,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "acorn",
                           "version": "5.7.1"
                         }
@@ -3921,7 +3598,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -3929,7 +3605,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "2.0.4"
             },
@@ -3942,7 +3617,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -3955,7 +3629,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3963,7 +3636,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3971,7 +3643,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3979,7 +3650,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3987,7 +3657,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3995,7 +3664,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -4008,7 +3676,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4037,7 +3704,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "cached-path-relative",
               "version": "1.0.1"
             },
@@ -4045,7 +3711,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "defined",
               "version": "1.0.0"
             },
@@ -4053,7 +3718,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -4061,7 +3725,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "xtend",
               "version": "4.0.1"
             },
@@ -4074,7 +3737,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonparse",
                   "version": "1.3.1"
                 },
@@ -4082,7 +3744,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "through",
                   "version": "2.3.8"
                 }
@@ -4099,7 +3760,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "resolve",
                   "version": "1.1.7"
                 }
@@ -4116,7 +3776,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "acorn",
                   "version": "5.7.1"
                 },
@@ -4124,7 +3783,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "defined",
                   "version": "1.0.0"
                 }
@@ -4141,7 +3799,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "path-platform",
                   "version": "0.11.15"
                 }
@@ -4158,7 +3815,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "path-parse",
                   "version": "1.0.5"
                 }
@@ -4175,7 +3831,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "minimist",
                   "version": "1.2.0"
                 }
@@ -4192,7 +3847,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -4200,7 +3854,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "typedarray",
                   "version": "0.0.6"
                 },
@@ -4213,7 +3866,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -4221,7 +3873,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4229,7 +3880,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -4237,7 +3887,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "1.0.7"
                     },
@@ -4245,7 +3894,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "string_decoder",
                       "version": "0.10.31"
                     },
@@ -4253,7 +3901,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     }
@@ -4274,7 +3921,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -4282,7 +3928,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -4290,7 +3935,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -4298,7 +3942,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -4306,7 +3949,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -4314,7 +3956,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -4327,7 +3968,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4353,7 +3993,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -4361,7 +4000,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4369,7 +4007,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -4377,7 +4014,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -4385,7 +4021,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -4393,7 +4028,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -4406,7 +4040,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4431,7 +4064,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -4444,7 +4076,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -4452,7 +4083,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4460,7 +4090,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -4468,7 +4097,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -4476,7 +4104,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -4484,7 +4111,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -4497,7 +4123,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4527,7 +4152,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -4535,7 +4159,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4543,7 +4166,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -4551,7 +4173,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -4559,7 +4180,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -4567,7 +4187,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -4580,7 +4199,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4606,7 +4224,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "core-util-is",
                           "version": "1.0.2"
                         },
@@ -4614,7 +4231,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -4622,7 +4238,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "isarray",
                           "version": "1.0.0"
                         },
@@ -4630,7 +4245,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "process-nextick-args",
                           "version": "2.0.0"
                         },
@@ -4638,7 +4252,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -4646,7 +4259,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "util-deprecate",
                           "version": "1.0.2"
                         },
@@ -4659,7 +4271,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -4692,7 +4303,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -4705,7 +4315,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -4722,7 +4331,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "bn.js",
                   "version": "4.11.8"
                 },
@@ -4735,7 +4343,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -4743,7 +4350,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "brorand",
                       "version": "1.1.0"
                     }
@@ -4760,7 +4366,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4781,7 +4386,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -4794,7 +4398,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4815,7 +4418,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -4828,7 +4430,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4836,7 +4437,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4853,7 +4453,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4861,7 +4460,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4878,7 +4476,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4891,7 +4488,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -4899,7 +4495,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4920,7 +4515,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4933,7 +4527,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -4941,7 +4534,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4966,7 +4558,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "bn.js",
                   "version": "4.11.8"
                 },
@@ -4979,7 +4570,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -4987,7 +4577,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "brorand",
                       "version": "1.1.0"
                     },
@@ -4995,7 +4584,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5003,7 +4591,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "minimalistic-assert",
                       "version": "1.0.1"
                     },
@@ -5011,7 +4598,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "minimalistic-crypto-utils",
                       "version": "1.0.1"
                     },
@@ -5024,7 +4610,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5032,7 +4617,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -5049,7 +4633,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         },
@@ -5057,7 +4640,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-crypto-utils",
                           "version": "1.0.1"
                         },
@@ -5070,7 +4652,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5078,7 +4659,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "minimalistic-assert",
                               "version": "1.0.1"
                             }
@@ -5107,7 +4687,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -5115,7 +4694,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -5128,7 +4706,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5136,7 +4713,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -5153,7 +4729,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5161,7 +4736,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -5178,7 +4752,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5191,7 +4764,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5199,7 +4771,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5220,7 +4791,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5233,7 +4803,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5241,7 +4810,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5258,7 +4826,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5266,7 +4833,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5283,7 +4849,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5296,7 +4861,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5304,7 +4868,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5325,7 +4888,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5338,7 +4900,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5346,7 +4907,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5380,7 +4940,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5388,7 +4947,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.2"
                     },
@@ -5401,7 +4959,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5409,7 +4966,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5426,7 +4982,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5434,7 +4989,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -5455,7 +5009,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -5468,7 +5021,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5481,7 +5033,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5489,7 +5040,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5514,7 +5064,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "buffer-xor",
                       "version": "1.0.3"
                     },
@@ -5522,7 +5071,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5530,7 +5078,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -5543,7 +5090,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5551,7 +5097,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5568,7 +5113,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5581,7 +5125,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5589,7 +5132,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5606,7 +5148,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5614,7 +5155,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5631,7 +5171,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5644,7 +5183,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -5652,7 +5190,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -5673,7 +5210,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5686,7 +5222,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -5694,7 +5229,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -5719,7 +5253,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -5732,7 +5265,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5745,7 +5277,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -5753,7 +5284,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -5786,7 +5316,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -5799,7 +5328,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5807,7 +5335,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -5824,7 +5351,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5837,7 +5363,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5845,7 +5370,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5866,7 +5390,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5879,7 +5402,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5887,7 +5409,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5904,7 +5425,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5912,7 +5432,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5929,7 +5448,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5942,7 +5460,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5950,7 +5467,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5971,7 +5487,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5984,7 +5499,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5992,7 +5506,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6017,7 +5530,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -6025,7 +5537,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -6038,7 +5549,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6046,7 +5556,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6063,7 +5572,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6071,7 +5579,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6088,7 +5595,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6101,7 +5607,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6109,7 +5614,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6130,7 +5634,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6143,7 +5646,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6151,7 +5653,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6168,7 +5669,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6176,7 +5676,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6193,7 +5692,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6206,7 +5704,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -6214,7 +5711,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -6235,7 +5731,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6248,7 +5743,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -6256,7 +5750,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -6289,7 +5782,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "bn.js",
                   "version": "4.11.8"
                 },
@@ -6297,7 +5789,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -6310,7 +5801,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -6323,7 +5813,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6344,7 +5833,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -6357,7 +5845,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6365,7 +5852,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6382,7 +5868,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6390,7 +5875,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6407,7 +5891,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6420,7 +5903,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6428,7 +5910,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6449,7 +5930,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6462,7 +5942,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6470,7 +5949,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6495,7 +5973,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -6503,7 +5980,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "brorand",
                       "version": "1.1.0"
                     },
@@ -6511,7 +5987,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -6519,7 +5994,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "minimalistic-assert",
                       "version": "1.0.1"
                     },
@@ -6527,7 +6001,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "minimalistic-crypto-utils",
                       "version": "1.0.1"
                     },
@@ -6540,7 +6013,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6548,7 +6020,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -6565,7 +6036,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         },
@@ -6573,7 +6043,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-crypto-utils",
                           "version": "1.0.1"
                         },
@@ -6586,7 +6055,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6594,7 +6062,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "minimalistic-assert",
                               "version": "1.0.1"
                             }
@@ -6619,7 +6086,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -6627,7 +6093,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -6640,7 +6105,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6648,7 +6112,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6665,7 +6128,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6673,7 +6135,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6690,7 +6151,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6703,7 +6163,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6711,7 +6170,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6732,7 +6190,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6745,7 +6202,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6753,7 +6209,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6770,7 +6225,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6778,7 +6232,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6795,7 +6248,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6808,7 +6260,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -6816,7 +6267,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -6837,7 +6287,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6850,7 +6299,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -6858,7 +6306,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -6892,7 +6339,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "bn.js",
                           "version": "4.11.8"
                         },
@@ -6900,7 +6346,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6908,7 +6353,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -6925,7 +6369,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6938,7 +6381,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6946,7 +6388,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6963,7 +6404,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6971,7 +6411,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6988,7 +6427,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7001,7 +6439,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7009,7 +6446,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7030,7 +6466,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7043,7 +6478,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7051,7 +6485,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7076,7 +6509,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -7089,7 +6521,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7102,7 +6533,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7110,7 +6540,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7135,7 +6564,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "buffer-xor",
                           "version": "1.0.3"
                         },
@@ -7143,7 +6571,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -7151,7 +6578,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -7164,7 +6590,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7172,7 +6597,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -7189,7 +6613,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7202,7 +6625,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7210,7 +6632,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7227,7 +6648,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7235,7 +6655,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7252,7 +6671,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7265,7 +6683,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7273,7 +6690,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7294,7 +6710,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7307,7 +6722,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7315,7 +6729,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7340,7 +6753,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             },
@@ -7353,7 +6765,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7366,7 +6777,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7374,7 +6784,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7403,7 +6812,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -7416,7 +6824,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7424,7 +6831,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -7441,7 +6847,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7454,7 +6859,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7462,7 +6866,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7483,7 +6886,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7496,7 +6898,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7504,7 +6905,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7521,7 +6921,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7529,7 +6928,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7546,7 +6944,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7559,7 +6956,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7567,7 +6963,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7588,7 +6983,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7601,7 +6995,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7609,7 +7002,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7634,7 +7026,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7642,7 +7033,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             },
@@ -7655,7 +7045,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7663,7 +7052,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7680,7 +7068,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7688,7 +7075,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7705,7 +7091,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7718,7 +7103,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7726,7 +7110,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7747,7 +7130,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7760,7 +7142,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7768,7 +7149,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7785,7 +7165,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7793,7 +7172,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7810,7 +7188,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7823,7 +7200,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "inherits",
                                           "version": "2.0.3"
                                         },
@@ -7831,7 +7207,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "safe-buffer",
                                           "version": "5.1.1"
                                         }
@@ -7852,7 +7227,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7865,7 +7239,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "inherits",
                                           "version": "2.0.3"
                                         },
@@ -7873,7 +7246,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "safe-buffer",
                                           "version": "5.1.1"
                                         }
@@ -7914,7 +7286,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "bn.js",
                   "version": "4.11.8"
                 },
@@ -7927,7 +7298,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -7944,7 +7314,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -7957,7 +7326,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -7978,7 +7346,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -7991,7 +7358,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -7999,7 +7365,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -8016,7 +7381,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8024,7 +7388,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -8041,7 +7404,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8054,7 +7416,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8062,7 +7423,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8083,7 +7443,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8096,7 +7455,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8104,7 +7462,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8134,7 +7491,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "bn.js",
                           "version": "4.11.8"
                         },
@@ -8142,7 +7498,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8150,7 +7505,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -8167,7 +7521,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8180,7 +7533,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8188,7 +7540,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8205,7 +7556,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8213,7 +7563,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8230,7 +7579,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8243,7 +7591,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8251,7 +7598,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8272,7 +7618,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8285,7 +7630,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8293,7 +7637,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8318,7 +7661,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -8331,7 +7673,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8344,7 +7685,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8352,7 +7692,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8377,7 +7716,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "buffer-xor",
                           "version": "1.0.3"
                         },
@@ -8385,7 +7723,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8393,7 +7730,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -8406,7 +7742,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8414,7 +7749,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8431,7 +7765,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8444,7 +7777,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8452,7 +7784,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8469,7 +7800,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8477,7 +7807,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8494,7 +7823,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8507,7 +7835,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8515,7 +7842,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8536,7 +7862,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8549,7 +7874,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8557,7 +7881,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8582,7 +7905,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             },
@@ -8595,7 +7917,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8608,7 +7929,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8616,7 +7936,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8645,7 +7964,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -8658,7 +7976,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8666,7 +7983,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8683,7 +7999,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8696,7 +8011,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8704,7 +8018,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8725,7 +8038,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8738,7 +8050,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8746,7 +8057,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8763,7 +8073,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8771,7 +8080,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8788,7 +8096,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8801,7 +8108,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8809,7 +8115,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8830,7 +8135,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8843,7 +8147,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8851,7 +8154,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8876,7 +8178,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8884,7 +8185,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             },
@@ -8897,7 +8197,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8905,7 +8204,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8922,7 +8220,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8930,7 +8227,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8947,7 +8243,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8960,7 +8255,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8968,7 +8262,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8989,7 +8282,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -9002,7 +8294,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -9010,7 +8301,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -9027,7 +8317,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -9035,7 +8324,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -9052,7 +8340,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -9065,7 +8352,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "inherits",
                                           "version": "2.0.3"
                                         },
@@ -9073,7 +8359,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "safe-buffer",
                                           "version": "5.1.1"
                                         }
@@ -9094,7 +8379,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -9107,7 +8391,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "inherits",
                                           "version": "2.0.3"
                                         },
@@ -9115,7 +8398,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "safe-buffer",
                                           "version": "5.1.1"
                                         }
@@ -9164,7 +8446,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bluebird",
           "version": "3.5.1"
         },
@@ -9172,7 +8453,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "clean-yaml-object",
           "version": "0.1.0"
         },
@@ -9180,7 +8460,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "deeper",
           "version": "2.1.0"
         },
@@ -9188,7 +8467,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "isexe",
           "version": "1.1.2"
         },
@@ -9196,7 +8474,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "only-shallow",
           "version": "1.2.0"
         },
@@ -9204,7 +8481,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "opener",
           "version": "1.4.3"
         },
@@ -9212,7 +8488,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "signal-exit",
           "version": "2.1.2"
         },
@@ -9220,7 +8495,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "stack-utils",
           "version": "0.4.0"
         },
@@ -9228,7 +8502,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "supports-color",
           "version": "1.3.1"
         },
@@ -9236,7 +8509,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "tmatch",
           "version": "2.0.1"
         },
@@ -9249,7 +8521,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "esprima",
               "version": "4.0.1"
             },
@@ -9262,7 +8533,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "sprintf-js",
                   "version": "1.0.3"
                 }
@@ -9283,7 +8553,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "core-util-is",
               "version": "1.0.2"
             },
@@ -9291,7 +8560,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -9299,7 +8567,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "1.0.0"
             },
@@ -9307,7 +8574,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "process-nextick-args",
               "version": "2.0.0"
             },
@@ -9315,7 +8581,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             },
@@ -9323,7 +8588,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "util-deprecate",
               "version": "1.0.2"
             },
@@ -9336,7 +8600,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -9357,7 +8620,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "signal-exit",
               "version": "2.1.2"
             },
@@ -9370,7 +8632,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isexe",
                   "version": "1.1.2"
                 }
@@ -9392,7 +8653,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "pseudomap",
                       "version": "1.0.2"
                     },
@@ -9400,7 +8660,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "yallist",
                       "version": "2.0.0"
                     }
@@ -9417,7 +8676,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -9442,7 +8700,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "fs.realpath",
               "version": "1.0.0"
             },
@@ -9450,7 +8707,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.1"
             },
@@ -9458,7 +8714,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "path-is-absolute",
               "version": "1.0.0"
             },
@@ -9471,7 +8726,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 }
@@ -9488,7 +8742,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 },
@@ -9501,7 +8754,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -9527,7 +8779,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "balanced-match",
                       "version": "1.0.0"
                     },
@@ -9535,7 +8786,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "concat-map",
                       "version": "0.0.1"
                     }
@@ -9560,7 +8810,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "events-to-array",
               "version": "1.1.2"
             },
@@ -9568,7 +8817,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -9581,7 +8829,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "4.0.1"
                 },
@@ -9594,7 +8841,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -9615,7 +8861,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -9623,7 +8868,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -9631,7 +8875,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -9639,7 +8882,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -9647,7 +8889,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -9655,7 +8896,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -9668,7 +8908,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -9693,7 +8932,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "color-support",
               "version": "1.1.3"
             },
@@ -9701,7 +8939,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "diff",
               "version": "1.4.0"
             },
@@ -9709,7 +8946,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-string-regexp",
               "version": "1.0.5"
             },
@@ -9722,7 +8958,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -9739,7 +8974,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -9747,7 +8981,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -9755,7 +8988,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "0.0.1"
                 },
@@ -9763,7 +8995,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "string_decoder",
                   "version": "0.10.31"
                 }
@@ -9780,7 +9011,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "4.0.1"
                 },
@@ -9793,7 +9023,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -9814,7 +9043,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "punycode",
                   "version": "1.4.1"
                 },
@@ -9827,7 +9055,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ansi-regex",
                       "version": "2.1.1"
                     }
@@ -9848,7 +9075,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "fs.realpath",
                   "version": "1.0.0"
                 },
@@ -9856,7 +9082,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.1"
                 },
@@ -9864,7 +9089,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "path-is-absolute",
                   "version": "1.0.0"
                 },
@@ -9877,7 +9101,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -9894,7 +9117,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     },
@@ -9907,7 +9129,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -9933,7 +9154,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "balanced-match",
                           "version": "1.0.0"
                         },
@@ -9941,7 +9161,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "concat-map",
                           "version": "0.0.1"
                         }
@@ -9966,7 +9185,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "events-to-array",
                   "version": "1.1.2"
                 },
@@ -9974,7 +9192,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -9987,7 +9204,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "4.0.1"
                     },
@@ -10000,7 +9216,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "sprintf-js",
                           "version": "1.0.3"
                         }
@@ -10021,7 +9236,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -10029,7 +9243,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -10037,7 +9250,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -10045,7 +9257,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -10053,7 +9264,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -10061,7 +9271,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -10074,7 +9283,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -10113,7 +9321,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "deep-equal",
                       "version": "0.1.2"
                     },
@@ -10121,7 +9328,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "defined",
                       "version": "0.0.0"
                     },
@@ -10129,7 +9335,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -10137,7 +9342,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "jsonify",
                       "version": "0.0.0"
                     },
@@ -10145,7 +9349,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "through",
                       "version": "2.3.8"
                     },
@@ -10158,7 +9361,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "through",
                           "version": "2.3.8"
                         }
@@ -10175,7 +9377,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "through",
                           "version": "2.3.8"
                         }
@@ -10192,7 +9393,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "duplexer",
                           "version": "0.1.1"
                         }
@@ -10217,7 +9417,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "caseless",
                   "version": "0.6.0"
                 },
@@ -10225,7 +9424,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "forever-agent",
                   "version": "0.5.2"
                 },
@@ -10233,7 +9431,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "json-stringify-safe",
                   "version": "5.0.1"
                 },
@@ -10241,7 +9438,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-types",
                   "version": "1.0.2"
                 },
@@ -10249,7 +9445,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "node-uuid",
                   "version": "1.4.8"
                 },
@@ -10257,7 +9452,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "qs",
                   "version": "1.2.2"
                 },
@@ -10265,7 +9459,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "tunnel-agent",
                   "version": "0.4.3"
                 },
@@ -10273,7 +9466,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws-sign2",
                   "version": "0.5.0"
                 },
@@ -10281,7 +9473,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "oauth-sign",
                   "version": "0.4.0"
                 },
@@ -10289,7 +9480,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "stringstream",
                   "version": "0.0.6"
                 },
@@ -10302,7 +9492,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "asn1",
                       "version": "0.1.11"
                     },
@@ -10310,7 +9499,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "assert-plus",
                       "version": "0.1.5"
                     },
@@ -10318,7 +9506,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ctype",
                       "version": "0.5.3"
                     }
@@ -10335,7 +9522,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "psl",
                       "version": "1.1.28"
                     },
@@ -10343,7 +9529,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "punycode",
                       "version": "1.4.1"
                     }
@@ -10365,7 +9550,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "core-util-is",
                           "version": "1.0.2"
                         },
@@ -10373,7 +9557,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -10381,7 +9564,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isarray",
                           "version": "0.0.1"
                         },
@@ -10389,7 +9571,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "string_decoder",
                           "version": "0.10.31"
                         }
@@ -10410,7 +9591,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "async",
                       "version": "0.9.0"
                     },
@@ -10418,7 +9598,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "mime",
                       "version": "1.2.11"
                     },
@@ -10431,7 +9610,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "delayed-stream",
                           "version": "0.0.5"
                         }
@@ -10452,7 +9630,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "hoek",
                       "version": "0.9.1"
                     },
@@ -10465,7 +9642,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "0.9.1"
                         }
@@ -10482,7 +9658,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "0.9.1"
                         }
@@ -10504,7 +9679,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hoek",
                               "version": "0.9.1"
                             }
@@ -10537,7 +9711,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "lcov-parse",
               "version": "0.0.10"
             },
@@ -10545,7 +9718,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "log-driver",
               "version": "1.2.5"
             },
@@ -10553,7 +9725,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "minimist",
               "version": "1.2.0"
             },
@@ -10566,7 +9737,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "2.7.3"
                 },
@@ -10579,7 +9749,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -10600,7 +9769,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws-sign2",
                   "version": "0.6.0"
                 },
@@ -10608,7 +9776,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws4",
                   "version": "1.7.0"
                 },
@@ -10616,7 +9783,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "caseless",
                   "version": "0.11.0"
                 },
@@ -10624,7 +9790,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "extend",
                   "version": "3.0.2"
                 },
@@ -10632,7 +9797,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "forever-agent",
                   "version": "0.6.1"
                 },
@@ -10640,7 +9804,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "is-typedarray",
                   "version": "1.0.0"
                 },
@@ -10648,7 +9811,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isstream",
                   "version": "0.1.2"
                 },
@@ -10656,7 +9818,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "json-stringify-safe",
                   "version": "5.0.1"
                 },
@@ -10664,7 +9825,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "oauth-sign",
                   "version": "0.8.2"
                 },
@@ -10672,7 +9832,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "qs",
                   "version": "6.3.2"
                 },
@@ -10680,7 +9839,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "stringstream",
                   "version": "0.0.6"
                 },
@@ -10688,7 +9846,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "tunnel-agent",
                   "version": "0.4.3"
                 },
@@ -10696,7 +9853,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "uuid",
                   "version": "3.3.2"
                 },
@@ -10709,7 +9865,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "delayed-stream",
                       "version": "1.0.0"
                     }
@@ -10726,7 +9881,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "mime-db",
                       "version": "1.35.0"
                     }
@@ -10743,7 +9897,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "punycode",
                       "version": "1.4.1"
                     }
@@ -10760,7 +9913,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "asynckit",
                       "version": "0.4.0"
                     },
@@ -10773,7 +9925,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "delayed-stream",
                           "version": "1.0.0"
                         }
@@ -10790,7 +9941,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "mime-db",
                           "version": "1.35.0"
                         }
@@ -10811,7 +9961,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "commander",
                       "version": "2.16.0"
                     },
@@ -10824,7 +9973,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -10841,7 +9989,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-styles",
                           "version": "2.2.1"
                         },
@@ -10849,7 +9996,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "escape-string-regexp",
                           "version": "1.0.5"
                         },
@@ -10857,7 +10003,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "supports-color",
                           "version": "2.0.0"
                         },
@@ -10870,7 +10015,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.1.1"
                             }
@@ -10887,7 +10031,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.1.1"
                             }
@@ -10908,7 +10051,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "generate-function",
                           "version": "2.0.0"
                         },
@@ -10916,7 +10058,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-my-ip-valid",
                           "version": "1.0.0"
                         },
@@ -10924,7 +10065,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "jsonpointer",
                           "version": "4.0.1"
                         },
@@ -10932,7 +10072,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "xtend",
                           "version": "4.0.1"
                         },
@@ -10945,7 +10084,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-property",
                               "version": "1.0.2"
                             }
@@ -10970,7 +10108,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "hoek",
                       "version": "2.16.3"
                     },
@@ -10983,7 +10120,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "2.16.3"
                         }
@@ -11000,7 +10136,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "2.16.3"
                         }
@@ -11022,7 +10157,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hoek",
                               "version": "2.16.3"
                             }
@@ -11047,7 +10181,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "assert-plus",
                       "version": "0.2.0"
                     },
@@ -11060,7 +10193,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "assert-plus",
                           "version": "1.0.0"
                         },
@@ -11068,7 +10200,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "extsprintf",
                           "version": "1.3.0"
                         },
@@ -11076,7 +10207,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "json-schema",
                           "version": "0.2.3"
                         },
@@ -11089,7 +10219,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             },
@@ -11097,7 +10226,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "core-util-is",
                               "version": "1.0.2"
                             },
@@ -11105,7 +10233,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "extsprintf",
                               "version": "1.3.0"
                             }
@@ -11126,7 +10253,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "asn1",
                           "version": "0.2.3"
                         },
@@ -11134,7 +10260,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "assert-plus",
                           "version": "1.0.0"
                         },
@@ -11142,7 +10267,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "safer-buffer",
                           "version": "2.1.2"
                         },
@@ -11150,7 +10274,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "jsbn",
                           "version": "0.1.1"
                         },
@@ -11158,7 +10281,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "tweetnacl",
                           "version": "0.14.5"
                         },
@@ -11171,7 +10293,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             }
@@ -11188,7 +10309,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             }
@@ -11205,7 +10325,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "tweetnacl",
                               "version": "0.14.5"
                             }
@@ -11222,7 +10341,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "jsbn",
                               "version": "0.1.1"
                             },
@@ -11230,7 +10348,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "safer-buffer",
                               "version": "2.1.2"
                             }
@@ -11263,7 +10380,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "arrify",
               "version": "1.0.1"
             },
@@ -11271,7 +10387,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "convert-source-map",
               "version": "1.2.0"
             },
@@ -11279,7 +10394,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "resolve-from",
               "version": "2.0.0"
             },
@@ -11287,7 +10401,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "signal-exit",
               "version": "3.0.0"
             },
@@ -11295,7 +10408,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "source-map",
               "version": "0.5.6"
             },
@@ -11308,7 +10420,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "md5-o-matic",
                   "version": "0.1.1"
                 }
@@ -11325,7 +10436,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "minimist",
                   "version": "0.0.8"
                 }
@@ -11347,7 +10457,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "md5-o-matic",
                       "version": "0.1.1"
                     }
@@ -11364,7 +10473,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -11381,7 +10489,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "graceful-fs",
                       "version": "4.1.4"
                     },
@@ -11389,7 +10496,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "imurmurhash",
                       "version": "0.1.4"
                     },
@@ -11397,7 +10503,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "slide",
                       "version": "1.1.6"
                     }
@@ -11423,7 +10528,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-utf8",
                       "version": "0.2.1"
                     }
@@ -11454,7 +10558,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-utf8",
                           "version": "0.2.1"
                         }
@@ -11484,7 +10587,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "pinkie",
                       "version": "2.0.4"
                     }
@@ -11506,7 +10608,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -11531,7 +10632,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "signal-exit",
                   "version": "2.1.2"
                 },
@@ -11544,7 +10644,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -11566,7 +10665,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pseudomap",
                           "version": "1.0.2"
                         },
@@ -11574,7 +10672,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "yallist",
                           "version": "2.0.0"
                         }
@@ -11591,7 +10688,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isexe",
                           "version": "1.1.2"
                         }
@@ -11616,7 +10712,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.1"
                 },
@@ -11624,7 +10719,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "path-is-absolute",
                   "version": "1.0.0"
                 },
@@ -11637,7 +10731,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -11654,7 +10747,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     },
@@ -11667,7 +10759,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -11693,7 +10784,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "balanced-match",
                           "version": "0.4.1"
                         },
@@ -11701,7 +10791,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "concat-map",
                           "version": "0.0.1"
                         }
@@ -11736,7 +10825,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -11758,7 +10846,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -11792,7 +10879,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "fs.realpath",
                       "version": "1.0.0"
                     },
@@ -11800,7 +10886,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.1"
                     },
@@ -11808,7 +10893,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "path-is-absolute",
                       "version": "1.0.0"
                     },
@@ -11821,7 +10905,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -11838,7 +10921,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         },
@@ -11851,7 +10933,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -11877,7 +10958,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "1.0.0"
                             },
@@ -11885,7 +10965,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -11914,7 +10993,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "commondir",
                   "version": "1.0.1"
                 },
@@ -11927,7 +11005,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -11954,7 +11031,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -11976,7 +11052,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -12009,7 +11084,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "os-homedir",
                   "version": "1.0.1"
                 },
@@ -12017,7 +11091,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "signal-exit",
                   "version": "2.1.2"
                 },
@@ -12030,7 +11103,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -12047,7 +11119,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -12064,7 +11135,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "signal-exit",
                       "version": "2.1.2"
                     },
@@ -12077,7 +11147,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isexe",
                           "version": "1.1.2"
                         }
@@ -12099,7 +11168,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pseudomap",
                               "version": "1.0.2"
                             },
@@ -12107,7 +11175,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "yallist",
                               "version": "2.0.0"
                             }
@@ -12124,7 +11191,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "isexe",
                               "version": "1.1.2"
                             }
@@ -12154,7 +11220,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "fs.realpath",
                           "version": "1.0.0"
                         },
@@ -12162,7 +11227,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.1"
                         },
@@ -12170,7 +11234,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "path-is-absolute",
                           "version": "1.0.0"
                         },
@@ -12183,7 +11246,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -12200,7 +11262,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             },
@@ -12213,7 +11274,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wrappy",
                                   "version": "1.0.2"
                                 }
@@ -12239,7 +11299,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "balanced-match",
                                   "version": "1.0.0"
                                 },
@@ -12247,7 +11306,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "concat-map",
                                   "version": "0.0.1"
                                 }
@@ -12280,7 +11338,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "camelcase",
                   "version": "3.0.0"
                 },
@@ -12288,7 +11345,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "decamelize",
                   "version": "1.2.0"
                 },
@@ -12296,7 +11352,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "require-main-filename",
                   "version": "1.0.1"
                 },
@@ -12304,7 +11359,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "set-blocking",
                   "version": "1.0.0"
                 },
@@ -12312,7 +11366,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "window-size",
                   "version": "0.2.0"
                 },
@@ -12320,7 +11373,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "y18n",
                   "version": "3.2.1"
                 },
@@ -12333,7 +11385,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.keys",
                       "version": "4.0.7"
                     },
@@ -12341,7 +11392,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.rest",
                       "version": "4.0.3"
                     }
@@ -12363,7 +11413,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "invert-kv",
                           "version": "1.0.0"
                         }
@@ -12389,7 +11438,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "number-is-nan",
                           "version": "1.0.0"
                         }
@@ -12406,7 +11454,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "number-is-nan",
                           "version": "1.0.0"
                         }
@@ -12423,7 +11470,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-regex",
                           "version": "2.1.1"
                         }
@@ -12444,7 +11490,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "camelcase",
                       "version": "2.1.1"
                     },
@@ -12457,7 +11502,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "lodash.keys",
                           "version": "4.0.7"
                         },
@@ -12465,7 +11509,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "lodash.rest",
                           "version": "4.0.3"
                         }
@@ -12491,7 +11534,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-regex",
                           "version": "2.1.1"
                         }
@@ -12513,7 +11555,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "number-is-nan",
                               "version": "1.0.0"
                             }
@@ -12530,7 +11571,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "number-is-nan",
                               "version": "1.0.0"
                             }
@@ -12547,7 +11587,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.1.1"
                             }
@@ -12578,7 +11617,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "number-is-nan",
                                   "version": "1.0.0"
                                 }
@@ -12595,7 +11633,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "number-is-nan",
                                   "version": "1.0.0"
                                 }
@@ -12612,7 +11649,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "ansi-regex",
                                   "version": "2.1.1"
                                 }
@@ -12641,7 +11677,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "object-assign",
                       "version": "4.1.0"
                     },
@@ -12649,7 +11684,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "symbol",
                       "version": "0.2.3"
                     },
@@ -12667,7 +11701,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -12689,7 +11722,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -12714,7 +11746,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "graceful-fs",
                           "version": "4.1.4"
                         },
@@ -12722,7 +11753,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pify",
                           "version": "2.3.0"
                         },
@@ -12735,7 +11765,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -12752,7 +11781,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-utf8",
                               "version": "0.2.1"
                             }
@@ -12774,7 +11802,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-arrayish",
                                   "version": "0.2.1"
                                 }
@@ -12813,7 +11840,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -12835,7 +11861,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -12865,7 +11890,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -12873,7 +11897,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -12886,7 +11909,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -12907,7 +11929,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -12915,7 +11936,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -12928,7 +11948,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -12945,7 +11964,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-utf8",
                                   "version": "0.2.1"
                                 }
@@ -12967,7 +11985,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-arrayish",
                                       "version": "0.2.1"
                                     }
@@ -12992,7 +12009,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hosted-git-info",
                               "version": "2.1.5"
                             },
@@ -13000,7 +12016,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "semver",
                               "version": "5.1.0"
                             },
@@ -13013,7 +12028,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "builtin-modules",
                                   "version": "1.1.1"
                                 }
@@ -13035,7 +12049,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -13052,7 +12065,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-exceptions",
                                       "version": "1.0.4"
                                     },
@@ -13060,7 +12072,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -13097,7 +12108,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "array-unique",
                   "version": "0.2.1"
                 },
@@ -13105,7 +12115,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "filename-regex",
                   "version": "2.0.0"
                 },
@@ -13113,7 +12122,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "is-extglob",
                   "version": "1.0.0"
                 },
@@ -13121,7 +12129,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "normalize-path",
                   "version": "2.0.1"
                 },
@@ -13134,7 +12141,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "arr-flatten",
                       "version": "1.0.1"
                     }
@@ -13151,7 +12157,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-posix-bracket",
                       "version": "0.1.1"
                     }
@@ -13168,7 +12173,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     }
@@ -13185,7 +12189,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     }
@@ -13202,7 +12205,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-buffer",
                       "version": "1.1.3"
                     }
@@ -13219,7 +12221,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extendable",
                       "version": "0.1.1"
                     },
@@ -13232,7 +12233,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "for-in",
                           "version": "0.1.5"
                         }
@@ -13253,7 +12253,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-primitive",
                       "version": "2.0.0"
                     },
@@ -13266,7 +12265,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-primitive",
                           "version": "2.0.0"
                         }
@@ -13287,7 +12285,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-dotfile",
                       "version": "1.0.2"
                     },
@@ -13295,7 +12292,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     },
@@ -13308,7 +12304,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -13330,7 +12325,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-extglob",
                               "version": "1.0.0"
                             }
@@ -13352,7 +12346,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-extglob",
                                   "version": "1.0.0"
                                 }
@@ -13381,7 +12374,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "preserve",
                       "version": "0.2.0"
                     },
@@ -13389,7 +12381,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "repeat-element",
                       "version": "1.1.2"
                     },
@@ -13407,7 +12398,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "repeat-element",
                               "version": "1.1.2"
                             },
@@ -13415,7 +12405,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "repeat-string",
                               "version": "1.5.4"
                             },
@@ -13428,7 +12417,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "isarray",
                                   "version": "1.0.0"
                                 }
@@ -13450,7 +12438,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-buffer",
                                       "version": "1.1.3"
                                     }
@@ -13476,7 +12463,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-buffer",
                                       "version": "1.1.3"
                                     }
@@ -13498,7 +12484,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -13539,7 +12524,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "abbrev",
                   "version": "1.0.7"
                 },
@@ -13547,7 +12531,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "async",
                   "version": "1.5.2"
                 },
@@ -13555,7 +12538,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "2.7.2"
                 },
@@ -13563,7 +12545,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "resolve",
                   "version": "1.1.7"
                 },
@@ -13571,7 +12552,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wordwrap",
                   "version": "1.0.0"
                 },
@@ -13584,7 +12564,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -13601,7 +12580,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "abbrev",
                       "version": "1.0.7"
                     }
@@ -13618,7 +12596,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -13635,7 +12612,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "has-flag",
                       "version": "1.0.0"
                     }
@@ -13652,7 +12628,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -13669,7 +12644,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "2.7.3"
                     },
@@ -13682,7 +12656,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "sprintf-js",
                           "version": "1.0.3"
                         }
@@ -13703,7 +12676,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "2.7.2"
                     },
@@ -13711,7 +12683,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "estraverse",
                       "version": "1.9.3"
                     },
@@ -13719,7 +12690,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esutils",
                       "version": "2.0.2"
                     },
@@ -13732,7 +12702,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "amdefine",
                           "version": "1.0.0"
                         }
@@ -13749,7 +12718,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "deep-is",
                           "version": "0.1.3"
                         },
@@ -13757,7 +12725,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "fast-levenshtein",
                           "version": "1.1.3"
                         },
@@ -13765,7 +12732,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "prelude-ls",
                           "version": "1.1.2"
                         },
@@ -13773,7 +12739,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wordwrap",
                           "version": "1.0.0"
                         },
@@ -13786,7 +12751,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "prelude-ls",
                               "version": "1.1.2"
                             }
@@ -13803,7 +12767,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "prelude-ls",
                               "version": "1.1.2"
                             },
@@ -13816,7 +12779,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "prelude-ls",
                                   "version": "1.1.2"
                                 }
@@ -13855,7 +12817,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "0.4.1"
                             },
@@ -13863,7 +12824,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -13884,7 +12844,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.1"
                         },
@@ -13892,7 +12851,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "path-is-absolute",
                           "version": "1.0.0"
                         },
@@ -13905,7 +12863,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -13922,7 +12879,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             },
@@ -13935,7 +12891,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wrappy",
                                   "version": "1.0.2"
                                 }
@@ -13961,7 +12916,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "balanced-match",
                                   "version": "0.4.1"
                                 },
@@ -13969,7 +12923,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "concat-map",
                                   "version": "0.0.1"
                                 }
@@ -13998,7 +12951,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "async",
                       "version": "1.5.2"
                     },
@@ -14011,7 +12963,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "minimist",
                           "version": "0.0.10"
                         },
@@ -14019,7 +12970,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wordwrap",
                           "version": "0.0.3"
                         }
@@ -14036,7 +12986,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "amdefine",
                           "version": "1.0.0"
                         }
@@ -14053,7 +13002,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "async",
                           "version": "0.2.10"
                         },
@@ -14061,7 +13009,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "source-map",
                           "version": "0.5.6"
                         },
@@ -14069,7 +13016,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "uglify-to-browserify",
                           "version": "1.0.2"
                         },
@@ -14082,7 +13028,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "camelcase",
                               "version": "1.2.1"
                             },
@@ -14090,7 +13035,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "decamelize",
                               "version": "1.2.0"
                             },
@@ -14098,7 +13042,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "window-size",
                               "version": "0.1.0"
                             },
@@ -14111,7 +13054,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wordwrap",
                                   "version": "0.0.2"
                                 },
@@ -14124,7 +13066,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "lazy-cache",
                                       "version": "1.0.4"
                                     },
@@ -14137,7 +13078,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "longest",
                                           "version": "1.0.1"
                                         },
@@ -14145,7 +13085,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "repeat-string",
                                           "version": "1.5.4"
                                         },
@@ -14158,7 +13097,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }
@@ -14188,7 +13126,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "longest",
                                           "version": "1.0.1"
                                         },
@@ -14196,7 +13133,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "repeat-string",
                                           "version": "1.5.4"
                                         },
@@ -14209,7 +13145,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }
@@ -14254,7 +13189,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "arrify",
                   "version": "1.0.1"
                 },
@@ -14262,7 +13196,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "require-main-filename",
                   "version": "1.0.1"
                 },
@@ -14275,7 +13208,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.keys",
                       "version": "4.0.7"
                     },
@@ -14283,7 +13215,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.rest",
                       "version": "4.0.3"
                     }
@@ -14310,7 +13241,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -14332,7 +13262,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -14362,7 +13291,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -14370,7 +13298,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -14383,7 +13310,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -14404,7 +13330,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -14412,7 +13337,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -14425,7 +13349,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -14442,7 +13365,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-utf8",
                                   "version": "0.2.1"
                                 }
@@ -14464,7 +13386,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-arrayish",
                                       "version": "0.2.1"
                                     }
@@ -14489,7 +13410,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hosted-git-info",
                               "version": "2.1.5"
                             },
@@ -14497,7 +13417,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "semver",
                               "version": "5.1.0"
                             },
@@ -14510,7 +13429,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "builtin-modules",
                                   "version": "1.1.1"
                                 }
@@ -14532,7 +13450,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -14549,7 +13466,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-exceptions",
                                       "version": "1.0.4"
                                     },
@@ -14557,7 +13473,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -14590,7 +13505,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "array-unique",
                       "version": "0.2.1"
                     },
@@ -14598,7 +13512,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "filename-regex",
                       "version": "2.0.0"
                     },
@@ -14606,7 +13519,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     },
@@ -14614,7 +13526,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "normalize-path",
                       "version": "2.0.1"
                     },
@@ -14627,7 +13538,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "arr-flatten",
                           "version": "1.0.1"
                         }
@@ -14644,7 +13554,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-posix-bracket",
                           "version": "0.1.1"
                         }
@@ -14661,7 +13570,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -14678,7 +13586,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -14695,7 +13602,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-buffer",
                           "version": "1.1.3"
                         }
@@ -14712,7 +13618,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extendable",
                           "version": "0.1.1"
                         },
@@ -14725,7 +13630,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "for-in",
                               "version": "0.1.5"
                             }
@@ -14746,7 +13650,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-primitive",
                           "version": "2.0.0"
                         },
@@ -14759,7 +13662,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-primitive",
                               "version": "2.0.0"
                             }
@@ -14780,7 +13682,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-dotfile",
                           "version": "1.0.2"
                         },
@@ -14788,7 +13689,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         },
@@ -14801,7 +13701,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-extglob",
                               "version": "1.0.0"
                             }
@@ -14823,7 +13722,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-extglob",
                                   "version": "1.0.0"
                                 }
@@ -14845,7 +13743,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-extglob",
                                       "version": "1.0.0"
                                     }
@@ -14874,7 +13771,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "preserve",
                           "version": "0.2.0"
                         },
@@ -14882,7 +13778,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "repeat-element",
                           "version": "1.1.2"
                         },
@@ -14900,7 +13795,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "repeat-element",
                                   "version": "1.1.2"
                                 },
@@ -14908,7 +13802,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "repeat-string",
                                   "version": "1.5.4"
                                 },
@@ -14921,7 +13814,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "isarray",
                                       "version": "1.0.0"
                                     }
@@ -14943,7 +13835,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -14969,7 +13860,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -14991,7 +13881,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
@@ -4,7 +4,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "dustjs-linkedin",
       "version": "2.5.0"
     },
@@ -12,7 +11,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "dustjs-helpers",
       "version": "1.5.0"
     },
@@ -20,7 +18,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "ejs",
       "version": "1.0.0"
     },
@@ -28,7 +25,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "jquery",
       "version": "2.2.4"
     },
@@ -36,7 +32,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "marked",
       "version": "0.3.5"
     },
@@ -44,7 +39,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "moment",
       "version": "2.15.1"
     },
@@ -52,7 +46,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "ms",
       "version": "0.7.3"
     },
@@ -60,7 +53,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "optional",
       "version": "0.1.4"
     },
@@ -68,7 +60,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "stream-buffers",
       "version": "3.0.2"
     },
@@ -76,7 +67,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "adm-zip",
       "version": "0.4.7"
     },
@@ -84,7 +74,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "file-type",
       "version": "8.1.0"
     },
@@ -97,7 +86,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ejs",
           "version": "0.8.8"
         }
@@ -114,7 +102,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ms",
           "version": "0.6.2"
         }
@@ -131,7 +118,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie",
           "version": "0.1.2"
         },
@@ -139,7 +125,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie-signature",
           "version": "1.0.5"
         }
@@ -156,7 +141,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bluebird",
           "version": "3.5.1"
         }
@@ -173,7 +157,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "vary",
           "version": "1.1.2"
         },
@@ -181,7 +164,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "methods",
           "version": "1.1.2"
         },
@@ -189,7 +171,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "parseurl",
           "version": "1.3.2"
         },
@@ -202,7 +183,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "2.0.0"
             }
@@ -223,7 +203,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.1.2"
         },
@@ -231,7 +210,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "on-headers",
           "version": "1.0.1"
         },
@@ -244,7 +222,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "2.0.0"
             }
@@ -261,7 +238,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.1.1"
             }
@@ -278,7 +254,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             }
@@ -299,7 +274,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "inherits",
           "version": "1.0.2"
         },
@@ -307,7 +281,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "once",
           "version": "1.1.1"
         },
@@ -315,7 +288,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ini",
           "version": "1.1.0"
         },
@@ -323,7 +295,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mkdirp",
           "version": "0.3.5"
         },
@@ -331,7 +302,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "osenv",
           "version": "0.0.3"
         },
@@ -339,7 +309,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "semver",
           "version": "1.1.4"
         },
@@ -352,7 +321,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ini",
               "version": "1.3.5"
             },
@@ -360,7 +328,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "proto-list",
               "version": "1.2.4"
             }
@@ -377,7 +344,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "abbrev",
               "version": "1.1.1"
             }
@@ -398,7 +364,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "graceful-fs",
           "version": "1.2.3"
         },
@@ -406,7 +371,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mime",
           "version": "1.2.11"
         },
@@ -414,7 +378,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "negotiator",
           "version": "0.2.8"
         },
@@ -422,7 +385,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "fd",
           "version": "0.0.3"
         },
@@ -435,7 +397,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "lru-cache",
               "version": "2.3.1"
             }
@@ -456,7 +417,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bytes",
           "version": "1.0.0"
         },
@@ -464,7 +424,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.0.1"
         },
@@ -472,7 +431,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "iconv-lite",
           "version": "0.4.4"
         },
@@ -480,7 +438,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "media-typer",
           "version": "0.3.0"
         },
@@ -488,7 +445,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "qs",
           "version": "2.2.4"
         },
@@ -501,7 +457,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.0.5"
             }
@@ -518,7 +473,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "bytes",
               "version": "1.0.0"
             },
@@ -526,7 +480,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "iconv-lite",
               "version": "0.4.4"
             }
@@ -543,7 +496,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "media-typer",
               "version": "0.3.0"
             },
@@ -556,7 +508,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.12.0"
                 }
@@ -581,7 +532,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ports",
           "version": "1.1.0"
         },
@@ -589,7 +539,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "underscore",
           "version": "1.8.3"
         },
@@ -602,7 +551,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "esprima",
               "version": "4.0.1"
             },
@@ -615,7 +563,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "sprintf-js",
                   "version": "1.0.3"
                 }
@@ -640,7 +587,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "escape-html",
           "version": "1.0.1"
         },
@@ -653,7 +599,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "negotiator",
               "version": "0.4.9"
             },
@@ -666,7 +611,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.12.0"
                 }
@@ -691,7 +635,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie-signature",
           "version": "1.0.6"
         },
@@ -699,7 +642,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "qs",
           "version": "2.4.2"
         },
@@ -707,7 +649,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "content-disposition",
           "version": "0.5.0"
         },
@@ -715,7 +656,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "content-type",
           "version": "1.0.4"
         },
@@ -723,7 +663,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "cookie",
           "version": "0.1.2"
         },
@@ -731,7 +670,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "depd",
           "version": "1.0.1"
         },
@@ -739,7 +677,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "escape-html",
           "version": "1.0.1"
         },
@@ -747,7 +684,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "fresh",
           "version": "0.2.4"
         },
@@ -755,7 +691,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "merge-descriptors",
           "version": "1.0.0"
         },
@@ -763,7 +698,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "methods",
           "version": "1.1.2"
         },
@@ -771,7 +705,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "parseurl",
           "version": "1.3.2"
         },
@@ -779,7 +712,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "path-to-regexp",
           "version": "0.1.3"
         },
@@ -787,7 +719,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "range-parser",
           "version": "1.0.3"
         },
@@ -795,7 +726,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "utils-merge",
           "version": "1.0.0"
         },
@@ -803,7 +733,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "vary",
           "version": "1.0.1"
         },
@@ -816,7 +745,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "0.7.1"
             }
@@ -833,7 +761,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ee-first",
               "version": "1.1.0"
             }
@@ -850,7 +777,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "crc",
               "version": "3.2.1"
             }
@@ -867,7 +793,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "forwarded",
               "version": "0.1.2"
             },
@@ -875,7 +800,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ipaddr.js",
               "version": "1.0.5"
             }
@@ -892,7 +816,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "negotiator",
               "version": "0.5.3"
             },
@@ -905,7 +828,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.35.0"
                 }
@@ -926,7 +848,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -939,7 +860,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -956,7 +876,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ee-first",
                   "version": "1.1.0"
                 }
@@ -977,7 +896,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "media-typer",
               "version": "0.3.0"
             },
@@ -990,7 +908,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-db",
                   "version": "1.35.0"
                 }
@@ -1011,7 +928,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "0.7.1"
             },
@@ -1019,7 +935,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "depd",
               "version": "1.0.1"
             },
@@ -1027,7 +942,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "destroy",
               "version": "1.0.3"
             },
@@ -1035,7 +949,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -1043,7 +956,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "fresh",
               "version": "0.2.4"
             },
@@ -1051,7 +963,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "mime",
               "version": "1.3.4"
             },
@@ -1059,7 +970,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "range-parser",
               "version": "1.0.3"
             },
@@ -1072,7 +982,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -1089,7 +998,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ee-first",
                   "version": "1.1.0"
                 }
@@ -1106,7 +1014,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "crc",
                   "version": "3.2.1"
                 }
@@ -1127,7 +1034,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-html",
               "version": "1.0.1"
             },
@@ -1135,7 +1041,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "parseurl",
               "version": "1.3.2"
             },
@@ -1143,7 +1048,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "utils-merge",
               "version": "1.0.0"
             },
@@ -1156,7 +1060,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 },
@@ -1164,7 +1067,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "depd",
                   "version": "1.0.1"
                 },
@@ -1172,7 +1074,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "destroy",
                   "version": "1.0.3"
                 },
@@ -1180,7 +1081,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "escape-html",
                   "version": "1.0.1"
                 },
@@ -1188,7 +1088,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "fresh",
                   "version": "0.2.4"
                 },
@@ -1196,7 +1095,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime",
                   "version": "1.3.4"
                 },
@@ -1204,7 +1102,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "range-parser",
                   "version": "1.0.3"
                 },
@@ -1217,7 +1114,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ms",
                       "version": "0.7.1"
                     }
@@ -1234,7 +1130,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ee-first",
                       "version": "1.1.0"
                     }
@@ -1251,7 +1146,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "crc",
                       "version": "3.2.1"
                     }
@@ -1280,7 +1174,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ms",
           "version": "0.7.1"
         },
@@ -1288,7 +1181,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "async",
           "version": "0.9.0"
         },
@@ -1296,7 +1188,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bson",
           "version": "0.4.23"
         },
@@ -1304,7 +1195,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "hooks-fixed",
           "version": "1.1.0"
         },
@@ -1312,7 +1202,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "kareem",
           "version": "1.0.1"
         },
@@ -1320,7 +1209,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mpath",
           "version": "0.1.1"
         },
@@ -1328,7 +1216,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "mpromise",
           "version": "0.5.4"
         },
@@ -1336,7 +1223,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "muri",
           "version": "1.0.0"
         },
@@ -1344,7 +1230,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "regexp-clone",
           "version": "0.0.1"
         },
@@ -1352,7 +1237,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "sliced",
           "version": "0.0.5"
         },
@@ -1365,7 +1249,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "bluebird",
               "version": "2.9.26"
             },
@@ -1373,7 +1256,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "regexp-clone",
               "version": "0.0.1"
             },
@@ -1381,7 +1263,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "sliced",
               "version": "0.0.5"
             },
@@ -1394,7 +1275,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -1415,7 +1295,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "es6-promise",
               "version": "2.1.1"
             },
@@ -1428,7 +1307,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -1436,7 +1314,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -1444,7 +1321,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "0.0.1"
                 },
@@ -1452,7 +1328,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "string_decoder",
                   "version": "0.10.31"
                 }
@@ -1469,7 +1344,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "bson",
                   "version": "0.4.23"
                 },
@@ -1482,7 +1356,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "nan",
                       "version": "2.10.0"
                     }
@@ -1511,7 +1384,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "streamifier",
           "version": "0.1.1"
         },
@@ -1534,7 +1406,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -1542,7 +1413,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -1550,7 +1420,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "0.0.1"
                     },
@@ -1558,7 +1427,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "string_decoder",
                       "version": "0.10.31"
                     }
@@ -1575,7 +1443,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "streamsearch",
                       "version": "0.1.2"
                     },
@@ -1588,7 +1455,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "core-util-is",
                           "version": "1.0.2"
                         },
@@ -1596,7 +1462,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -1604,7 +1469,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isarray",
                           "version": "0.0.1"
                         },
@@ -1612,7 +1476,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "string_decoder",
                           "version": "0.10.31"
                         }
@@ -1641,7 +1504,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "graceful-fs",
               "version": "4.1.11"
             },
@@ -1654,7 +1516,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "graceful-fs",
                   "version": "4.1.11"
                 }
@@ -1676,7 +1537,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "fs.realpath",
                       "version": "1.0.0"
                     },
@@ -1684,7 +1544,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -1692,7 +1551,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "path-is-absolute",
                       "version": "1.0.1"
                     },
@@ -1705,7 +1563,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -1722,7 +1579,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         },
@@ -1735,7 +1591,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -1761,7 +1616,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "1.0.0"
                             },
@@ -1769,7 +1623,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -1806,7 +1659,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "defined",
           "version": "1.0.0"
         },
@@ -1814,7 +1666,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "cached-path-relative",
           "version": "1.0.1"
         },
@@ -1822,7 +1673,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "constants-browserify",
           "version": "1.0.0"
         },
@@ -1830,7 +1680,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "domain-browser",
           "version": "1.1.7"
         },
@@ -1838,7 +1687,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "events",
           "version": "1.1.1"
         },
@@ -1846,7 +1694,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "htmlescape",
           "version": "1.1.1"
         },
@@ -1854,7 +1701,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "https-browserify",
           "version": "0.0.1"
         },
@@ -1862,7 +1708,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "inherits",
           "version": "2.0.3"
         },
@@ -1870,7 +1715,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "os-browserify",
           "version": "0.1.2"
         },
@@ -1878,7 +1722,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "path-browserify",
           "version": "0.0.1"
         },
@@ -1886,7 +1729,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "process",
           "version": "0.11.10"
         },
@@ -1894,7 +1736,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "punycode",
           "version": "1.4.1"
         },
@@ -1902,7 +1743,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "querystring-es3",
           "version": "0.2.1"
         },
@@ -1910,7 +1750,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "string_decoder",
           "version": "0.10.31"
         },
@@ -1918,7 +1757,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "tty-browserify",
           "version": "0.0.1"
         },
@@ -1926,7 +1764,6 @@
           "labels": {
             "scope": "dev"
           },
-          "dependencies": {},
           "name": "xtend",
           "version": "4.0.1"
         },
@@ -1939,7 +1776,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "resolve",
               "version": "1.1.7"
             }
@@ -1956,7 +1792,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "jsonparse",
               "version": "1.3.1"
             },
@@ -1964,7 +1799,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "through",
               "version": "2.3.8"
             }
@@ -1981,7 +1815,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "pako",
               "version": "0.2.9"
             }
@@ -1998,7 +1831,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "1.0.0"
             },
@@ -2006,7 +1838,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "base64-js",
               "version": "1.3.0"
             },
@@ -2014,7 +1845,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "ieee754",
               "version": "1.1.12"
             }
@@ -2031,7 +1861,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "date-now",
               "version": "0.1.4"
             }
@@ -2048,7 +1877,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "function-bind",
               "version": "1.1.1"
             }
@@ -2065,7 +1893,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "path-platform",
               "version": "0.11.15"
             }
@@ -2082,7 +1909,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "path-parse",
               "version": "1.0.5"
             }
@@ -2099,7 +1925,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "array-filter",
               "version": "0.0.1"
             },
@@ -2107,7 +1932,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "array-map",
               "version": "0.0.0"
             },
@@ -2115,7 +1939,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "array-reduce",
               "version": "0.0.0"
             },
@@ -2123,7 +1946,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "jsonify",
               "version": "0.0.0"
             }
@@ -2140,7 +1962,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "minimist",
               "version": "1.2.0"
             }
@@ -2157,7 +1978,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "process",
               "version": "0.11.10"
             }
@@ -2174,7 +1994,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "punycode",
               "version": "1.3.2"
             },
@@ -2182,7 +2001,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "querystring",
               "version": "0.2.0"
             }
@@ -2199,7 +2017,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             }
@@ -2216,7 +2033,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "indexof",
               "version": "0.0.1"
             }
@@ -2238,7 +2054,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.1"
                 }
@@ -2259,7 +2074,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2267,7 +2081,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "typedarray",
               "version": "0.0.6"
             },
@@ -2280,7 +2093,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2288,7 +2100,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "1.0.7"
                 },
@@ -2296,7 +2107,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2304,7 +2114,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2312,7 +2121,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "string_decoder",
                   "version": "0.10.31"
                 },
@@ -2320,7 +2128,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 }
@@ -2341,7 +2148,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "1.0.0"
             },
@@ -2349,7 +2155,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "core-util-is",
               "version": "1.0.2"
             },
@@ -2357,7 +2162,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2365,7 +2169,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "process-nextick-args",
               "version": "2.0.0"
             },
@@ -2373,7 +2176,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             },
@@ -2381,7 +2183,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "util-deprecate",
               "version": "1.0.2"
             },
@@ -2394,7 +2195,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -2420,7 +2220,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonify",
                   "version": "0.0.0"
                 }
@@ -2437,7 +2236,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2445,7 +2243,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -2471,7 +2268,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2479,7 +2275,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2487,7 +2282,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2495,7 +2289,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2503,7 +2296,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2511,7 +2303,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2524,7 +2315,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2549,7 +2339,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "fs.realpath",
               "version": "1.0.0"
             },
@@ -2557,7 +2346,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2565,7 +2353,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "path-is-absolute",
               "version": "1.0.1"
             },
@@ -2578,7 +2365,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 }
@@ -2595,7 +2381,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 },
@@ -2608,7 +2393,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -2634,7 +2418,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "balanced-match",
                       "version": "1.0.0"
                     },
@@ -2642,7 +2425,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "concat-map",
                       "version": "0.0.1"
                     }
@@ -2672,7 +2454,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2680,7 +2461,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2688,7 +2468,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2696,7 +2475,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2704,7 +2482,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2712,7 +2489,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2725,7 +2501,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2750,7 +2525,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2763,7 +2537,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2771,7 +2544,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2779,7 +2551,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2787,7 +2558,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2795,7 +2565,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2803,7 +2572,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2816,7 +2584,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2841,7 +2608,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "builtin-status-codes",
               "version": "3.0.0"
             },
@@ -2849,7 +2615,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -2857,7 +2622,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "to-arraybuffer",
               "version": "1.0.1"
             },
@@ -2865,7 +2629,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "xtend",
               "version": "4.0.1"
             },
@@ -2878,7 +2641,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -2886,7 +2648,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -2894,7 +2655,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -2902,7 +2662,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -2910,7 +2669,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -2918,7 +2676,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -2931,7 +2688,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -2961,7 +2717,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "acorn",
                   "version": "5.7.1"
                 },
@@ -2969,7 +2724,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -2982,7 +2736,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "acorn",
                       "version": "5.7.1"
                     }
@@ -3007,7 +2760,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "xtend",
               "version": "4.0.1"
             },
@@ -3020,7 +2772,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -3028,7 +2779,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -3036,7 +2786,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -3044,7 +2793,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -3052,7 +2800,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -3060,7 +2807,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -3073,7 +2819,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -3098,7 +2843,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "defined",
               "version": "1.0.0"
             },
@@ -3106,7 +2850,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             },
@@ -3114,7 +2857,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "umd",
               "version": "3.0.3"
             },
@@ -3127,7 +2869,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonparse",
                   "version": "1.3.1"
                 },
@@ -3135,7 +2876,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "through",
                   "version": "2.3.8"
                 }
@@ -3152,7 +2892,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "convert-source-map",
                   "version": "1.1.3"
                 },
@@ -3160,7 +2899,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "lodash.memoize",
                   "version": "3.0.4"
                 },
@@ -3168,7 +2906,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "source-map",
                   "version": "0.5.7"
                 },
@@ -3181,7 +2918,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "source-map",
                       "version": "0.5.7"
                     }
@@ -3202,7 +2938,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3215,7 +2950,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3223,7 +2957,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3231,7 +2964,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3239,7 +2971,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3247,7 +2978,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3255,7 +2985,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3268,7 +2997,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3302,7 +3030,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonparse",
                   "version": "1.3.1"
                 },
@@ -3310,7 +3037,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "through",
                   "version": "2.3.8"
                 }
@@ -3327,7 +3053,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "minimist",
                   "version": "1.2.0"
                 }
@@ -3349,7 +3074,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "jsonify",
                       "version": "0.0.0"
                     }
@@ -3366,7 +3090,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3374,7 +3097,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -3395,7 +3117,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3408,7 +3129,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3416,7 +3136,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3424,7 +3143,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3432,7 +3150,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3440,7 +3157,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3448,7 +3164,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3461,7 +3176,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3490,7 +3204,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "is-buffer",
               "version": "1.1.6"
             },
@@ -3498,7 +3211,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "path-is-absolute",
               "version": "1.0.1"
             },
@@ -3506,7 +3218,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "process",
               "version": "0.11.10"
             },
@@ -3514,7 +3225,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "xtend",
               "version": "4.0.1"
             },
@@ -3527,7 +3237,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonparse",
                   "version": "1.3.1"
                 },
@@ -3535,7 +3244,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "through",
                   "version": "2.3.8"
                 }
@@ -3552,7 +3260,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "acorn",
                   "version": "5.7.1"
                 },
@@ -3560,7 +3267,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3573,7 +3279,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "acorn",
                       "version": "5.7.1"
                     }
@@ -3594,7 +3299,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "convert-source-map",
                   "version": "1.1.3"
                 },
@@ -3602,7 +3306,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "lodash.memoize",
                   "version": "3.0.4"
                 },
@@ -3610,7 +3313,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "source-map",
                   "version": "0.5.7"
                 },
@@ -3623,7 +3325,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "source-map",
                       "version": "0.5.7"
                     }
@@ -3644,7 +3345,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "buffer-from",
                   "version": "1.1.0"
                 },
@@ -3652,7 +3352,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -3660,7 +3359,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "typedarray",
                   "version": "0.0.6"
                 },
@@ -3673,7 +3371,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3681,7 +3378,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3689,7 +3385,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3697,7 +3392,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3705,7 +3399,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3713,7 +3406,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3726,7 +3418,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3751,7 +3442,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3764,7 +3454,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3772,7 +3461,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3780,7 +3468,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3788,7 +3475,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3796,7 +3482,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3804,7 +3489,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -3817,7 +3501,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -3842,7 +3525,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "get-assigned-identifiers",
                   "version": "1.2.0"
                 },
@@ -3850,7 +3532,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "simple-concat",
                   "version": "1.0.0"
                 },
@@ -3858,7 +3539,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -3871,7 +3551,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "acorn",
                       "version": "5.7.1"
                     },
@@ -3879,7 +3558,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "xtend",
                       "version": "4.0.1"
                     },
@@ -3892,7 +3570,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "acorn",
                           "version": "5.7.1"
                         }
@@ -3921,7 +3598,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "2.0.4"
             },
@@ -3929,7 +3605,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -3942,7 +3617,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -3955,7 +3629,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -3963,7 +3636,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -3971,7 +3643,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -3979,7 +3650,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -3987,7 +3657,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -3995,7 +3664,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -4008,7 +3676,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4037,7 +3704,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "defined",
               "version": "1.0.0"
             },
@@ -4045,7 +3711,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "cached-path-relative",
               "version": "1.0.1"
             },
@@ -4053,7 +3718,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -4061,7 +3725,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "xtend",
               "version": "4.0.1"
             },
@@ -4074,7 +3737,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "resolve",
                   "version": "1.1.7"
                 }
@@ -4091,7 +3753,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "jsonparse",
                   "version": "1.3.1"
                 },
@@ -4099,7 +3760,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "through",
                   "version": "2.3.8"
                 }
@@ -4116,7 +3776,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "defined",
                   "version": "1.0.0"
                 },
@@ -4124,7 +3783,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "acorn",
                   "version": "5.7.1"
                 }
@@ -4141,7 +3799,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "path-platform",
                   "version": "0.11.15"
                 }
@@ -4158,7 +3815,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "path-parse",
                   "version": "1.0.5"
                 }
@@ -4175,7 +3831,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "minimist",
                   "version": "1.2.0"
                 }
@@ -4192,7 +3847,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -4200,7 +3854,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "typedarray",
                   "version": "0.0.6"
                 },
@@ -4213,7 +3866,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -4221,7 +3873,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "1.0.7"
                     },
@@ -4229,7 +3880,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -4237,7 +3887,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4245,7 +3894,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "string_decoder",
                       "version": "0.10.31"
                     },
@@ -4253,7 +3901,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     }
@@ -4274,7 +3921,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -4282,7 +3928,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -4290,7 +3935,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -4298,7 +3942,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -4306,7 +3949,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -4314,7 +3956,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -4327,7 +3968,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4353,7 +3993,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -4361,7 +4000,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -4369,7 +4007,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4377,7 +4014,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -4385,7 +4021,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -4393,7 +4028,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -4406,7 +4040,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4431,7 +4064,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "xtend",
                   "version": "4.0.1"
                 },
@@ -4444,7 +4076,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -4452,7 +4083,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -4460,7 +4090,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4468,7 +4097,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -4476,7 +4104,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -4484,7 +4111,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -4497,7 +4123,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4527,7 +4152,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -4535,7 +4159,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -4543,7 +4166,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4551,7 +4173,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -4559,7 +4180,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -4567,7 +4187,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -4580,7 +4199,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4606,7 +4224,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "isarray",
                           "version": "1.0.0"
                         },
@@ -4614,7 +4231,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "core-util-is",
                           "version": "1.0.2"
                         },
@@ -4622,7 +4238,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -4630,7 +4245,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "process-nextick-args",
                           "version": "2.0.0"
                         },
@@ -4638,7 +4252,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -4646,7 +4259,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "util-deprecate",
                           "version": "1.0.2"
                         },
@@ -4659,7 +4271,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -4692,7 +4303,6 @@
               "labels": {
                 "scope": "dev"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -4705,7 +4315,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -4722,7 +4331,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "bn.js",
                   "version": "4.11.8"
                 },
@@ -4735,7 +4343,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -4743,7 +4350,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "brorand",
                       "version": "1.1.0"
                     }
@@ -4760,7 +4366,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4781,7 +4386,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -4794,7 +4398,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4815,7 +4418,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -4828,7 +4430,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4836,7 +4437,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4853,7 +4453,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4861,7 +4460,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -4878,7 +4476,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4891,7 +4488,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -4899,7 +4495,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4920,7 +4515,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -4933,7 +4527,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -4941,7 +4534,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -4966,7 +4558,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "bn.js",
                   "version": "4.11.8"
                 },
@@ -4979,7 +4570,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -4987,7 +4577,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "brorand",
                       "version": "1.1.0"
                     },
@@ -4995,7 +4584,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5003,7 +4591,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "minimalistic-assert",
                       "version": "1.0.1"
                     },
@@ -5011,7 +4598,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "minimalistic-crypto-utils",
                       "version": "1.0.1"
                     },
@@ -5024,7 +4610,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5032,7 +4617,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -5049,7 +4633,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         },
@@ -5057,7 +4640,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-crypto-utils",
                           "version": "1.0.1"
                         },
@@ -5070,7 +4652,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5078,7 +4659,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "minimalistic-assert",
                               "version": "1.0.1"
                             }
@@ -5107,7 +4687,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -5115,7 +4694,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -5128,7 +4706,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5136,7 +4713,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -5153,7 +4729,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5161,7 +4736,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -5178,7 +4752,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5191,7 +4764,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5199,7 +4771,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5220,7 +4791,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5233,7 +4803,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5241,7 +4810,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5258,7 +4826,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5266,7 +4833,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5283,7 +4849,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5296,7 +4861,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5304,7 +4868,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5325,7 +4888,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5338,7 +4900,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5346,7 +4907,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5380,7 +4940,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.2"
                     },
@@ -5388,7 +4947,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5401,7 +4959,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5409,7 +4966,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5426,7 +4982,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5434,7 +4989,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -5455,7 +5009,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -5468,7 +5021,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5481,7 +5033,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5489,7 +5040,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5514,7 +5064,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "buffer-xor",
                       "version": "1.0.3"
                     },
@@ -5522,7 +5071,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5530,7 +5078,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -5543,7 +5090,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5551,7 +5097,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5568,7 +5113,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5581,7 +5125,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5589,7 +5132,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5606,7 +5148,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5614,7 +5155,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5631,7 +5171,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5644,7 +5183,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -5652,7 +5190,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -5673,7 +5210,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5686,7 +5222,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -5694,7 +5229,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -5719,7 +5253,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -5732,7 +5265,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5745,7 +5277,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -5753,7 +5284,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -5786,7 +5316,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -5799,7 +5328,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5807,7 +5335,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -5824,7 +5351,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5837,7 +5363,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5845,7 +5370,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5866,7 +5390,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -5879,7 +5402,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5887,7 +5409,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5904,7 +5425,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5912,7 +5432,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -5929,7 +5448,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5942,7 +5460,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5950,7 +5467,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -5971,7 +5487,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -5984,7 +5499,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -5992,7 +5506,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6017,7 +5530,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -6025,7 +5537,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -6038,7 +5549,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6046,7 +5556,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6063,7 +5572,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6071,7 +5579,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6088,7 +5595,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6101,7 +5607,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6109,7 +5614,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6130,7 +5634,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6143,7 +5646,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6151,7 +5653,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6168,7 +5669,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6176,7 +5676,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6193,7 +5692,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6206,7 +5704,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -6214,7 +5711,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -6235,7 +5731,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6248,7 +5743,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -6256,7 +5750,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -6289,7 +5782,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "bn.js",
                   "version": "4.11.8"
                 },
@@ -6297,7 +5789,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -6310,7 +5801,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -6323,7 +5813,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6344,7 +5833,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -6357,7 +5845,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6365,7 +5852,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6382,7 +5868,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6390,7 +5875,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6407,7 +5891,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6420,7 +5903,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6428,7 +5910,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6449,7 +5930,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6462,7 +5942,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6470,7 +5949,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6495,7 +5973,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -6503,7 +5980,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "brorand",
                       "version": "1.1.0"
                     },
@@ -6511,7 +5987,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -6519,7 +5994,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "minimalistic-assert",
                       "version": "1.0.1"
                     },
@@ -6527,7 +6001,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "minimalistic-crypto-utils",
                       "version": "1.0.1"
                     },
@@ -6540,7 +6013,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6548,7 +6020,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -6565,7 +6036,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         },
@@ -6573,7 +6043,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-crypto-utils",
                           "version": "1.0.1"
                         },
@@ -6586,7 +6055,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6594,7 +6062,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "minimalistic-assert",
                               "version": "1.0.1"
                             }
@@ -6619,7 +6086,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -6627,7 +6093,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -6640,7 +6105,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6648,7 +6112,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6665,7 +6128,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6673,7 +6135,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -6690,7 +6151,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6703,7 +6163,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6711,7 +6170,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6732,7 +6190,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6745,7 +6202,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6753,7 +6209,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6770,7 +6225,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6778,7 +6232,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6795,7 +6248,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6808,7 +6260,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -6816,7 +6267,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -6837,7 +6287,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6850,7 +6299,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -6858,7 +6306,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -6892,7 +6339,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "bn.js",
                           "version": "4.11.8"
                         },
@@ -6900,7 +6346,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6908,7 +6353,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -6925,7 +6369,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -6938,7 +6381,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6946,7 +6388,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6963,7 +6404,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -6971,7 +6411,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -6988,7 +6427,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7001,7 +6439,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7009,7 +6446,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7030,7 +6466,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7043,7 +6478,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7051,7 +6485,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7076,7 +6509,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -7089,7 +6521,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7102,7 +6533,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7110,7 +6540,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7135,7 +6564,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "buffer-xor",
                           "version": "1.0.3"
                         },
@@ -7143,7 +6571,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -7151,7 +6578,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -7164,7 +6590,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7172,7 +6597,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -7189,7 +6613,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7202,7 +6625,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7210,7 +6632,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7227,7 +6648,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7235,7 +6655,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7252,7 +6671,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7265,7 +6683,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7273,7 +6690,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7294,7 +6710,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7307,7 +6722,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7315,7 +6729,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7340,7 +6753,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             },
@@ -7353,7 +6765,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7366,7 +6777,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7374,7 +6784,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7403,7 +6812,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -7416,7 +6824,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7424,7 +6831,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -7441,7 +6847,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7454,7 +6859,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7462,7 +6866,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7483,7 +6886,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7496,7 +6898,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7504,7 +6905,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7521,7 +6921,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7529,7 +6928,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7546,7 +6944,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7559,7 +6956,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7567,7 +6963,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7588,7 +6983,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7601,7 +6995,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7609,7 +7002,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7634,7 +7026,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -7642,7 +7033,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             },
@@ -7655,7 +7045,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7663,7 +7052,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7680,7 +7068,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7688,7 +7075,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -7705,7 +7091,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7718,7 +7103,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7726,7 +7110,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7747,7 +7130,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -7760,7 +7142,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7768,7 +7149,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7785,7 +7165,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7793,7 +7172,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -7810,7 +7188,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7823,7 +7200,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "inherits",
                                           "version": "2.0.3"
                                         },
@@ -7831,7 +7207,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "safe-buffer",
                                           "version": "5.1.1"
                                         }
@@ -7852,7 +7227,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -7865,7 +7239,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "inherits",
                                           "version": "2.0.3"
                                         },
@@ -7873,7 +7246,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "safe-buffer",
                                           "version": "5.1.1"
                                         }
@@ -7914,7 +7286,6 @@
                   "labels": {
                     "scope": "dev"
                   },
-                  "dependencies": {},
                   "name": "bn.js",
                   "version": "4.11.8"
                 },
@@ -7927,7 +7298,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -7944,7 +7314,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "bn.js",
                       "version": "4.11.8"
                     },
@@ -7957,7 +7326,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -7978,7 +7346,6 @@
                       "labels": {
                         "scope": "dev"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -7991,7 +7358,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -7999,7 +7365,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -8016,7 +7381,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8024,7 +7388,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -8041,7 +7404,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8054,7 +7416,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8062,7 +7423,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8083,7 +7443,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8096,7 +7455,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8104,7 +7462,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8134,7 +7491,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "bn.js",
                           "version": "4.11.8"
                         },
@@ -8142,7 +7498,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8150,7 +7505,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "minimalistic-assert",
                           "version": "1.0.1"
                         }
@@ -8167,7 +7521,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8180,7 +7533,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8188,7 +7540,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8205,7 +7556,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8213,7 +7563,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8230,7 +7579,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8243,7 +7591,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8251,7 +7598,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8272,7 +7618,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8285,7 +7630,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8293,7 +7637,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8318,7 +7661,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -8331,7 +7673,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8344,7 +7685,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8352,7 +7692,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8377,7 +7716,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "buffer-xor",
                           "version": "1.0.3"
                         },
@@ -8385,7 +7723,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -8393,7 +7730,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -8406,7 +7742,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8414,7 +7749,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8431,7 +7765,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8444,7 +7777,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8452,7 +7784,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8469,7 +7800,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8477,7 +7807,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8494,7 +7823,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8507,7 +7835,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8515,7 +7842,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8536,7 +7862,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8549,7 +7874,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8557,7 +7881,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8582,7 +7905,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             },
@@ -8595,7 +7917,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8608,7 +7929,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8616,7 +7936,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8645,7 +7964,6 @@
                           "labels": {
                             "scope": "dev"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         },
@@ -8658,7 +7976,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8666,7 +7983,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             }
@@ -8683,7 +7999,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8696,7 +8011,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8704,7 +8018,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8725,7 +8038,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8738,7 +8050,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8746,7 +8057,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8763,7 +8073,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8771,7 +8080,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8788,7 +8096,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8801,7 +8108,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8809,7 +8115,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8830,7 +8135,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8843,7 +8147,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8851,7 +8154,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8876,7 +8178,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "inherits",
                               "version": "2.0.3"
                             },
@@ -8884,7 +8185,6 @@
                               "labels": {
                                 "scope": "dev"
                               },
-                              "dependencies": {},
                               "name": "safe-buffer",
                               "version": "5.1.1"
                             },
@@ -8897,7 +8197,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8905,7 +8204,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8922,7 +8220,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8930,7 +8227,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "safe-buffer",
                                   "version": "5.1.1"
                                 }
@@ -8947,7 +8243,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -8960,7 +8255,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -8968,7 +8262,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -8989,7 +8282,6 @@
                                   "labels": {
                                     "scope": "dev"
                                   },
-                                  "dependencies": {},
                                   "name": "inherits",
                                   "version": "2.0.3"
                                 },
@@ -9002,7 +8294,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -9010,7 +8301,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -9027,7 +8317,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -9035,7 +8324,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "safe-buffer",
                                       "version": "5.1.1"
                                     }
@@ -9052,7 +8340,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -9065,7 +8352,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "inherits",
                                           "version": "2.0.3"
                                         },
@@ -9073,7 +8359,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "safe-buffer",
                                           "version": "5.1.1"
                                         }
@@ -9094,7 +8379,6 @@
                                       "labels": {
                                         "scope": "dev"
                                       },
-                                      "dependencies": {},
                                       "name": "inherits",
                                       "version": "2.0.3"
                                     },
@@ -9107,7 +8391,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "inherits",
                                           "version": "2.0.3"
                                         },
@@ -9115,7 +8398,6 @@
                                           "labels": {
                                             "scope": "dev"
                                           },
-                                          "dependencies": {},
                                           "name": "safe-buffer",
                                           "version": "5.1.1"
                                         }
@@ -9164,7 +8446,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "bluebird",
           "version": "3.5.1"
         },
@@ -9172,7 +8453,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "clean-yaml-object",
           "version": "0.1.0"
         },
@@ -9180,7 +8460,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "deeper",
           "version": "2.1.0"
         },
@@ -9188,7 +8467,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "isexe",
           "version": "1.1.2"
         },
@@ -9196,7 +8474,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "only-shallow",
           "version": "1.2.0"
         },
@@ -9204,7 +8481,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "opener",
           "version": "1.4.3"
         },
@@ -9212,7 +8488,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "signal-exit",
           "version": "2.1.2"
         },
@@ -9220,7 +8495,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "stack-utils",
           "version": "0.4.0"
         },
@@ -9228,7 +8502,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "supports-color",
           "version": "1.3.1"
         },
@@ -9236,7 +8509,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "tmatch",
           "version": "2.0.1"
         },
@@ -9249,7 +8521,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "esprima",
               "version": "4.0.1"
             },
@@ -9262,7 +8533,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "sprintf-js",
                   "version": "1.0.3"
                 }
@@ -9283,7 +8553,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "1.0.0"
             },
@@ -9291,7 +8560,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "core-util-is",
               "version": "1.0.2"
             },
@@ -9299,7 +8567,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -9307,7 +8574,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "process-nextick-args",
               "version": "2.0.0"
             },
@@ -9315,7 +8581,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "safe-buffer",
               "version": "5.1.1"
             },
@@ -9323,7 +8588,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "util-deprecate",
               "version": "1.0.2"
             },
@@ -9336,7 +8600,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 }
@@ -9357,7 +8620,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "signal-exit",
               "version": "3.0.2"
             },
@@ -9375,7 +8637,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "2.0.0"
                     }
@@ -9392,7 +8653,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "pseudomap",
                       "version": "1.0.2"
                     },
@@ -9400,7 +8660,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "yallist",
                       "version": "2.1.2"
                     }
@@ -9425,7 +8684,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "fs.realpath",
               "version": "1.0.0"
             },
@@ -9433,7 +8691,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -9441,7 +8698,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "path-is-absolute",
               "version": "1.0.1"
             },
@@ -9454,7 +8710,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 }
@@ -9471,7 +8726,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wrappy",
                   "version": "1.0.2"
                 },
@@ -9484,7 +8738,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -9510,7 +8763,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "balanced-match",
                       "version": "1.0.0"
                     },
@@ -9518,7 +8770,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "concat-map",
                       "version": "0.0.1"
                     }
@@ -9543,7 +8794,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "events-to-array",
               "version": "1.1.2"
             },
@@ -9551,7 +8801,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "inherits",
               "version": "2.0.3"
             },
@@ -9564,7 +8813,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "4.0.1"
                 },
@@ -9577,7 +8825,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -9598,7 +8845,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "1.0.0"
                 },
@@ -9606,7 +8852,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -9614,7 +8859,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -9622,7 +8866,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "process-nextick-args",
                   "version": "2.0.0"
                 },
@@ -9630,7 +8873,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "safe-buffer",
                   "version": "5.1.1"
                 },
@@ -9638,7 +8880,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "util-deprecate",
                   "version": "1.0.2"
                 },
@@ -9651,7 +8892,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     }
@@ -9676,7 +8916,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "color-support",
               "version": "1.1.3"
             },
@@ -9684,7 +8923,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "diff",
               "version": "1.4.0"
             },
@@ -9692,7 +8930,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "escape-string-regexp",
               "version": "1.0.5"
             },
@@ -9705,7 +8942,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "0.7.1"
                 }
@@ -9722,7 +8958,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "core-util-is",
                   "version": "1.0.2"
                 },
@@ -9730,7 +8965,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -9738,7 +8972,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isarray",
                   "version": "0.0.1"
                 },
@@ -9746,7 +8979,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "string_decoder",
                   "version": "0.10.31"
                 }
@@ -9763,7 +8995,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "4.0.1"
                 },
@@ -9776,7 +9007,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -9797,7 +9027,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "punycode",
                   "version": "1.4.1"
                 },
@@ -9810,7 +9039,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ansi-regex",
                       "version": "2.1.1"
                     }
@@ -9831,7 +9059,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "fs.realpath",
                   "version": "1.0.0"
                 },
@@ -9839,7 +9066,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -9847,7 +9073,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "path-is-absolute",
                   "version": "1.0.1"
                 },
@@ -9860,7 +9085,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -9877,7 +9101,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     },
@@ -9890,7 +9113,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -9916,7 +9138,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "balanced-match",
                           "version": "1.0.0"
                         },
@@ -9924,7 +9145,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "concat-map",
                           "version": "0.0.1"
                         }
@@ -9949,7 +9169,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "events-to-array",
                   "version": "1.1.2"
                 },
@@ -9957,7 +9176,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.3"
                 },
@@ -9970,7 +9188,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "4.0.1"
                     },
@@ -9983,7 +9200,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "sprintf-js",
                           "version": "1.0.3"
                         }
@@ -10004,7 +9220,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isarray",
                       "version": "1.0.0"
                     },
@@ -10012,7 +9227,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "core-util-is",
                       "version": "1.0.2"
                     },
@@ -10020,7 +9234,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -10028,7 +9241,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "process-nextick-args",
                       "version": "2.0.0"
                     },
@@ -10036,7 +9248,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "safe-buffer",
                       "version": "5.1.1"
                     },
@@ -10044,7 +9255,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "util-deprecate",
                       "version": "1.0.2"
                     },
@@ -10057,7 +9267,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "safe-buffer",
                           "version": "5.1.1"
                         }
@@ -10096,7 +9305,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "deep-equal",
                       "version": "0.1.2"
                     },
@@ -10104,7 +9312,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "defined",
                       "version": "0.0.0"
                     },
@@ -10112,7 +9319,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.3"
                     },
@@ -10120,7 +9326,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "jsonify",
                       "version": "0.0.0"
                     },
@@ -10128,7 +9333,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "through",
                       "version": "2.3.8"
                     },
@@ -10141,7 +9345,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "through",
                           "version": "2.3.8"
                         }
@@ -10158,7 +9361,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "through",
                           "version": "2.3.8"
                         }
@@ -10175,7 +9377,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "duplexer",
                           "version": "0.1.1"
                         }
@@ -10200,7 +9401,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "mime-types",
                   "version": "1.0.2"
                 },
@@ -10208,7 +9408,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "qs",
                   "version": "1.2.2"
                 },
@@ -10216,7 +9415,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws-sign2",
                   "version": "0.5.0"
                 },
@@ -10224,7 +9422,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "caseless",
                   "version": "0.6.0"
                 },
@@ -10232,7 +9429,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "forever-agent",
                   "version": "0.5.2"
                 },
@@ -10240,7 +9436,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "json-stringify-safe",
                   "version": "5.0.1"
                 },
@@ -10248,7 +9443,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "node-uuid",
                   "version": "1.4.8"
                 },
@@ -10256,7 +9450,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "oauth-sign",
                   "version": "0.4.0"
                 },
@@ -10264,7 +9457,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "stringstream",
                   "version": "0.0.6"
                 },
@@ -10272,7 +9464,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "tunnel-agent",
                   "version": "0.4.3"
                 },
@@ -10285,7 +9476,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "asn1",
                       "version": "0.1.11"
                     },
@@ -10293,7 +9483,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "assert-plus",
                       "version": "0.1.5"
                     },
@@ -10301,7 +9490,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "ctype",
                       "version": "0.5.3"
                     }
@@ -10318,7 +9506,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "psl",
                       "version": "1.1.28"
                     },
@@ -10326,7 +9513,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "punycode",
                       "version": "1.4.1"
                     }
@@ -10348,7 +9534,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "core-util-is",
                           "version": "1.0.2"
                         },
@@ -10356,7 +9541,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.3"
                         },
@@ -10364,7 +9548,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isarray",
                           "version": "0.0.1"
                         },
@@ -10372,7 +9555,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "string_decoder",
                           "version": "0.10.31"
                         }
@@ -10393,7 +9575,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "mime",
                       "version": "1.2.11"
                     },
@@ -10401,7 +9582,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "async",
                       "version": "0.9.0"
                     },
@@ -10414,7 +9594,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "delayed-stream",
                           "version": "0.0.5"
                         }
@@ -10435,7 +9614,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "hoek",
                       "version": "0.9.1"
                     },
@@ -10448,7 +9626,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "0.9.1"
                         }
@@ -10465,7 +9642,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "0.9.1"
                         }
@@ -10487,7 +9663,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hoek",
                               "version": "0.9.1"
                             }
@@ -10520,7 +9695,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "lcov-parse",
               "version": "0.0.10"
             },
@@ -10528,7 +9702,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "log-driver",
               "version": "1.2.5"
             },
@@ -10536,7 +9709,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "minimist",
               "version": "1.2.0"
             },
@@ -10549,7 +9721,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "2.7.3"
                 },
@@ -10562,7 +9733,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "sprintf-js",
                       "version": "1.0.3"
                     }
@@ -10583,7 +9753,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws-sign2",
                   "version": "0.6.0"
                 },
@@ -10591,7 +9760,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "caseless",
                   "version": "0.11.0"
                 },
@@ -10599,7 +9767,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "forever-agent",
                   "version": "0.6.1"
                 },
@@ -10607,7 +9774,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "oauth-sign",
                   "version": "0.8.2"
                 },
@@ -10615,7 +9781,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "qs",
                   "version": "6.3.2"
                 },
@@ -10623,7 +9788,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "uuid",
                   "version": "3.3.2"
                 },
@@ -10631,7 +9795,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "aws4",
                   "version": "1.7.0"
                 },
@@ -10639,7 +9802,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "extend",
                   "version": "3.0.2"
                 },
@@ -10647,7 +9809,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "is-typedarray",
                   "version": "1.0.0"
                 },
@@ -10655,7 +9816,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "isstream",
                   "version": "0.1.2"
                 },
@@ -10663,7 +9823,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "json-stringify-safe",
                   "version": "5.0.1"
                 },
@@ -10671,7 +9830,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "stringstream",
                   "version": "0.0.6"
                 },
@@ -10679,7 +9837,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "tunnel-agent",
                   "version": "0.4.3"
                 },
@@ -10692,7 +9849,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "delayed-stream",
                       "version": "1.0.0"
                     }
@@ -10709,7 +9865,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "mime-db",
                       "version": "1.35.0"
                     }
@@ -10726,7 +9881,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "punycode",
                       "version": "1.4.1"
                     }
@@ -10743,7 +9897,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "asynckit",
                       "version": "0.4.0"
                     },
@@ -10756,7 +9909,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "delayed-stream",
                           "version": "1.0.0"
                         }
@@ -10773,7 +9925,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "mime-db",
                           "version": "1.35.0"
                         }
@@ -10794,7 +9945,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "hoek",
                       "version": "2.16.3"
                     },
@@ -10807,7 +9957,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "2.16.3"
                         }
@@ -10824,7 +9973,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "hoek",
                           "version": "2.16.3"
                         }
@@ -10846,7 +9994,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hoek",
                               "version": "2.16.3"
                             }
@@ -10871,7 +10018,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "commander",
                       "version": "2.16.0"
                     },
@@ -10884,7 +10030,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -10901,7 +10046,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "supports-color",
                           "version": "2.0.0"
                         },
@@ -10909,7 +10053,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-styles",
                           "version": "2.2.1"
                         },
@@ -10917,7 +10060,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "escape-string-regexp",
                           "version": "1.0.5"
                         },
@@ -10930,7 +10072,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.1.1"
                             }
@@ -10947,7 +10088,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.1.1"
                             }
@@ -10968,7 +10108,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "generate-function",
                           "version": "2.0.0"
                         },
@@ -10976,7 +10115,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-my-ip-valid",
                           "version": "1.0.0"
                         },
@@ -10984,7 +10122,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "jsonpointer",
                           "version": "4.0.1"
                         },
@@ -10992,7 +10129,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "xtend",
                           "version": "4.0.1"
                         },
@@ -11005,7 +10141,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-property",
                               "version": "1.0.2"
                             }
@@ -11030,7 +10165,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "assert-plus",
                       "version": "0.2.0"
                     },
@@ -11043,7 +10177,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "assert-plus",
                           "version": "1.0.0"
                         },
@@ -11051,7 +10184,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "extsprintf",
                           "version": "1.3.0"
                         },
@@ -11059,7 +10191,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "json-schema",
                           "version": "0.2.3"
                         },
@@ -11072,7 +10203,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             },
@@ -11080,7 +10210,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "core-util-is",
                               "version": "1.0.2"
                             },
@@ -11088,7 +10217,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "extsprintf",
                               "version": "1.3.0"
                             }
@@ -11109,7 +10237,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "asn1",
                           "version": "0.2.3"
                         },
@@ -11117,7 +10244,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "assert-plus",
                           "version": "1.0.0"
                         },
@@ -11125,7 +10251,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "jsbn",
                           "version": "0.1.1"
                         },
@@ -11133,7 +10258,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "safer-buffer",
                           "version": "2.1.2"
                         },
@@ -11141,7 +10265,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "tweetnacl",
                           "version": "0.14.5"
                         },
@@ -11154,7 +10277,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             }
@@ -11171,7 +10293,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "assert-plus",
                               "version": "1.0.0"
                             }
@@ -11188,7 +10309,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "tweetnacl",
                               "version": "0.14.5"
                             }
@@ -11205,7 +10325,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "jsbn",
                               "version": "0.1.1"
                             },
@@ -11213,7 +10332,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "safer-buffer",
                               "version": "2.1.2"
                             }
@@ -11246,7 +10364,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "arrify",
               "version": "1.0.1"
             },
@@ -11254,7 +10371,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "convert-source-map",
               "version": "1.2.0"
             },
@@ -11262,7 +10378,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "resolve-from",
               "version": "2.0.0"
             },
@@ -11270,7 +10385,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "signal-exit",
               "version": "3.0.0"
             },
@@ -11278,7 +10392,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "source-map",
               "version": "0.5.6"
             },
@@ -11291,7 +10404,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "md5-o-matic",
                   "version": "0.1.1"
                 }
@@ -11308,7 +10420,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "minimist",
                   "version": "0.0.8"
                 }
@@ -11330,7 +10441,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-utf8",
                       "version": "0.2.1"
                     }
@@ -11356,7 +10466,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "graceful-fs",
                       "version": "4.1.4"
                     },
@@ -11364,7 +10473,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "imurmurhash",
                       "version": "0.1.4"
                     },
@@ -11372,7 +10480,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "slide",
                       "version": "1.1.6"
                     }
@@ -11389,7 +10496,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "md5-o-matic",
                       "version": "0.1.1"
                     }
@@ -11406,7 +10512,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -11437,7 +10542,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-utf8",
                           "version": "0.2.1"
                         }
@@ -11467,7 +10571,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "pinkie",
                       "version": "2.0.4"
                     }
@@ -11489,7 +10592,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -11514,7 +10616,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "signal-exit",
                   "version": "2.1.2"
                 },
@@ -11527,7 +10628,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -11549,7 +10649,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pseudomap",
                           "version": "1.0.2"
                         },
@@ -11557,7 +10656,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "yallist",
                           "version": "2.0.0"
                         }
@@ -11574,7 +10672,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isexe",
                           "version": "1.1.2"
                         }
@@ -11599,7 +10696,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "inherits",
                   "version": "2.0.1"
                 },
@@ -11607,7 +10703,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "path-is-absolute",
                   "version": "1.0.0"
                 },
@@ -11620,7 +10715,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -11642,7 +10736,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "balanced-match",
                           "version": "0.4.1"
                         },
@@ -11650,7 +10743,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "concat-map",
                           "version": "0.0.1"
                         }
@@ -11671,7 +10763,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     },
@@ -11684,7 +10775,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -11719,7 +10809,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pinkie",
                           "version": "2.0.4"
                         }
@@ -11741,7 +10830,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -11775,7 +10863,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "inherits",
                       "version": "2.0.1"
                     },
@@ -11783,7 +10870,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "path-is-absolute",
                       "version": "1.0.0"
                     },
@@ -11796,7 +10882,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         }
@@ -11818,7 +10903,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "0.4.1"
                             },
@@ -11826,7 +10910,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -11847,7 +10930,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wrappy",
                           "version": "1.0.2"
                         },
@@ -11860,7 +10942,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -11889,7 +10970,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "commondir",
                   "version": "1.0.1"
                 },
@@ -11902,7 +10982,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -11929,7 +11008,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -11951,7 +11029,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -11984,7 +11061,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "os-homedir",
                   "version": "1.0.1"
                 },
@@ -11992,7 +11068,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "signal-exit",
                   "version": "2.1.2"
                 },
@@ -12005,7 +11080,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -12022,7 +11096,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -12039,7 +11112,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "signal-exit",
                       "version": "2.1.2"
                     },
@@ -12052,7 +11124,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "isexe",
                           "version": "1.1.2"
                         }
@@ -12074,7 +11145,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pseudomap",
                               "version": "1.0.2"
                             },
@@ -12082,7 +11152,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "yallist",
                               "version": "2.0.0"
                             }
@@ -12099,7 +11168,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "isexe",
                               "version": "1.1.2"
                             }
@@ -12129,7 +11197,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.1"
                         },
@@ -12137,7 +11204,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "path-is-absolute",
                           "version": "1.0.0"
                         },
@@ -12150,7 +11216,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -12172,7 +11237,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "balanced-match",
                                   "version": "0.4.1"
                                 },
@@ -12180,7 +11244,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "concat-map",
                                   "version": "0.0.1"
                                 }
@@ -12201,7 +11264,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             },
@@ -12214,7 +11276,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wrappy",
                                   "version": "1.0.2"
                                 }
@@ -12247,7 +11308,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "camelcase",
                   "version": "3.0.0"
                 },
@@ -12255,7 +11315,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "decamelize",
                   "version": "1.2.0"
                 },
@@ -12263,7 +11322,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "require-main-filename",
                   "version": "1.0.1"
                 },
@@ -12271,7 +11329,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "set-blocking",
                   "version": "1.0.0"
                 },
@@ -12279,7 +11336,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "window-size",
                   "version": "0.2.0"
                 },
@@ -12287,7 +11343,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "y18n",
                   "version": "3.2.1"
                 },
@@ -12300,7 +11355,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.keys",
                       "version": "4.0.7"
                     },
@@ -12308,7 +11362,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.rest",
                       "version": "4.0.3"
                     }
@@ -12330,7 +11383,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "invert-kv",
                           "version": "1.0.0"
                         }
@@ -12356,7 +11408,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "number-is-nan",
                           "version": "1.0.0"
                         }
@@ -12373,7 +11424,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "number-is-nan",
                           "version": "1.0.0"
                         }
@@ -12390,7 +11440,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-regex",
                           "version": "2.0.0"
                         }
@@ -12411,7 +11460,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "camelcase",
                       "version": "2.1.1"
                     },
@@ -12424,7 +11472,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "lodash.keys",
                           "version": "4.0.7"
                         },
@@ -12432,7 +11479,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "lodash.rest",
                           "version": "4.0.3"
                         }
@@ -12458,7 +11504,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "ansi-regex",
                           "version": "2.0.0"
                         }
@@ -12480,7 +11525,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "number-is-nan",
                               "version": "1.0.0"
                             }
@@ -12497,7 +11541,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "number-is-nan",
                               "version": "1.0.0"
                             }
@@ -12514,7 +11557,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "ansi-regex",
                               "version": "2.0.0"
                             }
@@ -12545,7 +11587,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "number-is-nan",
                                   "version": "1.0.0"
                                 }
@@ -12562,7 +11603,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "number-is-nan",
                                   "version": "1.0.0"
                                 }
@@ -12579,7 +11619,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "ansi-regex",
                                   "version": "2.0.0"
                                 }
@@ -12608,7 +11647,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "object-assign",
                       "version": "4.1.0"
                     },
@@ -12616,7 +11654,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "symbol",
                       "version": "0.2.3"
                     },
@@ -12629,7 +11666,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "graceful-fs",
                           "version": "4.1.4"
                         },
@@ -12637,7 +11673,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "pify",
                           "version": "2.3.0"
                         },
@@ -12650,7 +11685,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -12667,7 +11701,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-utf8",
                               "version": "0.2.1"
                             }
@@ -12689,7 +11722,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-arrayish",
                                   "version": "0.2.1"
                                 }
@@ -12719,7 +11751,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -12741,7 +11772,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -12780,7 +11810,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -12788,7 +11817,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -12801,7 +11829,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -12822,7 +11849,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -12830,7 +11856,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -12843,7 +11868,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -12860,7 +11884,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-utf8",
                                   "version": "0.2.1"
                                 }
@@ -12882,7 +11905,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-arrayish",
                                       "version": "0.2.1"
                                     }
@@ -12907,7 +11929,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hosted-git-info",
                               "version": "2.1.5"
                             },
@@ -12915,7 +11936,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "semver",
                               "version": "5.1.0"
                             },
@@ -12928,7 +11948,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "builtin-modules",
                                   "version": "1.1.1"
                                 }
@@ -12950,7 +11969,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -12967,7 +11985,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-exceptions",
                                       "version": "1.0.4"
                                     },
@@ -12975,7 +11992,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -13009,7 +12025,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -13031,7 +12046,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -13064,7 +12078,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "abbrev",
                   "version": "1.0.7"
                 },
@@ -13072,7 +12085,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "async",
                   "version": "1.5.2"
                 },
@@ -13080,7 +12092,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "esprima",
                   "version": "2.7.2"
                 },
@@ -13088,7 +12099,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "resolve",
                   "version": "1.1.7"
                 },
@@ -13096,7 +12106,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "wordwrap",
                   "version": "1.0.0"
                 },
@@ -13109,7 +12118,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "wrappy",
                       "version": "1.0.2"
                     }
@@ -13126,7 +12134,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "has-flag",
                       "version": "1.0.0"
                     }
@@ -13143,7 +12150,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "isexe",
                       "version": "1.1.2"
                     }
@@ -13160,7 +12166,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "minimist",
                       "version": "0.0.8"
                     }
@@ -13177,7 +12182,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "abbrev",
                       "version": "1.0.7"
                     }
@@ -13194,7 +12198,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "2.7.2"
                     },
@@ -13207,7 +12210,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "sprintf-js",
                           "version": "1.0.3"
                         }
@@ -13228,7 +12230,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "estraverse",
                       "version": "1.9.3"
                     },
@@ -13236,7 +12237,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esutils",
                       "version": "2.0.2"
                     },
@@ -13244,7 +12244,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "esprima",
                       "version": "2.7.2"
                     },
@@ -13257,7 +12256,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "amdefine",
                           "version": "1.0.0"
                         }
@@ -13274,7 +12272,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "deep-is",
                           "version": "0.1.3"
                         },
@@ -13282,7 +12279,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "fast-levenshtein",
                           "version": "1.1.3"
                         },
@@ -13290,7 +12286,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "prelude-ls",
                           "version": "1.1.2"
                         },
@@ -13298,7 +12293,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wordwrap",
                           "version": "1.0.0"
                         },
@@ -13311,7 +12305,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "prelude-ls",
                               "version": "1.1.2"
                             }
@@ -13328,7 +12321,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "prelude-ls",
                               "version": "1.1.2"
                             },
@@ -13341,7 +12333,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "prelude-ls",
                                   "version": "1.1.2"
                                 }
@@ -13380,7 +12371,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "balanced-match",
                               "version": "0.4.1"
                             },
@@ -13388,7 +12378,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "concat-map",
                               "version": "0.0.1"
                             }
@@ -13409,7 +12398,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "inherits",
                           "version": "2.0.1"
                         },
@@ -13417,7 +12405,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "path-is-absolute",
                           "version": "1.0.0"
                         },
@@ -13430,7 +12417,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             }
@@ -13452,7 +12438,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "balanced-match",
                                   "version": "0.4.1"
                                 },
@@ -13460,7 +12445,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "concat-map",
                                   "version": "0.0.1"
                                 }
@@ -13481,7 +12465,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "wrappy",
                               "version": "1.0.2"
                             },
@@ -13494,7 +12477,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wrappy",
                                   "version": "1.0.2"
                                 }
@@ -13523,7 +12505,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "async",
                       "version": "1.5.2"
                     },
@@ -13536,7 +12517,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "minimist",
                           "version": "0.0.10"
                         },
@@ -13544,7 +12524,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "wordwrap",
                           "version": "0.0.3"
                         }
@@ -13561,7 +12540,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "amdefine",
                           "version": "1.0.0"
                         }
@@ -13578,7 +12556,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "async",
                           "version": "0.2.10"
                         },
@@ -13586,7 +12563,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "source-map",
                           "version": "0.5.6"
                         },
@@ -13594,7 +12570,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "uglify-to-browserify",
                           "version": "1.0.2"
                         },
@@ -13607,7 +12582,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "camelcase",
                               "version": "1.2.1"
                             },
@@ -13615,7 +12589,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "decamelize",
                               "version": "1.2.0"
                             },
@@ -13623,7 +12596,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "window-size",
                               "version": "0.1.0"
                             },
@@ -13636,7 +12608,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "wordwrap",
                                   "version": "0.0.2"
                                 },
@@ -13649,7 +12620,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "lazy-cache",
                                       "version": "1.0.4"
                                     },
@@ -13662,7 +12632,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "longest",
                                           "version": "1.0.1"
                                         },
@@ -13670,7 +12639,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "repeat-string",
                                           "version": "1.5.4"
                                         },
@@ -13683,7 +12651,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }
@@ -13713,7 +12680,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "longest",
                                           "version": "1.0.1"
                                         },
@@ -13721,7 +12687,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "repeat-string",
                                           "version": "1.5.4"
                                         },
@@ -13734,7 +12699,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }
@@ -13779,7 +12743,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "array-unique",
                   "version": "0.2.1"
                 },
@@ -13787,7 +12750,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "filename-regex",
                   "version": "2.0.0"
                 },
@@ -13795,7 +12757,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "is-extglob",
                   "version": "1.0.0"
                 },
@@ -13803,7 +12764,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "normalize-path",
                   "version": "2.0.1"
                 },
@@ -13816,7 +12776,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "arr-flatten",
                       "version": "1.0.1"
                     }
@@ -13833,7 +12792,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-posix-bracket",
                       "version": "0.1.1"
                     }
@@ -13850,7 +12808,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-buffer",
                       "version": "1.1.3"
                     }
@@ -13867,7 +12824,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     }
@@ -13884,7 +12840,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     }
@@ -13901,7 +12856,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extendable",
                       "version": "0.1.1"
                     },
@@ -13914,7 +12868,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "for-in",
                           "version": "0.1.5"
                         }
@@ -13935,7 +12888,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-primitive",
                       "version": "2.0.0"
                     },
@@ -13948,7 +12900,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-primitive",
                           "version": "2.0.0"
                         }
@@ -13969,7 +12920,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-dotfile",
                       "version": "1.0.2"
                     },
@@ -13977,7 +12927,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     },
@@ -13990,7 +12939,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -14012,7 +12960,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-extglob",
                               "version": "1.0.0"
                             }
@@ -14034,7 +12981,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-extglob",
                                   "version": "1.0.0"
                                 }
@@ -14063,7 +13009,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "preserve",
                       "version": "0.2.0"
                     },
@@ -14071,7 +13016,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "repeat-element",
                       "version": "1.1.2"
                     },
@@ -14089,7 +13033,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "repeat-string",
                               "version": "1.5.4"
                             },
@@ -14097,7 +13040,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "repeat-element",
                               "version": "1.1.2"
                             },
@@ -14110,7 +13052,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "isarray",
                                   "version": "1.0.0"
                                 }
@@ -14132,7 +13073,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-buffer",
                                       "version": "1.1.3"
                                     }
@@ -14158,7 +13098,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-buffer",
                                       "version": "1.1.3"
                                     }
@@ -14180,7 +13119,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -14221,7 +13159,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "require-main-filename",
                   "version": "1.0.1"
                 },
@@ -14229,7 +13166,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "arrify",
                   "version": "1.0.1"
                 },
@@ -14242,7 +13178,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.keys",
                       "version": "4.0.7"
                     },
@@ -14250,7 +13185,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "lodash.rest",
                       "version": "4.0.3"
                     }
@@ -14277,7 +13211,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -14285,7 +13218,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -14298,7 +13230,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -14319,7 +13250,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "graceful-fs",
                               "version": "4.1.4"
                             },
@@ -14327,7 +13257,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pify",
                               "version": "2.3.0"
                             },
@@ -14340,7 +13269,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -14357,7 +13285,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-utf8",
                                   "version": "0.2.1"
                                 }
@@ -14379,7 +13306,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-arrayish",
                                       "version": "0.2.1"
                                     }
@@ -14404,7 +13330,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "hosted-git-info",
                               "version": "2.1.5"
                             },
@@ -14412,7 +13337,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "semver",
                               "version": "5.1.0"
                             },
@@ -14425,7 +13349,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "builtin-modules",
                                   "version": "1.1.1"
                                 }
@@ -14447,7 +13370,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -14464,7 +13386,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-exceptions",
                                       "version": "1.0.4"
                                     },
@@ -14472,7 +13393,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "spdx-license-ids",
                                       "version": "1.2.1"
                                     }
@@ -14506,7 +13426,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "pinkie",
                               "version": "2.0.4"
                             }
@@ -14528,7 +13447,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "pinkie",
                                   "version": "2.0.4"
                                 }
@@ -14557,7 +13475,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "array-unique",
                       "version": "0.2.1"
                     },
@@ -14565,7 +13482,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "filename-regex",
                       "version": "2.0.0"
                     },
@@ -14573,7 +13489,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "is-extglob",
                       "version": "1.0.0"
                     },
@@ -14581,7 +13496,6 @@
                       "labels": {
                         "scope": "prod"
                       },
-                      "dependencies": {},
                       "name": "normalize-path",
                       "version": "2.0.1"
                     },
@@ -14594,7 +13508,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "arr-flatten",
                           "version": "1.0.1"
                         }
@@ -14611,7 +13524,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-posix-bracket",
                           "version": "0.1.1"
                         }
@@ -14628,7 +13540,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-buffer",
                           "version": "1.1.3"
                         }
@@ -14645,7 +13556,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -14662,7 +13572,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         }
@@ -14679,7 +13588,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extendable",
                           "version": "0.1.1"
                         },
@@ -14692,7 +13600,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "for-in",
                               "version": "0.1.5"
                             }
@@ -14713,7 +13620,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-primitive",
                           "version": "2.0.0"
                         },
@@ -14726,7 +13632,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-primitive",
                               "version": "2.0.0"
                             }
@@ -14747,7 +13652,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-dotfile",
                           "version": "1.0.2"
                         },
@@ -14755,7 +13659,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "is-extglob",
                           "version": "1.0.0"
                         },
@@ -14768,7 +13671,6 @@
                               "labels": {
                                 "scope": "prod"
                               },
-                              "dependencies": {},
                               "name": "is-extglob",
                               "version": "1.0.0"
                             }
@@ -14790,7 +13692,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "is-extglob",
                                   "version": "1.0.0"
                                 }
@@ -14812,7 +13713,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "is-extglob",
                                       "version": "1.0.0"
                                     }
@@ -14841,7 +13741,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "preserve",
                           "version": "0.2.0"
                         },
@@ -14849,7 +13748,6 @@
                           "labels": {
                             "scope": "prod"
                           },
-                          "dependencies": {},
                           "name": "repeat-element",
                           "version": "1.1.2"
                         },
@@ -14867,7 +13765,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "repeat-string",
                                   "version": "1.5.4"
                                 },
@@ -14875,7 +13772,6 @@
                                   "labels": {
                                     "scope": "prod"
                                   },
-                                  "dependencies": {},
                                   "name": "repeat-element",
                                   "version": "1.1.2"
                                 },
@@ -14888,7 +13784,6 @@
                                       "labels": {
                                         "scope": "prod"
                                       },
-                                      "dependencies": {},
                                       "name": "isarray",
                                       "version": "1.0.0"
                                     }
@@ -14910,7 +13805,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -14936,7 +13830,6 @@
                                           "labels": {
                                             "scope": "prod"
                                           },
-                                          "dependencies": {},
                                           "name": "is-buffer",
                                           "version": "1.1.3"
                                         }
@@ -14958,7 +13851,6 @@
                                               "labels": {
                                                 "scope": "prod"
                                               },
-                                              "dependencies": {},
                                               "name": "is-buffer",
                                               "version": "1.1.3"
                                             }

--- a/test/lib/fixtures/missing-deps/expected-tree.json
+++ b/test/lib/fixtures/missing-deps/expected-tree.json
@@ -2,6 +2,5 @@
   "name": "pkg-missing-deps",
   "size": 1,
   "version": "1.0.0",
-  "hasDevDependencies": false,
-  "dependencies": {}
+  "hasDevDependencies": false
 }

--- a/test/lib/fixtures/out-of-sync-tree/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync-tree/expected-tree.json
@@ -9,7 +9,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ms",
           "version": "2.1.1"
         }
@@ -19,10 +18,9 @@
     },
     "body-parser": {
       "labels": {
-        "scope": "prod"
+        "scope": "prod",
+        "missingLockFileEntry": true
       },
-      "missingLockFileEntry": true,
-      "dependencies": {},
       "name": "body-parser",
       "version": "^1.18.2"
     },
@@ -40,7 +38,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ms",
               "version": "2.0.0"
             }
@@ -66,7 +63,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "base64-js",
               "version": "1.3.0"
             },
@@ -74,7 +70,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "ieee754",
               "version": "1.1.8"
             },
@@ -82,7 +77,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "isarray",
               "version": "1.0.0"
             }
@@ -94,7 +88,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "events",
           "version": "1.1.1"
         },
@@ -102,7 +95,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "ieee754",
           "version": "1.1.8"
         },
@@ -110,7 +102,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "jmespath",
           "version": "0.15.0"
         },
@@ -118,7 +109,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "querystring",
           "version": "0.2.0"
         },
@@ -126,7 +116,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "sax",
           "version": "1.2.1"
         },
@@ -139,7 +128,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "punycode",
               "version": "1.3.2"
             },
@@ -147,7 +135,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "querystring",
               "version": "0.2.0"
             }
@@ -159,7 +146,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "uuid",
           "version": "3.1.0"
         },
@@ -172,7 +158,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "sax",
               "version": "1.2.1"
             },
@@ -180,7 +165,6 @@
               "labels": {
                 "scope": "prod"
               },
-              "dependencies": {},
               "name": "xmlbuilder",
               "version": "9.0.7"
             }
@@ -211,7 +195,6 @@
                   "labels": {
                     "scope": "prod"
                   },
-                  "dependencies": {},
                   "name": "ms",
                   "version": "2.0.0"
                 }
@@ -227,7 +210,6 @@
           "labels": {
             "scope": "prod"
           },
-          "dependencies": {},
           "name": "is-buffer",
           "version": "1.1.6"
         }
@@ -239,7 +221,6 @@
       "labels": {
         "scope": "prod"
       },
-      "dependencies": {},
       "name": "bignumber.js",
       "version": "7.2.1"
     }

--- a/test/lib/fixtures/out-of-sync/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync/expected-tree.json
@@ -15,10 +15,8 @@
                 "scope": "prod",
                 "pruned": "cyclic"
               },
-              "dependencies": {},
               "name": "debug",
-              "version": "2.0.0",
-              "cyclic": true
+              "version": "2.0.0"
             }
           },
           "name": "ms",
@@ -30,21 +28,19 @@
     },
     "lodash": {
       "labels": {
-        "scope": "prod"
+        "scope": "prod",
+        "missingLockFileEntry": true
       },
-      "dependencies": {},
       "name": "lodash",
-      "version": "4.17.11",
-      "missingLockFileEntry": true
+      "version": "4.17.11"
     },
     "body-parser": {
       "labels": {
-        "scope": "prod"
+        "scope": "prod",
+        "missingLockFileEntry": true
       },
-      "dependencies": {},
       "name": "body-parser",
-      "version": "^1.18.2",
-      "missingLockFileEntry": true
+      "version": "^1.18.2"
     }
   },
   "hasDevDependencies": true,

--- a/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
+++ b/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
@@ -19,33 +19,25 @@
           "version": "1.0.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "depd": {
           "name": "depd",
           "version": "1.0.1",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "iconv-lite": {
           "name": "iconv-lite",
           "version": "0.4.4",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "media-typer": {
           "name": "media-typer",
           "version": "0.3.0",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "on-finished": {
           "name": "on-finished",
           "version": "2.1.0",
@@ -58,9 +50,7 @@
               "version": "1.0.5",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "qs": {
@@ -68,9 +58,7 @@
           "version": "2.2.4",
           "labels": {
             "scope": "prod"
-          },
-          "dependencies": {}
-        },
+          }},
         "raw-body": {
           "name": "raw-body",
           "version": "1.3.0",
@@ -83,17 +71,13 @@
               "version": "1.0.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "iconv-lite": {
               "name": "iconv-lite",
               "version": "0.4.4",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            }
+              }}
           }
         },
         "type-is": {
@@ -108,9 +92,7 @@
               "version": "0.3.0",
               "labels": {
                 "scope": "prod"
-              },
-              "dependencies": {}
-            },
+              }},
             "mime-types": {
               "name": "mime-types",
               "version": "2.0.14",
@@ -123,9 +105,7 @@
                   "version": "1.12.0",
                   "labels": {
                     "scope": "prod"
-                  },
-                  "dependencies": {}
-                }
+                  }}
               }
             }
           }
@@ -137,8 +117,6 @@
       "version": "8.1.0",
       "labels": {
         "scope": "prod"
-      },
-      "dependencies": {}
-    }
+      }}
   }
 }

--- a/test/lib/fixtures/simple-test/expected-tree.json
+++ b/test/lib/fixtures/simple-test/expected-tree.json
@@ -15,7 +15,6 @@
       },
       "dependencies": {
         "function-bind": {
-          "dependencies": {},
           "labels": {
             "scope": "prod"
           },
@@ -32,7 +31,6 @@
       },
       "dependencies": {
         "ms": {
-          "dependencies": {},
           "labels": {
             "scope": "dev"
           },

--- a/test/lib/package-lock-depTree.test.ts
+++ b/test/lib/package-lock-depTree.test.ts
@@ -47,7 +47,7 @@ test('Parse npm package.json with empty devDependencies', async (t) => {
   );
 
   t.false(depTree.hasDevDependencies, 'Package doesn\'t have devDependencies');
-  t.ok(depTree.dependencies['adm-zip'], 'Dependencies are reported correctly');
+  t.ok(depTree.dependencies!['adm-zip'], 'Dependencies are reported correctly');
 });
 
 test('Parse npm package-lock.json with missing dependency', async (t) => {
@@ -145,8 +145,7 @@ test('Parse npm package-lock.json with cyclic deps', async (t) => {
     'package.json',
     'package-lock.json',
   );
-  t.strictEqual(depTree.dependencies.debug.dependencies.ms.dependencies.debug.cyclic, true, 'Cyclic dependency is found correctly');
-  t.strictEqual(depTree.dependencies.debug.dependencies.ms.dependencies.debug.labels!.pruned, 'cyclic', 'Cyclic label is set');
+  t.strictEqual(depTree.dependencies!.debug.dependencies!.ms.dependencies!.debug.labels!.pruned, 'cyclic', 'Cyclic label is set');
 });
 
 test('Parse npm package-lock.json with self-reference cyclic deps', async (t) => {

--- a/test/lib/yarn.test.ts
+++ b/test/lib/yarn.test.ts
@@ -51,8 +51,7 @@ if (getRuntimeVersion() < 6) {
       'package.json',
       'yarn.lock',
     );
-    t.strictEqual(depTree.dependencies.debug.dependencies.ms.dependencies.debug.cyclic, true, 'Cyclic dependency is found correctly');
-    t.strictEqual(depTree.dependencies.debug.dependencies.ms.dependencies.debug.labels!.pruned, 'cyclic', 'Cyclic dependency is found correctly');
+    t.strictEqual(depTree.dependencies!.debug.dependencies!.ms.dependencies!.debug.labels!.pruned, 'cyclic', 'Cyclic dependency is found correctly');
   });
 
   test('Parse yarn.lock with dev deps only', async (t) => {
@@ -76,7 +75,7 @@ if (getRuntimeVersion() < 6) {
     );
 
     t.false(depTree.hasDevDependencies, 'Package doesn\'t have devDependencies');
-    t.ok(depTree.dependencies['adm-zip'], 'Dependencies are reported correctly');
+    t.ok(depTree.dependencies!['adm-zip'], 'Dependencies are reported correctly');
   });
 
   test('Parse yarn.lock with devDependencies', async (t) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,11 @@
     "compilerOptions": {
         "outDir": "./dist",
         "pretty": true,
-        "target": "es5",
-        "lib": ["es5", "es2015.promise"],
+        "target": "es2015",
+        "lib": [
+            "es2015",
+            "es2016.array.include"
+        ],
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "target": "es2015",
         "lib": [
             "es2015",
-            "es2016.array.include"
+            "es2016.array.include",
+            "es2017.object"
         ],
         "module": "commonjs",
         "sourceMap": true,


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-dotnet/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

DepTree intreface has diverged from the one used in e.g. DepGraph.
The biggest difference is the dependencies keys, which is not mandatory anymore.
This change is a prereq for using depgraphs.

### Notes for the reviewer

Just carefully review tests and think of potential impact and omitted parts.

### More information

- [BST-631](https://snyksec.atlassian.net/browse/BST-631)