### PR TITLE
feat: replace for loop with Promise.all for ~1 min improvement in some cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@yarnpkg/lockfile": "^1.0.2",
     "graphlib": "^2.1.5",
     "lodash": "^4.17.14",
+    "p-map": "2.1.0",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-dotnet/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

Some projects with dense dependencies will see 1 min shaved off
`snyk test --dev`

```Tested 1897 dependencies for known issues, found 122 issues, 21409 vulnerable paths.```

*before*

```
real	3m38.727s
user	1m15.105s
sys	0m7.165s
```

*after* with promise.all() 
```
real	2m32.861s
user	1m12.167s
sys	0m5.526s
```

*after* with pMap 😱 
```
real	0m52.625s
user	0m45.793s
sys	0m2.508s
```
### More information

- [zendesk](https://snyk.zendesk.com/agent/tickets/2993)
