### PR TITLE
feat: config tree size limit for yarn and npm.

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,0 +1,4 @@
+{
+  "NPM_TREE_SIZE_LIMIT": 6.0e6,
+  "YARN_TREE_SIZE_LIMIT": 6.0e6
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,2 @@
+import { loadConfig } from 'snyk-config';
+export const config: any = loadConfig(__dirname + '../..');

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import * as graphlib from 'graphlib';
 import * as uuid from 'uuid/v4';
+import { config } from '../config';
 import { setImmediatePromise } from '../set-immediate-promise';
 
 import {
@@ -143,10 +144,9 @@ export class PackageLockParser implements LockfileParser {
 
     // number of dependencies including root one
     let treeSize = 1;
-    const treeSizeLimit = 6.0e6;
     for (const dep of topLevelDeps) {
       // tree size limit should be 6 millions.
-      if (treeSize > treeSizeLimit) {
+      if (treeSize > config.NPM_TREE_SIZE_LIMIT) {
         throw new TreeSizeLimitError();
       }
       // if any of top level dependencies is a part of cycle

--- a/lib/parsers/yarn-lock-parse.ts
+++ b/lib/parsers/yarn-lock-parse.ts
@@ -18,7 +18,9 @@ import {
   InvalidUserInputError,
   UnsupportedRuntimeError,
   OutOfSyncError,
+  TreeSizeLimitError,
 } from '../errors';
+import { config } from '../config';
 
 const EVENT_PROCESSING_CONCURRENCY = 5;
 
@@ -158,6 +160,10 @@ export class YarnLockParser implements LockfileParser {
       });
 
       for (const [subName, subVersion] of subDependencies) {
+        // tree size limit should be 6 millions.
+        if (this.treeSize > config.YARN_TREE_SIZE_LIMIT) {
+          throw new TreeSizeLimitError();
+        }
         const subDependency: DepTreeDep = {
           labels: {
             scope: tree.labels!.scope, // propagate scope label only

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "graphlib": "^2.1.5",
     "lodash": "^4.17.14",
     "p-map": "2.1.0",
+    "snyk-config": "^3.0.0",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/test/lib/yarn.test.ts
+++ b/test/lib/yarn.test.ts
@@ -2,6 +2,7 @@
 // Shebang is required, and file *has* to be executable: chmod +x file.test.js
 // See: https://github.com/tapjs/node-tap/issues/313#issuecomment-250067741
 import { test } from 'tap';
+import { config } from '../../lib/config';
 import { buildDepTreeFromFiles, getYarnWorkspacesFromFiles } from '../../lib';
 import getRuntimeVersion from '../../lib/get-node-runtime-version';
 import * as fs from 'fs';
@@ -10,6 +11,7 @@ import {
   UnsupportedRuntimeError,
   InvalidUserInputError,
   OutOfSyncError,
+  TreeSizeLimitError,
 } from '../../lib/errors';
 
 if (getRuntimeVersion() < 6) {
@@ -249,4 +251,17 @@ test('identify package.json as Not a workspace project', async (t) => {
     'package.json',
   );
   t.is(workspaces, false, 'Not a yarn workspace');
+});
+
+test('Yarn Tree size exceeds the allowed limit of 500 dependencies.', async (t) => {
+  config.YARN_TREE_SIZE_LIMIT = 500;
+  t.rejects(
+    buildDepTreeFromFiles(
+      `${__dirname}/fixtures/goof/`,
+      'package.json',
+      'yarn.lock',
+    ),
+    new TreeSizeLimitError(),
+    'Expected error is thrown',
+  );
 });


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does
config treeSizeLimit for yarn & npm

This will be improved in another pr with `configurable treeSizeLimit` tests for yarn & npm

Edit --
Side pr no longer necessary because the side pr upgrade are already applied on master so we could proceed with this