### PR TITLE
perf: event-loop-spinner with sharing

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,6 @@
 import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as _ from '@snyk/lodash';
 import {
   LockfileParser,
   Lockfile,
@@ -97,9 +96,9 @@ async function buildDepTreeFromFiles(
   }
 
   let lockFileType: LockfileType;
-  if (_.endsWith(lockFilePath, 'package-lock.json')) {
+  if (lockFilePath.endsWith('package-lock.json')) {
     lockFileType = LockfileType.npm;
-  } else if (_.endsWith(lockFilePath, 'yarn.lock')) {
+  } else if (lockFilePath.endsWith('yarn.lock')) {
     lockFileType = LockfileType.yarn;
   } else {
     throw new InvalidUserInputError(

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,4 +1,3 @@
-import * as _ from '@snyk/lodash';
 import { PackageLock } from './package-lock-parser';
 import { YarnLock } from './yarn-lock-parse';
 import { InvalidUserInputError } from '../errors';
@@ -94,7 +93,7 @@ export function getTopLevelDeps(
 ): Dep[] {
   const dependencies: Dep[] = [];
 
-  const dependenciesIterator = _.entries({
+  const dependenciesIterator = Object.entries({
     ...targetFile.dependencies,
     ...(includeDev ? targetFile.devDependencies : null),
   });

--- a/lib/parsers/yarn-lock-parse-base.ts
+++ b/lib/parsers/yarn-lock-parse-base.ts
@@ -78,7 +78,7 @@ export abstract class YarnLockParseBase<T extends YarnLockFileTypes>
       version: manifestFile.version || '',
     };
 
-    const nodeVersion = _.get(manifestFile, 'engines.node');
+    const nodeVersion = manifestFile?.engines?.node;
     if (nodeVersion) {
       _.set(depTree, 'meta.nodeVersion', nodeVersion);
     }
@@ -131,7 +131,7 @@ export abstract class YarnLockParseBase<T extends YarnLockFileTypes>
         continue;
       }
 
-      const subDependencies = _.entries({
+      const subDependencies = Object.entries({
         ...dependency.dependencies,
         ...dependency.optionalDependencies,
       });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@snyk/lodash": "^4.17.15-patch",
     "@yarnpkg/core": "^2.0.0-rc.26",
     "@yarnpkg/lockfile": "^1.1.0",
-    "event-loop-spinner": "^1.1.0",
+    "event-loop-spinner": "^2.0.0",
     "p-map": "2.1.0",
     "snyk-config": "^3.0.0",
     "source-map-support": "^0.5.7",


### PR DESCRIPTION
### What this does

The upgraded `event-loop-spinner` can better share state with other libraries, hopefully leading to less yielding.

Also found some incomplete lodash reduction lying around, may as well go in!