### PR TITLE
feat: add support for yarn workspaces pattern in workspaces.packages

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -8,13 +8,17 @@ export interface Dep {
   dev?: boolean;
 }
 
+interface WorkspacesAlternateConfig {
+  packages?: string[];
+}
+
 export interface ManifestFile {
   name: string;
   private?: string;
   engines?: {
     node?: string;
   };
-  workspaces?: string[];
+  workspaces?: string[] | WorkspacesAlternateConfig;
   dependencies?: {
     [dep: string]: string;
   };
@@ -126,7 +130,10 @@ export function getYarnWorkspaces(targetFile: string): string[] | false {
   try {
     const packageJson: ManifestFile = parseManifestFile(targetFile);
     if (!!packageJson.workspaces && !!packageJson.private) {
-      return [...packageJson.workspaces];
+      const workspacesPackages = packageJson.workspaces as string[];
+      const workspacesAlternateConfigPackages = (packageJson.workspaces as WorkspacesAlternateConfig)
+        .packages;
+      return [...(workspacesAlternateConfigPackages || workspacesPackages)];
     }
     return false;
   } catch (e) {

--- a/test/lib/fixtures/yarn-workspace-alternate-config/package.json
+++ b/test/lib/fixtures/yarn-workspace-alternate-config/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "jest",
+  "devDependencies": {
+    "chalk": "^2.0.1"
+  },
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  }
+}

--- a/test/lib/yarn-workflows.test.ts
+++ b/test/lib/yarn-workflows.test.ts
@@ -16,6 +16,14 @@ test('Identify package.json as a yarn workspace', async (t) => {
   );
 });
 
+test('Identify package.json as a yarn workspace when using alternate configuration format', async (t) => {
+  const workspaces = getYarnWorkspacesFromFiles(
+    `${__dirname}/fixtures/yarn-workspace-alternate-config/`,
+    'package.json',
+  );
+  t.deepEqual(workspaces, ['packages/*'], 'Workspaces identified as expected');
+});
+
 test('identify package.json as Not a workspace project', async (t) => {
   const workspaces = getYarnWorkspacesFromFiles(
     `${__dirname}/fixtures/external-tarball/`,


### PR DESCRIPTION
resolves https://github.com/snyk/snyk/issues/1251

- [X] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [X] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [X] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

This PR addresses https://github.com/snyk/snyk/issues/1251, adding support for the alternate Yarn Workspaces configuration in `package.json` at `workspaces.packages`
```
{
  "name": "my-workspace",
  "private": true,
  "workspaces": {
    "packages": [ "packages/*" ]
  }
}
```