### PR TITLE
fix: update dep-graph to use upstream lodash

### DIFF
--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -2,7 +2,7 @@ import * as _cloneDeep from 'lodash.clonedeep';
 import * as _isEmpty from 'lodash.isempty';
 import * as _set from 'lodash.set';
 import * as _toPairs from 'lodash.topairs';
-import * as graphlib from '@snyk/graphlib';
+import * as graphlib from 'graphlib';
 import * as uuid from 'uuid/v4';
 import { config } from '../config';
 import { eventLoopSpinner } from 'event-loop-spinner';

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "homepage": "https://github.com/snyk/nodejs-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/graphlib": "2.1.9-patch",
+    "graphlib": "2.1.8",
     "@yarnpkg/lockfile": "^1.1.0",
     "event-loop-spinner": "^2.0.0",
     "got": "11.4.0",


### PR DESCRIPTION
Updating dep-graph to prevent including our lodash fork.
