### PR TITLE
fix: use snyk-config version v4.0.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash.set": "^4.3.2",
     "lodash.topairs": "^4.3.0",
     "p-map": "2.1.0",
-    "snyk-config": "^3.0.0",
+    "snyk-config": "^4.0.0-rc.2",
     "tslib": "^1.9.3",
     "uuid": "^8.3.0",
     "yaml": "^1.9.2"


### PR DESCRIPTION
Updates to the new snyk-config version that should get shipped with the CLI first.

Requirement for https://github.com/snyk/snyk/pull/1524
Follow up to the https://github.com/snyk/config/pull/43