### PR TITLE
feat: support dep graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 .eslintcache
 *.log
 /package-lock.json
+.idea

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 Snyk helps you find, fix and monitor for known vulnerabilities in your dependencies, both on an ad hoc basis and as part of your CI (Build) system.
 
 ## Snyk Node.js Lockfile Parser
-Given a package.json & package-lock.json builds a dep tree
+Given a package.json & package-lock.json builds a dep tree or a dep graph

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -1,0 +1,137 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { InvalidUserInputError, UnsupportedError } from './errors';
+import {
+  Lockfile,
+  LockfileParser,
+  LockfileType,
+  ManifestFile,
+  parseManifestFile,
+} from './parsers';
+import { PackageLockParser } from './parsers/package-lock-parser';
+import { YarnLockParser } from './parsers/yarn-lock-parse';
+
+export function parseManifestAndLock(
+  manifestFileContents: string,
+  lockFileContents: string,
+  lockfileParser: LockfileParser,
+  defaultManifestFileName: string = 'package.json',
+): {
+  manifestFile: ManifestFile;
+  lockFile: Lockfile;
+} {
+  const manifestFile: ManifestFile = parseManifestFile(manifestFileContents);
+  if (!manifestFile.name) {
+    manifestFile.name = path.isAbsolute(defaultManifestFileName)
+      ? path.basename(defaultManifestFileName)
+      : defaultManifestFileName;
+  }
+
+  const lockFile: Lockfile = lockfileParser.parseLockFile(lockFileContents);
+  return { manifestFile, lockFile };
+}
+
+export function getLockFileParser(
+  lockFileContents: string,
+  lockfileType?: LockfileType,
+): LockfileParser {
+  if (!lockfileType) {
+    lockfileType = LockfileType.npm;
+  } else if (lockfileType === LockfileType.yarn) {
+    lockfileType = getYarnLockfileType(lockFileContents);
+  }
+
+  switch (lockfileType) {
+    case LockfileType.npm:
+      return new PackageLockParser();
+    case LockfileType.yarn:
+      return new YarnLockParser();
+    case LockfileType.yarn2:
+      throw new UnsupportedError(
+        'Yarn2 support has been temporarily removed to support Node.js versions 8.x.x',
+      );
+    /**
+     * Removing yarn 2 support as this breaks support for yarn with Node.js 8
+     * See: https://github.com/snyk/snyk/issues/1270
+     *
+     * Uncomment following code once Snyk stops Node.js 8 support
+     * // parsing yarn.lock is supported for Node.js v10 and higher
+     * if (getRuntimeVersion() >= 10) {
+     *  lockfileParser = new Yarn2LockParser();
+     *  } else {
+     *   throw new UnsupportedRuntimeError(
+     *     'Parsing `yarn.lock` is not ' +
+     *       'supported on Node.js version less than 10. Please upgrade your ' +
+     *       'Node.js environment or use `package-lock.json`',
+     *   );
+     * }
+     * break;
+     */
+    default:
+      throw new InvalidUserInputError(
+        'Unsupported lockfile type ' +
+          `${lockfileType} provided. Only 'npm' or 'yarn' is currently ` +
+          'supported.',
+      );
+  }
+}
+
+export function getFilesContent(
+  root: string,
+  manifestFilePath: string,
+  lockFilePath: string,
+) {
+  if (!root || !manifestFilePath || !lockFilePath) {
+    throw new Error('Missing required parameters for buildDepTreeFromFiles()');
+  }
+
+  const manifestFileFullPath = path.resolve(root, manifestFilePath);
+  const lockFileFullPath = path.resolve(root, lockFilePath);
+
+  if (!fs.existsSync(manifestFileFullPath)) {
+    throw new InvalidUserInputError(
+      'Target file package.json not found at ' +
+        `location: ${manifestFileFullPath}`,
+    );
+  }
+  if (!fs.existsSync(lockFileFullPath)) {
+    throw new InvalidUserInputError(
+      'Lockfile not found at location: ' + lockFileFullPath,
+    );
+  }
+
+  const manifestFileContents = fs.readFileSync(manifestFileFullPath, 'utf-8');
+  const lockFileContents = fs.readFileSync(lockFileFullPath, 'utf-8');
+
+  let lockFileType: LockfileType;
+  if (lockFilePath.endsWith('package-lock.json')) {
+    lockFileType = LockfileType.npm;
+  } else if (lockFilePath.endsWith('yarn.lock')) {
+    lockFileType = getYarnLockfileType(lockFileContents, root, lockFilePath);
+  } else {
+    throw new InvalidUserInputError(
+      `Unknown lockfile ${lockFilePath}. ` +
+        'Please provide either package-lock.json or yarn.lock.',
+    );
+  }
+  return { manifestFileContents, lockFileContents, lockFileType };
+}
+
+function getYarnLockfileType(
+  lockFileContents: string,
+  root?: string,
+  lockFilePath?: string,
+): LockfileType {
+  if (
+    lockFileContents.includes('__metadata') ||
+    (root &&
+      lockFilePath &&
+      fs.existsSync(
+        path.resolve(root, lockFilePath.replace('yarn.lock', '.yarnrc.yml')),
+      ))
+  ) {
+    return LockfileType.yarn2;
+  } else {
+    return LockfileType.yarn;
+  }
+}

--- a/lib/dep-graph.ts
+++ b/lib/dep-graph.ts
@@ -1,0 +1,49 @@
+import { LockfileType } from './parsers';
+import { DepGraph } from '@snyk/dep-graph';
+import {
+  getFilesContent,
+  getLockFileParser,
+  parseManifestAndLock,
+} from './common';
+
+export async function buildDepGraph(
+  manifestFileContents: string,
+  lockFileContents: string,
+  includeDev = false,
+  lockfileType?: LockfileType,
+  strict: boolean = true,
+  defaultManifestFileName?: string,
+): Promise<DepGraph> {
+  const lockfileParser = getLockFileParser(lockFileContents, lockfileType);
+  const { manifestFile, lockFile } = parseManifestAndLock(
+    manifestFileContents,
+    lockFileContents,
+    lockfileParser,
+    defaultManifestFileName,
+  );
+
+  return lockfileParser.getDepGraph(manifestFile, lockFile, includeDev, strict);
+}
+
+export async function buildDepGraphFromFiles(
+  root: string,
+  manifestFilePath: string,
+  lockFilePath: string,
+  includeDev = false,
+  strict = true,
+): Promise<DepGraph> {
+  const {
+    manifestFileContents,
+    lockFileContents,
+    lockFileType,
+  } = getFilesContent(root, manifestFilePath, lockFilePath);
+
+  return await buildDepGraph(
+    manifestFileContents,
+    lockFileContents,
+    includeDev,
+    lockFileType,
+    strict,
+    manifestFilePath,
+  );
+}

--- a/lib/dep-tree.ts
+++ b/lib/dep-tree.ts
@@ -1,0 +1,53 @@
+import { LockfileType, PkgTree } from './parsers';
+import {
+  getFilesContent,
+  getLockFileParser,
+  parseManifestAndLock,
+} from './common';
+
+export async function buildDepTree(
+  manifestFileContents: string,
+  lockFileContents: string,
+  includeDev = false,
+  lockfileType?: LockfileType,
+  strict: boolean = true,
+  defaultManifestFileName?: string,
+): Promise<PkgTree> {
+  const lockfileParser = getLockFileParser(lockFileContents, lockfileType);
+  const { manifestFile, lockFile } = parseManifestAndLock(
+    manifestFileContents,
+    lockFileContents,
+    lockfileParser,
+    defaultManifestFileName,
+  );
+
+  return lockfileParser.getDependencyTree(
+    manifestFile,
+    lockFile,
+    includeDev,
+    strict,
+  );
+}
+
+export async function buildDepTreeFromFiles(
+  root: string,
+  manifestFilePath: string,
+  lockFilePath: string,
+  includeDev = false,
+  strict = true,
+): Promise<PkgTree> {
+  const {
+    manifestFileContents,
+    lockFileContents,
+    lockFileType,
+  } = getFilesContent(root, manifestFilePath, lockFilePath);
+
+  return await buildDepTree(
+    manifestFileContents,
+    lockFileContents,
+    includeDev,
+    lockFileType,
+    strict,
+    manifestFilePath,
+  );
+}

--- a/lib/get-node-id.ts
+++ b/lib/get-node-id.ts
@@ -1,0 +1,15 @@
+type NodeId = string;
+export type NodeIdMap = Record<NodeId, number>;
+
+export function getNodeId(
+  nodeIdMap: NodeIdMap,
+  name: string,
+  version: string = '',
+) {
+  const nodeId = `${name}@${version}`;
+  if (!nodeIdMap[nodeId]) {
+    nodeIdMap[nodeId] = 1;
+    return nodeId;
+  }
+  return `${nodeId}|${nodeIdMap[nodeId]++}`;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,8 @@ import {
 
 export { buildDepTree, buildDepTreeFromFiles } from './dep-tree';
 
+export { buildDepGraph, buildDepGraphFromFiles } from './dep-graph';
+
 export {
   getYarnWorkspacesFromFiles,
   getYarnWorkspaces,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,29 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import {
-  LockfileParser,
-  Lockfile,
-  ManifestFile,
-  PkgTree,
-  Scope,
-  parseManifestFile,
-  LockfileType,
-  getYarnWorkspaces,
-} from './parsers';
-import { PackageLockParser } from './parsers/package-lock-parser';
-import { YarnLockParser } from './parsers/yarn-lock-parse';
+import { getYarnWorkspaces, LockfileType, PkgTree, Scope } from './parsers';
 // import { Yarn2LockParser } from './parsers/yarn2-lock-parse';
 // import getRuntimeVersion from './get-node-runtime-version';
 import {
-  UnsupportedRuntimeError,
   InvalidUserInputError,
   OutOfSyncError,
-  UnsupportedError,
+  UnsupportedRuntimeError,
 } from './errors';
 
+export { buildDepTree, buildDepTreeFromFiles } from './dep-tree';
+
 export {
-  buildDepTree,
-  buildDepTreeFromFiles,
   getYarnWorkspacesFromFiles,
   getYarnWorkspaces,
   PkgTree,
@@ -33,124 +21,6 @@ export {
   InvalidUserInputError,
   OutOfSyncError,
 };
-
-async function buildDepTree(
-  manifestFileContents: string,
-  lockFileContents: string,
-  includeDev = false,
-  lockfileType?: LockfileType,
-  strict: boolean = true,
-  defaultManifestFileName: string = 'package.json',
-): Promise<PkgTree> {
-  if (!lockfileType) {
-    lockfileType = LockfileType.npm;
-  } else if (lockfileType === LockfileType.yarn) {
-    lockfileType = getYarnLockfileType(lockFileContents);
-  }
-
-  let lockfileParser: LockfileParser;
-  switch (lockfileType) {
-    case LockfileType.npm:
-      lockfileParser = new PackageLockParser();
-      break;
-    case LockfileType.yarn:
-      lockfileParser = new YarnLockParser();
-      break;
-    case LockfileType.yarn2:
-      throw new UnsupportedError(
-        'Yarn2 support has been temporarily removed to support Node.js versions 8.x.x',
-      );
-    /**
-     * Removing yarn 2 support as this breaks support for yarn with Node.js 8
-     * See: https://github.com/snyk/snyk/issues/1270
-     *
-     * Uncomment following code once Snyk stops Node.js 8 support
-     * // parsing yarn.lock is supported for Node.js v10 and higher
-     * if (getRuntimeVersion() >= 10) {
-     *  lockfileParser = new Yarn2LockParser();
-     *  } else {
-     *   throw new UnsupportedRuntimeError(
-     *     'Parsing `yarn.lock` is not ' +
-     *       'supported on Node.js version less than 10. Please upgrade your ' +
-     *       'Node.js environment or use `package-lock.json`',
-     *   );
-     * }
-     * break;
-     */
-    default:
-      throw new InvalidUserInputError(
-        'Unsupported lockfile type ' +
-          `${lockfileType} provided. Only 'npm' or 'yarn' is currently ` +
-          'supported.',
-      );
-  }
-
-  const manifestFile: ManifestFile = parseManifestFile(manifestFileContents);
-  if (!manifestFile.name) {
-    manifestFile.name = path.isAbsolute(defaultManifestFileName)
-      ? path.basename(defaultManifestFileName)
-      : defaultManifestFileName;
-  }
-
-  const lockFile: Lockfile = lockfileParser.parseLockFile(lockFileContents);
-  return lockfileParser.getDependencyTree(
-    manifestFile,
-    lockFile,
-    includeDev,
-    strict,
-  );
-}
-
-async function buildDepTreeFromFiles(
-  root: string,
-  manifestFilePath: string,
-  lockFilePath: string,
-  includeDev = false,
-  strict = true,
-): Promise<PkgTree> {
-  if (!root || !manifestFilePath || !lockFilePath) {
-    throw new Error('Missing required parameters for buildDepTreeFromFiles()');
-  }
-
-  const manifestFileFullPath = path.resolve(root, manifestFilePath);
-  const lockFileFullPath = path.resolve(root, lockFilePath);
-
-  if (!fs.existsSync(manifestFileFullPath)) {
-    throw new InvalidUserInputError(
-      'Target file package.json not found at ' +
-        `location: ${manifestFileFullPath}`,
-    );
-  }
-  if (!fs.existsSync(lockFileFullPath)) {
-    throw new InvalidUserInputError(
-      'Lockfile not found at location: ' + lockFileFullPath,
-    );
-  }
-
-  const manifestFileContents = fs.readFileSync(manifestFileFullPath, 'utf-8');
-  const lockFileContents = fs.readFileSync(lockFileFullPath, 'utf-8');
-
-  let lockFileType: LockfileType;
-  if (lockFilePath.endsWith('package-lock.json')) {
-    lockFileType = LockfileType.npm;
-  } else if (lockFilePath.endsWith('yarn.lock')) {
-    lockFileType = getYarnLockfileType(lockFileContents, root, lockFilePath);
-  } else {
-    throw new InvalidUserInputError(
-      `Unknown lockfile ${lockFilePath}. ` +
-        'Please provide either package-lock.json or yarn.lock.',
-    );
-  }
-
-  return await buildDepTree(
-    manifestFileContents,
-    lockFileContents,
-    includeDev,
-    lockFileType,
-    strict,
-    manifestFilePath,
-  );
-}
 
 function getYarnWorkspacesFromFiles(
   root,
@@ -171,23 +41,4 @@ function getYarnWorkspacesFromFiles(
   const manifestFileContents = fs.readFileSync(manifestFileFullPath, 'utf-8');
 
   return getYarnWorkspaces(manifestFileContents);
-}
-
-function getYarnLockfileType(
-  lockFileContents: string,
-  root?: string,
-  lockFilePath?: string,
-): LockfileType {
-  if (
-    lockFileContents.includes('__metadata') ||
-    (root &&
-      lockFilePath &&
-      fs.existsSync(
-        path.resolve(root, lockFilePath.replace('yarn.lock', '.yarnrc.yml')),
-      ))
-  ) {
-    return LockfileType.yarn2;
-  } else {
-    return LockfileType.yarn;
-  }
 }

--- a/lib/parsers/get-package-lock-dep-graph.ts
+++ b/lib/parsers/get-package-lock-dep-graph.ts
@@ -1,0 +1,182 @@
+import {
+  Dep,
+  getTopLevelDeps,
+  Lockfile,
+  LockfileType,
+  ManifestFile,
+  Scope,
+} from './index';
+import { InvalidUserInputError, OutOfSyncError } from '../errors';
+import { DepGraph, DepGraphBuilder } from '@snyk/dep-graph';
+import {
+  PackageLock,
+  PackageLockDep,
+  PackageLockDeps,
+} from './package-lock-parser';
+import { eventLoopSpinner } from 'event-loop-spinner';
+import { getNodeId, NodeIdMap } from '../get-node-id';
+
+type NodeId = string;
+type MemoizationMap = Map<PackageLockDep, NodeId>;
+
+export async function getPackageLockDepGraph(
+  manifestFile: ManifestFile,
+  lockfile: Lockfile,
+  includeDev = false,
+  strict = true,
+): Promise<DepGraph> {
+  if (lockfile.type !== LockfileType.npm) {
+    throw new InvalidUserInputError(
+      'Unsupported lockfile provided. Please ' + 'provide `package-lock.json`.',
+    );
+  }
+  const packageLock = lockfile as PackageLock;
+
+  linkRequiresToDependencies(packageLock.dependencies || {}, [packageLock]);
+
+  const rootPkgInfo = {
+    name: manifestFile.name,
+    version: manifestFile.version,
+  };
+
+  const pkgManager = {
+    name: LockfileType.npm,
+  };
+
+  const depGraphBuilder = new DepGraphBuilder(pkgManager, rootPkgInfo);
+
+  const topLevelDeps: Dep[] = getTopLevelDeps(manifestFile, includeDev);
+
+  const devMemoizationMap: MemoizationMap = new Map();
+  const prodMemoizationMap: MemoizationMap = new Map();
+  const nodeIdMap: NodeIdMap = {};
+
+  for (const dep of topLevelDeps) {
+    const dependency = packageLock.dependencies?.[dep.name];
+    if (/^file:/.test(dep.version)) {
+      addTopLevelDepNodeToGraph(depGraphBuilder, nodeIdMap, dep);
+      continue;
+    }
+
+    const version = dependency?.version;
+    if (strict && !version) {
+      throw new OutOfSyncError(dep.name, LockfileType.npm);
+    }
+    const nodeId = addTopLevelDepNodeToGraph(
+      depGraphBuilder,
+      nodeIdMap,
+      dep,
+      version,
+    );
+    const isDev = !!dep.dev;
+
+    await addDepsToGraph(
+      depGraphBuilder,
+      dependency?.linkedRequires,
+      isDev,
+      nodeIdMap,
+      isDev ? devMemoizationMap : prodMemoizationMap,
+      nodeId,
+    );
+  }
+
+  return depGraphBuilder.build();
+}
+
+/** This function will add direct dependencies to the graph (aka "top level" dep) */
+function addTopLevelDepNodeToGraph(
+  depGraphBuilder: DepGraphBuilder,
+  nodeIdMap: NodeIdMap,
+  dep: Dep,
+  version: string = dep.version,
+) {
+  const nodeId = getNodeId(nodeIdMap, dep.name, version);
+  depGraphBuilder.addPkgNode({ name: dep.name, version }, nodeId, {
+    labels: { scope: dep.dev ? Scope.dev : Scope.prod },
+  });
+  depGraphBuilder.connectDep(depGraphBuilder.rootNodeId, nodeId);
+  return nodeId;
+}
+
+/*
+ * This function will recursively iterate over a package-lock data structure
+ * and will replace the `require` property with a `linkedRequires` that will
+ * connect each 'require' dependency to it's actual PackageLockDep
+ * (so it will be easier to iterate over later)
+ */
+function linkRequiresToDependencies(
+  lockfileDeps: PackageLockDeps,
+  ancestors: PackageLockDep[] = [],
+): void {
+  for (const dep of Object.values(lockfileDeps)) {
+    const currentAncestors = [dep].concat(ancestors);
+    if (dep.requires) {
+      dep.linkedRequires = {};
+      for (const key of Object.keys(dep.requires)) {
+        dep.linkedRequires[key] = find(key, currentAncestors);
+      }
+      delete dep.requires;
+    }
+
+    if (dep.dependencies) {
+      linkRequiresToDependencies(dep.dependencies, currentAncestors);
+    }
+  }
+}
+
+function find(key: string, ancestors: PackageLockDep[] = []): PackageLockDep {
+  for (const dep of ancestors) {
+    if (dep.dependencies?.[key]) {
+      return dep.dependencies[key];
+    }
+  }
+  throw new Error('');
+}
+
+/*
+ * This function will recursively iterate over the "linked" version of the package-lock (after linkRequiresToDependencies)
+ * and will add each dependency to the graph.
+ * It uses a memoization map inorder not to re-iterate on visited dependencies
+ * It uses 'nodeIdMap' inorder to create different nodeIds for different dependencies for the same version
+ * (i.e. in a package-lock file you might get the same package with the same version but with different dependencies)
+ * */
+async function addDepsToGraph(
+  depGraphBuilder: DepGraphBuilder,
+  lockDeps: PackageLockDeps = {},
+  isDev: boolean,
+  nodeIdMap: NodeIdMap,
+  memoizationMap: MemoizationMap,
+  parentNodeId: string,
+): Promise<void> {
+  for (const [depName, dep] of Object.entries(lockDeps)) {
+    const nodeId = getNodeId(nodeIdMap, depName, dep.version);
+    if (memoizationMap.has(dep)) {
+      depGraphBuilder.connectDep(parentNodeId, memoizationMap.get(dep)!);
+      continue;
+    }
+
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+
+    depGraphBuilder.addPkgNode(
+      { name: depName, version: dep.version },
+      nodeId,
+      { labels: { scope: isDev ? Scope.dev : Scope.prod } },
+    );
+
+    depGraphBuilder.connectDep(parentNodeId, nodeId);
+    memoizationMap.set(dep, nodeId);
+
+    if (dep.linkedRequires) {
+      await addDepsToGraph(
+        depGraphBuilder,
+        dep.linkedRequires,
+        isDev,
+        nodeIdMap,
+        memoizationMap,
+        nodeId,
+      );
+    }
+  }
+}

--- a/lib/parsers/get-yarn-lock-dep-graph.ts
+++ b/lib/parsers/get-yarn-lock-dep-graph.ts
@@ -1,0 +1,158 @@
+import { Dep, getTopLevelDeps, LockfileType, ManifestFile } from './index';
+import { DepGraphBuilder } from '@snyk/dep-graph';
+import * as pMap from 'p-map';
+import { YarnLock } from './yarn-lock-parse';
+import { eventLoopSpinner } from 'event-loop-spinner';
+import { OutOfSyncError } from '../errors';
+import {
+  EVENT_PROCESSING_CONCURRENCY,
+  YarnLockDep,
+} from './yarn-lock-parse-base';
+import { getNodeId, NodeIdMap } from '../get-node-id';
+
+type VersionHolder = YarnLockDep | { version: string };
+type NodeId = string;
+type QueueItem = {
+  parentNodeId: NodeId;
+  childName: string;
+  childVersionSpec: string;
+};
+type MemoizationMap = Map<VersionHolder, NodeId>;
+
+export async function getYarnLockDepGraph(
+  manifestFile: ManifestFile,
+  yarnLock: YarnLock,
+  includeDev = false,
+  strict = true,
+) {
+  const rootPkgInfo = {
+    name: manifestFile.name,
+    version: manifestFile.version,
+  };
+
+  const pkgManager = {
+    name: 'yarn',
+    version: yarnLock.type === LockfileType.yarn ? '1' : '2',
+  };
+  const depGraphBuilder = new DepGraphBuilder(pkgManager, rootPkgInfo);
+  const prodMemoizationMap: MemoizationMap = new Map();
+  const devMemoizationMap: MemoizationMap = new Map();
+  const nodeIdMap: NodeIdMap = {};
+
+  const topLevelDeps: Dep[] = getTopLevelDeps(manifestFile, includeDev);
+
+  await pMap(
+    topLevelDeps,
+    (dep) =>
+      addTopLevelDepChainToGraph(
+        depGraphBuilder,
+        dep.name,
+        dep.version,
+        yarnLock,
+        strict,
+        !!dep.dev,
+        dep.dev ? devMemoizationMap : prodMemoizationMap,
+        nodeIdMap,
+      ),
+    { concurrency: EVENT_PROCESSING_CONCURRENCY },
+  );
+
+  return depGraphBuilder.build();
+}
+
+/*
+ * This function takes a top level dependency name and verion and will iterate
+ * over the YarnLock object and add all nodes to the graph
+ * */
+async function addTopLevelDepChainToGraph(
+  depGraphBuilder: DepGraphBuilder,
+  depName: string,
+  depRange: string,
+  yarnLock: YarnLock,
+  strict: boolean,
+  isDev: boolean,
+  memoizationMap: MemoizationMap,
+  nodeIdMap: NodeIdMap,
+): Promise<void> {
+  if (/^file:/.test(depRange)) {
+    addNodeToGraph(depName, { version: depRange }, depGraphBuilder.rootNodeId);
+    return;
+  }
+
+  const queue: QueueItem[] = [
+    {
+      parentNodeId: depGraphBuilder.rootNodeId,
+      childName: depName,
+      childVersionSpec: depRange,
+    },
+  ];
+
+  while (queue.length > 0) {
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+
+    const { parentNodeId, childName, childVersionSpec } = queue.pop()!;
+    const childLockKey = `${childName}@${childVersionSpec}`;
+    const dependencyFromLockFile = yarnLock.object[childLockKey];
+    if (!dependencyFromLockFile) {
+      if (strict) {
+        throw new OutOfSyncError(childName, LockfileType.yarn);
+      }
+      addNodeToGraph(childName, { version: childVersionSpec }, parentNodeId, {
+        missingLockFileEntry: 'true',
+      });
+      continue;
+    }
+
+    const [nodeExists, childNodeId] = addNodeToGraph(
+      childName,
+      dependencyFromLockFile,
+      parentNodeId,
+    );
+
+    if (nodeExists) continue;
+
+    const subDependencies = Object.entries({
+      ...dependencyFromLockFile.dependencies,
+      ...dependencyFromLockFile.optionalDependencies,
+    });
+
+    queue.push(
+      ...subDependencies.map(([name, versionSpecifier]) => ({
+        parentNodeId: childNodeId,
+        childName: name,
+        childVersionSpec: versionSpecifier,
+      })),
+    );
+  }
+
+  /*
+   * This function will add a node to the graph and will connect it to it's parent
+   * If the node for this dependency already exists, it will only connect it to the graph
+   * */
+  function addNodeToGraph(
+    name,
+    yarnLockDep: VersionHolder,
+    parentNodeId,
+    labels: any = {},
+  ): [boolean, string] {
+    const nodeExists = memoizationMap.has(yarnLockDep);
+    if (nodeExists) {
+      const nodeId = memoizationMap.get(yarnLockDep)!;
+      depGraphBuilder.connectDep(parentNodeId, nodeId);
+      return [nodeExists, nodeId];
+    }
+
+    const nodeId = getNodeId(nodeIdMap, name, yarnLockDep.version);
+    labels.scope = isDev ? 'dev' : 'prod';
+    depGraphBuilder.addPkgNode(
+      { name, version: yarnLockDep.version! },
+      nodeId,
+      { labels },
+    );
+    depGraphBuilder.connectDep(parentNodeId, nodeId);
+    memoizationMap.set(yarnLockDep, nodeId);
+    return [nodeExists, nodeId];
+  }
+}

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -1,6 +1,7 @@
 import { PackageLock } from './package-lock-parser';
 import { YarnLock } from './yarn-lock-parse';
 import { InvalidUserInputError } from '../errors';
+import { DepGraph } from '@snyk/dep-graph';
 // import { Yarn2Lock } from './yarn2-lock-parse';
 
 export interface Dep {
@@ -80,6 +81,12 @@ export interface LockfileParser {
     includeDev?: boolean,
     strict?: boolean,
   ) => Promise<PkgTree>;
+  getDepGraph: (
+    manifestFile: ManifestFile,
+    lockfile: Lockfile,
+    includeDev?: boolean,
+    strict?: boolean,
+  ) => Promise<DepGraph>;
 }
 
 export type Lockfile = PackageLock | YarnLock; // | Yarn2Lock;

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -24,6 +24,8 @@ import {
   OutOfSyncError,
   TreeSizeLimitError,
 } from '../errors';
+import { DepGraph } from '@snyk/dep-graph';
+import { getPackageLockDepGraph } from './get-package-lock-dep-graph';
 
 export interface PackageLock {
   name: string;
@@ -42,6 +44,7 @@ export interface PackageLockDep {
   requires?: {
     [depName: string]: string;
   };
+  linkedRequires?: Record<string, PackageLockDep>;
   dependencies?: PackageLockDeps;
   dev?: boolean;
 }
@@ -459,5 +462,14 @@ export class PackageLockParser implements LockfileParser {
     flattenLockfileRec(lockfile.dependencies || {}, []);
 
     return depMap;
+  }
+
+  public async getDepGraph(
+    manifestFile: ManifestFile,
+    lockfile: Lockfile,
+    includeDev = false,
+    strict = true,
+  ): Promise<DepGraph> {
+    return getPackageLockDepGraph(manifestFile, lockfile, includeDev, strict);
   }
 }

--- a/lib/parsers/yarn-lock-parse-base.ts
+++ b/lib/parsers/yarn-lock-parse-base.ts
@@ -20,8 +20,11 @@ import {
   TreeSizeLimitError,
 } from '../errors';
 import { config } from '../config';
+import { DepGraph } from '@snyk/dep-graph';
+import { getYarnLockDepGraph } from './get-yarn-lock-dep-graph';
+import { YarnLock } from './yarn-lock-parse';
 
-const EVENT_PROCESSING_CONCURRENCY = 5;
+export const EVENT_PROCESSING_CONCURRENCY = 5;
 
 export type YarnLockFileTypes = LockfileType.yarn | LockfileType.yarn2;
 
@@ -190,5 +193,25 @@ export abstract class YarnLockParseBase<T extends YarnLockFileTypes>
     if (eventLoopSpinner.isStarving()) {
       await eventLoopSpinner.spin();
     }
+  }
+
+  public async getDepGraph(
+    manifestFile: ManifestFile,
+    yarnLock: Lockfile,
+    includeDev = false,
+    strict = true,
+  ): Promise<DepGraph> {
+    if (yarnLock.type !== this.type) {
+      throw new InvalidUserInputError(
+        'Unsupported lockfile provided. Please provide `yarn.lock`.',
+      );
+    }
+
+    return await getYarnLockDepGraph(
+      manifestFile,
+      yarnLock as YarnLock,
+      includeDev,
+      strict,
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "homepage": "https://github.com/snyk/nodejs-lockfile-parser#readme",
   "dependencies": {
+    "@snyk/dep-graph": "^1.23.1",
     "@snyk/graphlib": "2.1.9-patch.3",
     "@yarnpkg/lockfile": "^1.1.0",
     "event-loop-spinner": "^2.0.0",

--- a/test/lib/dep-graph-compare.test.ts
+++ b/test/lib/dep-graph-compare.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'tap';
+import { buildDepGraphFromFiles, buildDepTreeFromFiles } from '../../lib';
+import { depTreeToGraph } from '@snyk/dep-graph/dist/legacy';
+
+const fixtures = [
+  { name: 'dev-deps-only', npm: true, yarn: true },
+  { name: 'empty-dev-deps', npm: true, yarn: true },
+  { name: 'external-tarball', npm: true, yarn: true },
+  { name: 'git-ssh-url-deps', npm: true, yarn: true },
+  { name: 'goof', npm: true, yarn: true },
+  { name: 'missing-deps', npm: true, yarn: true },
+  { name: 'missing-name', npm: true, yarn: true },
+  { name: 'package-json-without-name', npm: true },
+  { name: 'package-repeated-in-manifest', npm: true, yarn: true },
+  { name: 'simple-test', npm: true },
+  { name: 'undefined-deps', npm: true },
+  { name: 'file-as-version', npm: true, yarn: true },
+  { name: 'invalid-files', error: true },
+  { name: 'missing-deps-in-lock', error: true },
+  { name: 'out-of-sync', error: true },
+  { name: 'out-of-sync-tree', error: true },
+];
+
+fixtures.forEach((fixture) => {
+  if (fixture.npm) compareLock(fixture, 'package-lock.json', 'npm');
+  if (fixture.yarn) compareLock(fixture, 'yarn1/yarn.lock', 'yarn');
+  if (fixture.error) {
+    comparePackageLockError(fixture, 'package-lock.json', 'npm');
+    comparePackageLockError(fixture, 'yarn1/yarn.lock', 'yarn');
+  }
+});
+
+function compareLock({ name }, lockFilePath, type) {
+  test(`${type} - compare dep tree and dep graph results - ${name}`, async (t) => {
+    for (const includeDev of [true, false]) {
+      const { depGraphFromTree, depGraph } = await generateDepGraphs(
+        name,
+        lockFilePath,
+        includeDev,
+        type,
+      );
+
+      t.ok(depGraph.equals(depGraphFromTree), `includeDev=${includeDev}`);
+    }
+  });
+}
+
+function comparePackageLockError({ name }, lockFilePath, type) {
+  test(`${type} - compare errors dep tree and dep graph results - ${name}`, async (t) => {
+    for (const includeDev of [true, false]) {
+      const {
+        depGraphFromTree: fromTreeError,
+        depGraph: depGraphError,
+      } = await generateDepGraphs(name, lockFilePath, includeDev, type);
+
+      t.deepEqual(
+        [depGraphError.code, depGraphError.name, depGraphError.message],
+        [fromTreeError.code, fromTreeError.name, fromTreeError.message],
+        `fixture "${name}" error when includeDev=${includeDev}`,
+      );
+    }
+  });
+}
+
+async function generateDepGraphs(
+  name,
+  lockFilePath,
+  includeDev: boolean,
+  type,
+) {
+  const root = `${__dirname}/fixtures/${name}/`;
+  const manifestFilePath = 'package.json';
+
+  const [depGraphFromTree, depGraph] = await Promise.all([
+    buildDepTreeFromFiles(root, manifestFilePath, lockFilePath, includeDev)
+      .then((depTree) => depTreeToGraph(depTree, type))
+      .catch((err) => err),
+    buildDepGraphFromFiles(
+      root,
+      manifestFilePath,
+      lockFilePath,
+      includeDev,
+    ).catch((err) => err),
+  ]);
+  return { depGraphFromTree, depGraph };
+}


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

Adds support for parsing `package-lock` and `yarn.lock` into [DepGraph](https://github.com/snyk/dep-graph)