### PR TITLE
BREAKING CHANGE: remove tree size limit

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,4 +1,1 @@
-{
-  "NPM_TREE_SIZE_LIMIT": 6.0e6,
-  "YARN_TREE_SIZE_LIMIT": 6.0e6
-}
+{}

--- a/lib/parsers/lock-parser-base.ts
+++ b/lib/parsers/lock-parser-base.ts
@@ -18,11 +18,7 @@ import {
   PkgTree,
   Scope,
 } from './';
-import {
-  InvalidUserInputError,
-  OutOfSyncError,
-  TreeSizeLimitError,
-} from '../errors';
+import { InvalidUserInputError, OutOfSyncError } from '../errors';
 
 export interface PackageLockDeps {
   [depName: string]: PackageLockDep;
@@ -57,7 +53,7 @@ interface EdgeDirection {
 export abstract class LockParserBase implements LockfileParser {
   protected pathDelimiter = '|';
 
-  constructor(protected type: LockfileType, protected treeSizeLimit: number) {}
+  constructor(protected type: LockfileType) {}
 
   public abstract parseLockFile(lockFileContents: string): Lockfile;
 
@@ -129,9 +125,6 @@ export abstract class LockParserBase implements LockfileParser {
     // number of dependencies including root one
     let treeSize = 1;
     for (const dep of topLevelDeps) {
-      if (treeSize > this.treeSizeLimit) {
-        throw new TreeSizeLimitError();
-      }
       // if any of top level dependencies is a part of cycle
       // it now has a different item in the map
       const key = this.getDepTreeKey(dep);

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -1,7 +1,6 @@
 import { Dep, Lockfile, LockfileType, Scope } from './index';
 import { InvalidUserInputError } from '../errors';
 import { DepMap, DepMapItem, LockParserBase } from './lock-parser-base';
-import { config } from '../config';
 
 export interface PackageLock {
   name: string;
@@ -26,7 +25,7 @@ export interface PackageLockDep {
 
 export class PackageLockParser extends LockParserBase {
   constructor() {
-    super(LockfileType.npm, config.NPM_TREE_SIZE_LIMIT);
+    super(LockfileType.npm);
   }
 
   public parseLockFile(lockFileContents: string): PackageLock {

--- a/lib/parsers/yarn-lock-parser.ts
+++ b/lib/parsers/yarn-lock-parser.ts
@@ -10,7 +10,6 @@ import {
 } from './index';
 import { InvalidUserInputError } from '../errors';
 import { DepMap, LockParserBase } from './lock-parser-base';
-import { config } from '../config';
 
 export type YarnLockFileTypes = LockfileType.yarn | LockfileType.yarn2;
 
@@ -37,7 +36,7 @@ export interface YarnLockDep {
 
 export class YarnLockParser extends LockParserBase {
   constructor() {
-    super(LockfileType.yarn, config.YARN_TREE_SIZE_LIMIT);
+    super(LockfileType.yarn);
   }
 
   public parseLockFile(lockFileContents: string): YarnLock {

--- a/test/lib/package-lock-depTree.test.ts
+++ b/test/lib/package-lock-depTree.test.ts
@@ -4,13 +4,8 @@
 import { test } from 'tap';
 import * as _isEmpty from 'lodash.isempty';
 
-import {
-  InvalidUserInputError,
-  OutOfSyncError,
-  TreeSizeLimitError,
-} from '../../lib/errors';
+import { InvalidUserInputError, OutOfSyncError } from '../../lib/errors';
 import { load } from '../utils';
-import { config } from '../../lib/config';
 import { buildDepTreeFromFiles, LockfileType } from '../../lib';
 
 test('Parse npm package-lock.json', async (t) => {
@@ -252,17 +247,4 @@ test('`package.json` with file as version', async (t) => {
   );
 
   t.deepEqual(depTree, expectedDepTree, 'Tree generated as expected');
-});
-
-test('Npm Tree size exceeds the allowed limit of 500 dependencies.', async (t) => {
-  config.NPM_TREE_SIZE_LIMIT = 500;
-  t.rejects(
-    buildDepTreeFromFiles(
-      `${__dirname}/fixtures/goof/`,
-      'package.json',
-      'package-lock.json',
-    ),
-    new TreeSizeLimitError(),
-    'Expected error is thrown',
-  );
 });

--- a/test/lib/yarn.test.ts
+++ b/test/lib/yarn.test.ts
@@ -5,7 +5,6 @@ import { test } from 'tap';
 import * as path from 'path';
 
 import { load, readFixture } from '../utils';
-import { config } from '../../lib/config';
 import { buildDepTreeFromFiles, buildDepTree, LockfileType } from '../../lib';
 import getRuntimeVersion from '../../lib/get-node-runtime-version';
 import {
@@ -191,28 +190,6 @@ for (const version of ['yarn1', 'yarn2']) {
       } else {
         t.fail();
       }
-    }
-  });
-
-  // special case
-  test(`Yarn Tree size exceeds the allowed limit of 500 dependencies (${version})`, async (t) => {
-    try {
-      config.YARN_TREE_SIZE_LIMIT = 500;
-      await buildDepTreeFromFiles(
-        `${__dirname}/fixtures/goof/`,
-        'package.json',
-        `${version}/yarn.lock`,
-      );
-      t.fail('Expected TreeSizeLimitError to be thrown');
-    } catch (err) {
-      if (version === 'yarn2') {
-        t.equals(err.constructor.name, 'UnsupportedError');
-        t.equals(err.message, yarn2Error);
-      } else {
-        t.equals(err.constructor.name, 'TreeSizeLimitError');
-      }
-    } finally {
-      config.YARN_TREE_SIZE_LIMIT = 6.0e6;
     }
   });
 }


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

As we are creating optimised trees (see https://github.com/snyk/nodejs-lockfile-parser/pull/93), and that in most places we don't serialise the DepTree object, we don't need to really care about the size of the tree, but on the number of dependencies.
After reviewing most of the "big trees" tickets in Zendesk, the number of dependencies are limited by thousands, which shouldn't be a problem any more. 

This pr removes the limit of the tree size.

This is a breaking change, as we must verify that this plugin consumers doesn't serialise this object. 