### PR TITLE
fix: return to previous OutOfSync error

### DIFF
--- a/lib/parsers/lock-parser-base.ts
+++ b/lib/parsers/lock-parser-base.ts
@@ -152,7 +152,7 @@ export abstract class LockParserBase implements LockfileParser {
         // TODO: also check the package version
         // for a stricter check
         if (strict) {
-          throw new OutOfSyncError(depName, this.type);
+          throw new OutOfSyncError(dep.name, this.type);
         }
         depTree.dependencies[dep.name] = createDepTreeDepFromDep(dep);
         if (!depTree.dependencies[dep.name].labels) {

--- a/test/lib/yarn.test.ts
+++ b/test/lib/yarn.test.ts
@@ -95,7 +95,7 @@ const SCENARIOS_REJECTED = [
   {
     name: 'Parse yarn.lock with missing dependency',
     workspace: 'missing-deps-in-lock',
-    expectedError: new OutOfSyncError('uptime@1.4.7', LockfileType.yarn),
+    expectedError: new OutOfSyncError('uptime', LockfileType.yarn),
   },
   {
     name: 'Parse invalid yarn.lock',
@@ -107,7 +107,7 @@ const SCENARIOS_REJECTED = [
   {
     name: 'Out of sync yarn.lock strict mode',
     workspace: 'out-of-sync',
-    expectedError: new OutOfSyncError('lodash@4.17.11', LockfileType.yarn),
+    expectedError: new OutOfSyncError('lodash', LockfileType.yarn),
   },
 ];
 


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

Shows the previous (pre https://github.com/snyk/nodejs-lockfile-parser/pull/93) OutOfSync error
