### PR TITLE
chore: upgrade tap to remove vulns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.log
 /package-lock.json
 .idea
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
     "prettier": "^1.19.1",
-    "tap": "^12.6.1",
+    "tap": "^15.0.4",
     "typescript": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "npm run unit-test",
-    "unit-test": "tap -Rspec ./test/lib/*.test.[tj]s --timeout=300",
+    "unit-test": "tap --ts -Rspec ./test/lib/*.test.[tj]s --timeout=300 --no-check-coverage",
     "lint": "eslint --color --cache '{lib,test}/**/*.{js,ts}' && prettier --check '{lib,test}/**/*.{js,ts}'",
     "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
     "build": "tsc",
@@ -56,6 +56,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "prettier": "^1.19.1",
     "tap": "^15.0.4",
+    "ts-node": "^9.1.1",
     "typescript": "^4.1.0"
   }
 }


### PR DESCRIPTION
### What this does
Update tap version in order to remove critical transitive vulns