### PR TITLE
feat: add npm 7 support

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -56,7 +56,8 @@ export interface PkgTree extends DepTreeDep {
   };
   meta?: {
     nodeVersion?: string;
-    packageManagerVersion?: string;
+    lockfileVersion?: number;
+    packageManager?: string;
   };
   hasDevDependencies?: boolean;
   cyclic?: boolean;
@@ -70,6 +71,7 @@ export enum Scope {
 
 export enum LockfileType {
   npm = 'npm',
+  npm7 = 'npm7',
   yarn = 'yarn',
   yarn2 = 'yarn2',
 }
@@ -120,7 +122,9 @@ export function getTopLevelDeps(
     });
   }
 
-  if (isNpm7(lockfile) && targetFile.peerDependencies) {
+  // Only include peerDependencies if using npm and npm is at least
+  // version 7 as npm v7 automatically installs peerDependencies
+  if (lockfile.type === LockfileType.npm7 && targetFile.peerDependencies) {
     for (const [name, version] of Object.entries(targetFile.peerDependencies)) {
       dependencies.push({
         name,
@@ -129,15 +133,6 @@ export function getTopLevelDeps(
     }
   }
   return dependencies;
-}
-
-// Only include peerDependencies if using npm and npm is at least
-// version 7 as npm v7 automatically installs peerDependencies
-function isNpm7(lockfile: Lockfile): boolean {
-  return (
-    lockfile.type === LockfileType.npm &&
-    (lockfile as PackageLock).lockfileVersion === 2
-  );
 }
 
 export function createDepTreeDepFromDep(dep: Dep): DepTreeDep {

--- a/lib/parsers/yarn-lock-parser.ts
+++ b/lib/parsers/yarn-lock-parser.ts
@@ -66,10 +66,13 @@ export class YarnLockParser extends LockParserBase {
       strict,
     );
 
-    if (!depTree.meta) depTree.meta = {};
-    depTree.meta.packageManagerVersion = '1';
+    const meta = { lockfileVersion: 1, packageManager: 'yarn' };
+    const depTreeWithMeta = {
+      ...depTree,
+      meta: { ...depTree.meta, ...meta },
+    };
 
-    return depTree;
+    return depTreeWithMeta;
   }
 
   protected getDepMap(lockfile: Lockfile): DepMap {

--- a/lib/parsers/yarn2-lock-parser.ts
+++ b/lib/parsers/yarn2-lock-parser.ts
@@ -68,10 +68,13 @@ export class Yarn2LockParser extends LockParserBase {
       strict,
     );
 
-    if (!depTree.meta) depTree.meta = {};
-    depTree.meta.packageManagerVersion = '2';
+    const meta = { lockfileVersion: 2, packageManager: 'yarn' };
+    const depTreeWithMeta = {
+      ...depTree,
+      meta: { ...depTree.meta, ...meta },
+    };
 
-    return depTree;
+    return depTreeWithMeta;
   }
 
   protected getDepMap(lockfile: Lockfile): DepMap {

--- a/test/lib/fixtures/cyclic-dep-simple/yarn1/expected-tree.json
+++ b/test/lib/fixtures/cyclic-dep-simple/yarn1/expected-tree.json
@@ -33,6 +33,7 @@
   "version": "0.7.1",
   "meta": {
     "nodeVersion": ">=8.0",
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/cyclic-dep-simple/yarn2/expected-tree.json
+++ b/test/lib/fixtures/cyclic-dep-simple/yarn2/expected-tree.json
@@ -33,6 +33,7 @@
   "version": "0.7.1",
   "meta": {
     "nodeVersion": ">=8.0",
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/dev-deps-only/expected-tree-empty.json
+++ b/test/lib/fixtures/dev-deps-only/expected-tree-empty.json
@@ -3,5 +3,9 @@
   "size": 1,
   "version": "0.0.1",
   "hasDevDependencies": true,
+  "meta": {
+    "lockfileVersion": 1,
+    "packageManager": "npm"
+  },
   "dependencies": {}
 }

--- a/test/lib/fixtures/dev-deps-only/expected-tree.json
+++ b/test/lib/fixtures/dev-deps-only/expected-tree.json
@@ -2,6 +2,10 @@
   "name": "pkg-dev-deps-only",
   "size": 3,
   "version": "0.0.1",
+  "meta": {
+    "lockfileVersion": 1,
+    "packageManager": "npm"
+  },
   "hasDevDependencies": true,
   "dependencies": {
     "debug": {
@@ -22,3 +26,4 @@
     }
   }
 }
+

--- a/test/lib/fixtures/dev-deps-only/yarn1/expected-tree-with-dev.json
+++ b/test/lib/fixtures/dev-deps-only/yarn1/expected-tree-with-dev.json
@@ -22,6 +22,7 @@
     }
   },
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/dev-deps-only/yarn2/expected-tree-with-dev.json
+++ b/test/lib/fixtures/dev-deps-only/yarn2/expected-tree-with-dev.json
@@ -22,6 +22,7 @@
     }
   },
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/empty-dev-deps/yarn1/expected-tree-with-dev.json
+++ b/test/lib/fixtures/empty-dev-deps/yarn1/expected-tree-with-dev.json
@@ -14,6 +14,7 @@
   "version": "0.0.3",
   "meta": {
     "nodeVersion": "6.14.1",
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/empty-dev-deps/yarn2/expected-tree-with-dev.json
+++ b/test/lib/fixtures/empty-dev-deps/yarn2/expected-tree-with-dev.json
@@ -14,6 +14,7 @@
   "version": "0.0.3",
   "meta": {
     "nodeVersion": "6.14.1",
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/external-tarball/yarn1/expected-tree.json
+++ b/test/lib/fixtures/external-tarball/yarn1/expected-tree.json
@@ -121,6 +121,7 @@
   "size": 16,
   "version": "",
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/external-tarball/yarn2/expected-tree.json
+++ b/test/lib/fixtures/external-tarball/yarn2/expected-tree.json
@@ -121,6 +121,7 @@
   "size": 16,
   "version": "",
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/file-as-version/expected-tree.json
+++ b/test/lib/fixtures/file-as-version/expected-tree.json
@@ -27,5 +27,9 @@
   "hasDevDependencies": false,
   "name": "pkg-dev-deps-only",
   "size": 4,
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "meta": {
+    "lockfileVersion": 2,
+    "packageManager": "npm"
+  }
 }

--- a/test/lib/fixtures/file-as-version/yarn1/expected-tree.json
+++ b/test/lib/fixtures/file-as-version/yarn1/expected-tree.json
@@ -29,6 +29,7 @@
   "size": 4,
   "version": "0.0.1",
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/file-as-version/yarn2/expected-tree.json
+++ b/test/lib/fixtures/file-as-version/yarn2/expected-tree.json
@@ -29,6 +29,7 @@
   "size": 4,
   "version": "0.0.1",
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/git-ssh-url-deps/yarn1/expected-tree.json
+++ b/test/lib/fixtures/git-ssh-url-deps/yarn1/expected-tree.json
@@ -121,6 +121,7 @@
   "size": 16,
   "version": "",
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/git-ssh-url-deps/yarn2/expected-tree.json
+++ b/test/lib/fixtures/git-ssh-url-deps/yarn2/expected-tree.json
@@ -121,6 +121,7 @@
   "size": 16,
   "version": "",
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps-yarn.json
@@ -6554,7 +6554,7 @@
                 },
                 "supports-color": {
                   "labels": {
-                   "scope": "prod"
+                    "scope": "prod"
                   },
                   "dependencies": {
                     "has-flag": {
@@ -7143,6 +7143,8 @@
   "version": "0.0.3",
   "size": 914,
   "meta": {
-    "nodeVersion": "6.14.1"
+    "nodeVersion": "6.14.1",
+    "lockfileVersion": 1,
+    "packageManager": "npm"
   }
 }

--- a/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-no-dev-deps.json
@@ -3,7 +3,9 @@
   "version": "0.0.3",
   "size": 910,
   "meta": {
-    "nodeVersion": "6.14.1"
+    "nodeVersion": "6.14.1",
+    "lockfileVersion": 1,
+    "packageManager": "npm"
   },
   "hasDevDependencies": true,
   "dependencies": {

--- a/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
+++ b/test/lib/fixtures/goof/dep-tree-with-dev-deps.json
@@ -13900,6 +13900,8 @@
   "version": "0.0.3",
   "size": 1791,
   "meta": {
-    "nodeVersion": "6.14.1"
+    "nodeVersion": "6.14.1",
+    "lockfileVersion": 1,
+    "packageManager": "npm"
   }
 }

--- a/test/lib/fixtures/goof/yarn1/expected-tree-with-dev.json
+++ b/test/lib/fixtures/goof/yarn1/expected-tree-with-dev.json
@@ -11381,5 +11381,9 @@
   "name": "goof",
   "size": 1983,
   "version": "0.0.3",
-  "meta": { "nodeVersion": "6.14.1", "packageManagerVersion": "1" }
+  "meta": {
+    "nodeVersion": "6.14.1",
+    "lockfileVersion": "1",
+    "packageManager": "yarn"
+  }
 }

--- a/test/lib/fixtures/goof/yarn1/expected-tree.json
+++ b/test/lib/fixtures/goof/yarn1/expected-tree.json
@@ -4932,5 +4932,9 @@
   "name": "goof",
   "size": 852,
   "version": "0.0.3",
-  "meta": { "nodeVersion": "6.14.1", "packageManagerVersion": "1" }
+  "meta": {
+    "nodeVersion": "6.14.1",
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
+  }
 }

--- a/test/lib/fixtures/goof/yarn2/expected-tree-with-dev.json
+++ b/test/lib/fixtures/goof/yarn2/expected-tree-with-dev.json
@@ -18317,5 +18317,9 @@
   "name": "goof",
   "size": 3189,
   "version": "0.0.3",
-  "meta": { "nodeVersion": "6.14.1", "packageManagerVersion": "2" }
+  "meta": {
+    "nodeVersion": "6.14.1",
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
+  }
 }

--- a/test/lib/fixtures/goof/yarn2/expected-tree.json
+++ b/test/lib/fixtures/goof/yarn2/expected-tree.json
@@ -6658,5 +6658,9 @@
   "name": "goof",
   "size": 1152,
   "version": "0.0.3",
-  "meta": { "nodeVersion": "6.14.1", "packageManagerVersion": "2" }
+  "meta": {
+    "nodeVersion": "6.14.1",
+    "lockfileVersion": "2",
+    "packageManager": "yarn"
+  }
 }

--- a/test/lib/fixtures/missing-deps/expected-tree.json
+++ b/test/lib/fixtures/missing-deps/expected-tree.json
@@ -3,5 +3,10 @@
   "size": 1,
   "version": "1.0.0",
   "hasDevDependencies": false,
+  "meta": {
+    "lockfileVersion": 1,
+    "packageManager": "npm"
+  },
   "dependencies": {}
 }
+

--- a/test/lib/fixtures/missing-deps/yarn1/expected-tree-with-dev.json
+++ b/test/lib/fixtures/missing-deps/yarn1/expected-tree-with-dev.json
@@ -5,6 +5,7 @@
   "hasDevDependencies": false,
   "dependencies": {},
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/missing-deps/yarn1/expected-tree.json
+++ b/test/lib/fixtures/missing-deps/yarn1/expected-tree.json
@@ -5,6 +5,7 @@
   "hasDevDependencies": false,
   "dependencies": {},
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/missing-deps/yarn2/expected-tree-with-dev.json
+++ b/test/lib/fixtures/missing-deps/yarn2/expected-tree-with-dev.json
@@ -5,6 +5,7 @@
   "hasDevDependencies": false,
   "dependencies": {},
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/missing-deps/yarn2/expected-tree.json
+++ b/test/lib/fixtures/missing-deps/yarn2/expected-tree.json
@@ -5,6 +5,7 @@
   "hasDevDependencies": false,
   "dependencies": {},
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/missing-name/yarn1/expected-tree.json
+++ b/test/lib/fixtures/missing-name/yarn1/expected-tree.json
@@ -31,6 +31,7 @@
   "size": 4,
   "version": "0.0.1",
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/missing-name/yarn2/expected-tree.json
+++ b/test/lib/fixtures/missing-name/yarn2/expected-tree.json
@@ -31,6 +31,7 @@
   "size": 4,
   "version": "0.0.1",
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/npm-7/expected-tree.json
+++ b/test/lib/fixtures/npm-7/expected-tree.json
@@ -1,12 +1,12 @@
 {
   "hasDevDependencies": true,
-  "name": "goof",
+  "name": "npm-7",
   "size": 5,
-  "version": "0.0.3",
+  "version": "1.0.0",
   "meta": {
-    "nodeVersion": "6.14.1",
-    "lockfileVersion": 1,
-    "packageManager": "npm"
+    "nodeVersion": "12.0.0",
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   },
   "dependencies": {
     "has": {

--- a/test/lib/fixtures/npm-7/package-lock.json
+++ b/test/lib/fixtures/npm-7/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "npm-7",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "devDependencies": {
+        "debug": "^2.2.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    }
+  }
+}

--- a/test/lib/fixtures/npm-7/package.json
+++ b/test/lib/fixtures/npm-7/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "npm-7",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "has": "^1.0.3"
+  },
+  "devDependencies": {
+    "debug": "^2.2.0"
+  }
+}

--- a/test/lib/fixtures/npm-protocol/yarn1/expected-tree.json
+++ b/test/lib/fixtures/npm-protocol/yarn1/expected-tree.json
@@ -13,6 +13,7 @@
   "size": 2,
   "version": "",
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/npm-protocol/yarn2/expected-tree.json
+++ b/test/lib/fixtures/npm-protocol/yarn2/expected-tree.json
@@ -13,6 +13,7 @@
   "size": 2,
   "version": "",
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/out-of-sync-tree/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync-tree/expected-tree.json
@@ -228,5 +228,9 @@
   "hasDevDependencies": true,
   "name": "out-of-sync-small",
   "size": 30,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "meta": {
+    "lockfileVersion": 1,
+    "packageManager": "npm"
+  }
 }

--- a/test/lib/fixtures/out-of-sync/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync/expected-tree.json
@@ -48,6 +48,9 @@
   "size": 6,
   "version": "0.7.1",
   "meta": {
-    "nodeVersion": ">=8.0"
+    "nodeVersion": ">=8.0",
+    "lockfileVersion": 1,
+    "packageManager": "npm"
   }
 }
+

--- a/test/lib/fixtures/out-of-sync/yarn1/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync/yarn1/expected-tree.json
@@ -39,6 +39,8 @@
   "version": "0.7.1",
   "meta": {
     "nodeVersion": ">=8.0",
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }
+

--- a/test/lib/fixtures/out-of-sync/yarn2/expected-tree.json
+++ b/test/lib/fixtures/out-of-sync/yarn2/expected-tree.json
@@ -39,6 +39,8 @@
   "version": "0.7.1",
   "meta": {
     "nodeVersion": ">=8.0",
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }
+

--- a/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
+++ b/test/lib/fixtures/package-repeated-in-manifest/expected-tree.json
@@ -4,7 +4,9 @@
   "version": "0.0.3",
   "hasDevDependencies": true,
   "meta": {
-    "nodeVersion": "10.8.0"
+    "nodeVersion": "10.8.0",
+    "lockfileVersion": 1,
+    "packageManager": "npm"
   },
   "dependencies": {
     "body-parser": {

--- a/test/lib/fixtures/package-repeated-in-manifest/yarn1/expected-tree.json
+++ b/test/lib/fixtures/package-repeated-in-manifest/yarn1/expected-tree.json
@@ -5,8 +5,8 @@
   "hasDevDependencies": true,
   "meta": {
     "nodeVersion": "10.8.0",
-    "packageManagerVersion": "1"
-
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   },
   "dependencies": {
     "body-parser": {

--- a/test/lib/fixtures/package-repeated-in-manifest/yarn2/expected-tree.json
+++ b/test/lib/fixtures/package-repeated-in-manifest/yarn2/expected-tree.json
@@ -5,7 +5,8 @@
   "hasDevDependencies": true,
   "meta": {
     "nodeVersion": "10.8.0",
-    "packageManagerVersion": "2"
+    "lockfileVersion": "2",
+    "packageManager": "yarn"
   },
   "dependencies": {
     "body-parser": {

--- a/test/lib/fixtures/peer-deps/npm6/expected-tree.json
+++ b/test/lib/fixtures/peer-deps/npm6/expected-tree.json
@@ -27,5 +27,9 @@
   "hasDevDependencies": false,
   "name": "goof",
   "size": 4,
-  "version": "0.0.3"
+  "version": "0.0.3",
+  "meta": {
+    "lockfileVersion": 1,
+    "packageManager": "npm"
+  }
 }

--- a/test/lib/fixtures/peer-deps/npm7/expected-tree.json
+++ b/test/lib/fixtures/peer-deps/npm7/expected-tree.json
@@ -3,6 +3,10 @@
   "name": "goof",
   "size": 6,
   "version": "0.0.3",
+  "meta": {
+    "lockfileVersion": 2,
+    "packageManager": "npm"
+  },
   "dependencies": {
     "adm-zip": {
       "labels": { "scope": "prod" },

--- a/test/lib/fixtures/peer-deps/yarn/expected-tree.json
+++ b/test/lib/fixtures/peer-deps/yarn/expected-tree.json
@@ -29,6 +29,7 @@
   "size": 4,
   "version": "0.0.3",
   "meta": {
-    "packageManagerVersion": "1"
+    "lockfileVersion": 1,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/fixtures/peer-deps/yarn2/expected-tree.json
+++ b/test/lib/fixtures/peer-deps/yarn2/expected-tree.json
@@ -29,6 +29,7 @@
   "size": 4,
   "version": "0.0.3",
   "meta": {
-    "packageManagerVersion": "2"
+    "lockfileVersion": 2,
+    "packageManager": "yarn"
   }
 }

--- a/test/lib/yarn.test.ts
+++ b/test/lib/yarn.test.ts
@@ -203,5 +203,5 @@ test('.yarnrc.yaml is missing, but still resolving to yarn2 version', async (t) 
     `yarn.lock`,
   );
 
-  t.equal(depTree.meta?.packageManagerVersion, '2', 'resolved to yarn v2');
+  t.equal(depTree.meta?.lockfileVersion, 2, 'resolved to yarn v2');
 });


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

This allows the parser to parse which version of lockfile is being used aswell as allowing it to report back the package manager and lockfile version so that they are available in the CLI.