### PR TITLE
fix: correct messaging in out of sync errors if using yarn2

### DIFF
--- a/lib/errors/out-of-sync-error.ts
+++ b/lib/errors/out-of-sync-error.ts
@@ -3,11 +3,13 @@ import { LockfileType } from '../parsers';
 const LOCK_FILE_NAME = {
   npm: 'package-lock.json',
   yarn: 'yarn.lock',
+  yarn2: 'yarn.lock',
 };
 
 const INSTALL_COMMAND = {
   npm: 'npm install',
   yarn: 'yarn install',
+  yarn2: 'yarn install',
 };
 
 export class OutOfSyncError extends Error {


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

Getting an out of sync error when using yarn2 now produces accurate messaging instead of `undefined` being present