### PR TITLE
fix: pass includePeerDeps instead of a whole lockfile

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -102,7 +102,7 @@ export function parseManifestFile(manifestFileContents: string): ManifestFile {
 export function getTopLevelDeps(
   targetFile: ManifestFile,
   includeDev: boolean,
-  lockfile: Lockfile,
+  includePeerDeps = false,
 ): Dep[] {
   const dependencies: Dep[] = [];
 
@@ -123,9 +123,7 @@ export function getTopLevelDeps(
     });
   }
 
-  // Only include peerDependencies if using npm and npm is at least
-  // version 7 as npm v7 automatically installs peerDependencies
-  if (lockfile.type === LockfileType.npm7 && targetFile.peerDependencies) {
+  if (includePeerDeps && targetFile.peerDependencies) {
     for (const [name, version] of Object.entries(targetFile.peerDependencies)) {
       dependencies.push({
         name,

--- a/lib/parsers/lock-parser-base.ts
+++ b/lib/parsers/lock-parser-base.ts
@@ -124,11 +124,13 @@ export abstract class LockParserBase implements LockfileParser {
       depGraph,
     );
 
+    // Only include peerDependencies if using npm and npm is at least
+    // version 7 as npm v7 automatically installs peerDependencies
     // get trees for dependencies from manifest file
     const topLevelDeps: Dep[] = getTopLevelDeps(
       manifestFile,
       includeDev,
-      lockfile,
+      lockfile.type === LockfileType.npm7,
     );
 
     // number of dependencies including root one


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

Instead of passing an entire lockfile to a function that only uses it
to decide if we need to grab peer deps, do this calculation upfront
and optionally allow grabbing peer deps. This also allows for future support
of --peer
