### PR TITLE
add constants for lockFileType npm7

### DIFF
--- a/lib/errors/out-of-sync-error.ts
+++ b/lib/errors/out-of-sync-error.ts
@@ -2,12 +2,14 @@ import { LockfileType } from '../parsers';
 
 const LOCK_FILE_NAME = {
   npm: 'package-lock.json',
+  npm7: 'package-lock.json',
   yarn: 'yarn.lock',
   yarn2: 'yarn.lock',
 };
 
 const INSTALL_COMMAND = {
   npm: 'npm install',
+  npm7: 'npm install',
   yarn: 'yarn install',
   yarn2: 'yarn install',
 };


### PR DESCRIPTION
fix `undefined` strings in OutOfSyncError

> OutOfSyncError: Dependency @types/jest was not found in undefined. Your package.json and undefined are probably out of sync. Please run "undefined" and try again.

- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [ ] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [ ] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [SC-XXXX]()
- [Link to documentation]()

### Screenshots

_Visuals that may help the reviewer_
