### PR TITLE
fix: applies resolutions when finding top level deps if yarn 2

### DIFF
--- a/lib/parsers/lock-parser-base.ts
+++ b/lib/parsers/lock-parser-base.ts
@@ -133,11 +133,12 @@ export abstract class LockParserBase implements LockfileParser {
     // Only include peerDependencies if using npm and npm is at least
     // version 7 as npm v7 automatically installs peerDependencies
     // get trees for dependencies from manifest file
-    const topLevelDeps: Dep[] = getTopLevelDeps(
-      manifestFile,
+    const topLevelDeps: Dep[] = getTopLevelDeps({
+      targetFile: manifestFile,
       includeDev,
-      lockfile.type === LockfileType.npm7,
-    );
+      includePeerDeps: lockfile.type === LockfileType.npm7,
+      applyYarn2Resolutions: lockfile.type === LockfileType.yarn2,
+    });
 
     // number of dependencies including root one
     let treeSize = 1;

--- a/test/fixtures/yarn2/scoped-resolutions/applicable-resolutions-with-scoped-pkg/expected-top-level-deps.json
+++ b/test/fixtures/yarn2/scoped-resolutions/applicable-resolutions-with-scoped-pkg/expected-top-level-deps.json
@@ -1,0 +1,1 @@
+[{ "dev": false, "name": "express", "version": "4.12.4" }]

--- a/test/fixtures/yarn2/scoped-resolutions/applicable-resolutions-with-scoped-pkg/package.json
+++ b/test/fixtures/yarn2/scoped-resolutions/applicable-resolutions-with-scoped-pkg/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@scoped/testPkg",
+  "dependencies": {
+    "express": "4.0.0"
+  },
+  "resolutions": {
+    "@scoped/testPkg/express": "4.12.4"
+  }
+}

--- a/test/fixtures/yarn2/scoped-resolutions/applicable-resolutions/expected-top-level-deps.json
+++ b/test/fixtures/yarn2/scoped-resolutions/applicable-resolutions/expected-top-level-deps.json
@@ -1,0 +1,1 @@
+[{ "dev": false, "name": "express", "version": "4.12.4" }]

--- a/test/fixtures/yarn2/scoped-resolutions/applicable-resolutions/package.json
+++ b/test/fixtures/yarn2/scoped-resolutions/applicable-resolutions/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "testPkg",
+  "dependencies": {
+    "express": "4.0.0"
+  },
+  "resolutions": {
+    "testPkg/express": "4.12.4"
+  }
+}

--- a/test/fixtures/yarn2/scoped-resolutions/inapplicable-resolutions-with-scoped-pkg/expected-top-level-deps.json
+++ b/test/fixtures/yarn2/scoped-resolutions/inapplicable-resolutions-with-scoped-pkg/expected-top-level-deps.json
@@ -1,0 +1,1 @@
+[{ "dev": false, "name": "express", "version": "4.0.0" }]

--- a/test/fixtures/yarn2/scoped-resolutions/inapplicable-resolutions-with-scoped-pkg/package.json
+++ b/test/fixtures/yarn2/scoped-resolutions/inapplicable-resolutions-with-scoped-pkg/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "testPkg",
+  "dependencies": {
+    "express": "4.0.0"
+  },
+  "resolutions": {
+    "@scoped/someOtherPkg/express": "4.12.4"
+  }
+}

--- a/test/fixtures/yarn2/scoped-resolutions/inapplicable-resolutions/expected-top-level-deps.json
+++ b/test/fixtures/yarn2/scoped-resolutions/inapplicable-resolutions/expected-top-level-deps.json
@@ -1,0 +1,1 @@
+[{ "dev": false, "name": "express", "version": "4.0.0" }]

--- a/test/fixtures/yarn2/scoped-resolutions/inapplicable-resolutions/package.json
+++ b/test/fixtures/yarn2/scoped-resolutions/inapplicable-resolutions/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "testPkg",
+  "dependencies": {
+    "express": "4.0.0"
+  },
+  "resolutions": {
+    "someOtherPkg/express": "4.12.4"
+  }
+}

--- a/test/fixtures/yarn2/simple-resolutions/expected-top-level-deps.json
+++ b/test/fixtures/yarn2/simple-resolutions/expected-top-level-deps.json
@@ -1,0 +1,1 @@
+[{ "dev": false, "name": "express", "version": "4.12.4" }]

--- a/test/fixtures/yarn2/simple-resolutions/package.json
+++ b/test/fixtures/yarn2/simple-resolutions/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "testPkg",
+  "dependencies": {
+    "express": "4.0.0"
+  },
+  "resolutions": {
+    "express": "4.12.4"
+  }
+}

--- a/test/jest/get-top-level-deps.test.ts
+++ b/test/jest/get-top-level-deps.test.ts
@@ -1,0 +1,75 @@
+import { getTopLevelDeps, ManifestFile } from '../../lib/parsers';
+
+describe('getTopLevelDeps', () => {
+  describe('yarn2', () => {
+    it('applies resolutions correctly - simple resolution', () => {
+      const yarn2SimpleResolutionsManifest: ManifestFile = require('../fixtures/yarn2/simple-resolutions/package.json');
+
+      const topLevelDeps = getTopLevelDeps({
+        targetFile: yarn2SimpleResolutionsManifest,
+        includeDev: false,
+        applyYarn2Resolutions: true,
+      });
+
+      const expectedTopLevelDeps = require('../fixtures/yarn2/simple-resolutions/expected-top-level-deps.json');
+
+      expect(topLevelDeps).toStrictEqual(expectedTopLevelDeps);
+    });
+
+    it('applies resolutions correctly - applicable scoped resolution', () => {
+      const yarn2SimpleResolutionsManifest: ManifestFile = require('../fixtures/yarn2/scoped-resolutions/applicable-resolutions/package.json');
+
+      const topLevelDeps = getTopLevelDeps({
+        targetFile: yarn2SimpleResolutionsManifest,
+        includeDev: false,
+        applyYarn2Resolutions: true,
+      });
+
+      const expectedTopLevelDeps = require('../fixtures/yarn2/scoped-resolutions/applicable-resolutions/expected-top-level-deps.json');
+
+      expect(topLevelDeps).toStrictEqual(expectedTopLevelDeps);
+    });
+
+    it('applies resolutions correctly - inapplicable scoped resolution', () => {
+      const yarn2SimpleResolutionsManifest: ManifestFile = require('../fixtures/yarn2/scoped-resolutions/inapplicable-resolutions/package.json');
+
+      const topLevelDeps = getTopLevelDeps({
+        targetFile: yarn2SimpleResolutionsManifest,
+        includeDev: false,
+        applyYarn2Resolutions: true,
+      });
+
+      const expectedTopLevelDeps = require('../fixtures/yarn2/scoped-resolutions/inapplicable-resolutions/expected-top-level-deps.json');
+
+      expect(topLevelDeps).toStrictEqual(expectedTopLevelDeps);
+    });
+
+    it('applies resolutions correctly - applicable scoped resolution with a scoped pkg', () => {
+      const yarn2SimpleResolutionsManifest: ManifestFile = require('../fixtures/yarn2/scoped-resolutions/applicable-resolutions-with-scoped-pkg/package.json');
+
+      const topLevelDeps = getTopLevelDeps({
+        targetFile: yarn2SimpleResolutionsManifest,
+        includeDev: false,
+        applyYarn2Resolutions: true,
+      });
+
+      const expectedTopLevelDeps = require('../fixtures/yarn2/scoped-resolutions/applicable-resolutions-with-scoped-pkg/expected-top-level-deps.json');
+
+      expect(topLevelDeps).toStrictEqual(expectedTopLevelDeps);
+    });
+
+    it('applies resolutions correctly - inapplicable scoped resolution', () => {
+      const yarn2SimpleResolutionsManifest: ManifestFile = require('../fixtures/yarn2/scoped-resolutions/inapplicable-resolutions-with-scoped-pkg/package.json');
+
+      const topLevelDeps = getTopLevelDeps({
+        targetFile: yarn2SimpleResolutionsManifest,
+        includeDev: false,
+        applyYarn2Resolutions: true,
+      });
+
+      const expectedTopLevelDeps = require('../fixtures/yarn2/scoped-resolutions/inapplicable-resolutions-with-scoped-pkg/expected-top-level-deps.json');
+
+      expect(topLevelDeps).toStrictEqual(expectedTopLevelDeps);
+    });
+  });
+});


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [ ] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [ ] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

This makes a small fix to apply resolutions when finding top level deps. Currently scoped just to yarn2 for first rollout.