### PR TITLE
fix: freeze semantic release on pipeline to avoid breaking change in v18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
     resource_class: small
     steps:
       - install_deps
-      - run: sudo npm i -g semantic-release @semantic-release/exec pkg
+      - run: sudo npm i -g semantic-release@17 @semantic-release/exec pkg
       - run:
           name: Publish to GitHub
           command: semantic-release


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [ ] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [ ] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

This freezes the semantic release version used on the pipeline as the latest release - v18 - requires node v14+. 
