### PR TITLE
fix: support optional peerDependencies with npm7

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -17,6 +17,10 @@ export type ManifestDependencies = {
   [dep: string]: string;
 };
 
+export type PeerDependenciesMeta = {
+  [dep: string]: { optional: boolean };
+};
+
 export interface ManifestFile {
   name: string;
   private?: string;
@@ -28,6 +32,7 @@ export interface ManifestFile {
   devDependencies?: ManifestDependencies;
   optionalDependencies?: ManifestDependencies;
   peerDependencies?: ManifestDependencies;
+  peerDependenciesMeta?: PeerDependenciesMeta;
   resolutions?: ManifestDependencies;
   version?: string;
 }
@@ -131,6 +136,9 @@ export function getTopLevelDeps({
 
   if (includePeerDeps && targetFile.peerDependencies) {
     for (const [name, version] of Object.entries(targetFile.peerDependencies)) {
+      if (targetFile?.peerDependenciesMeta?.[name]?.optional) {
+        continue;
+      }
       dependencies.push({
         name,
         version,

--- a/test/fixtures/optional-peer-deps-npm7/direct-optional-installed/expected-tree.json
+++ b/test/fixtures/optional-peer-deps-npm7/direct-optional-installed/expected-tree.json
@@ -1,0 +1,189 @@
+{
+  "dependencies": {
+    "body-parser": {
+      "labels": { "scope": "prod" },
+      "name": "body-parser",
+      "version": "1.19.0",
+      "dependencies": {
+        "bytes": {
+          "labels": { "scope": "prod" },
+          "name": "bytes",
+          "version": "3.1.0"
+        },
+        "content-type": {
+          "labels": { "scope": "prod" },
+          "name": "content-type",
+          "version": "1.0.4"
+        },
+        "debug": {
+          "labels": { "scope": "prod" },
+          "name": "debug",
+          "version": "2.6.9",
+          "dependencies": {
+            "ms": {
+              "labels": { "scope": "prod" },
+              "name": "ms",
+              "version": "2.0.0"
+            }
+          }
+        },
+        "depd": {
+          "labels": { "scope": "prod" },
+          "name": "depd",
+          "version": "1.1.2"
+        },
+        "http-errors": {
+          "labels": { "scope": "prod" },
+          "name": "http-errors",
+          "version": "1.7.2",
+          "dependencies": {
+            "depd": {
+              "labels": { "scope": "prod" },
+              "name": "depd",
+              "version": "1.1.2"
+            },
+            "inherits": {
+              "labels": { "scope": "prod" },
+              "name": "inherits",
+              "version": "2.0.3"
+            },
+            "setprototypeof": {
+              "labels": { "scope": "prod" },
+              "name": "setprototypeof",
+              "version": "1.1.1"
+            },
+            "statuses": {
+              "labels": { "scope": "prod" },
+              "name": "statuses",
+              "version": "1.5.0"
+            },
+            "toidentifier": {
+              "labels": { "scope": "prod" },
+              "name": "toidentifier",
+              "version": "1.0.0"
+            }
+          }
+        },
+        "iconv-lite": {
+          "labels": { "scope": "prod" },
+          "name": "iconv-lite",
+          "version": "0.4.24",
+          "dependencies": {
+            "safer-buffer": {
+              "labels": { "scope": "prod" },
+              "name": "safer-buffer",
+              "version": "2.1.2"
+            }
+          }
+        },
+        "on-finished": {
+          "labels": { "scope": "prod" },
+          "name": "on-finished",
+          "version": "2.3.0",
+          "dependencies": {
+            "ee-first": {
+              "labels": { "scope": "prod" },
+              "name": "ee-first",
+              "version": "1.1.1"
+            }
+          }
+        },
+        "qs": {
+          "labels": { "scope": "prod" },
+          "name": "qs",
+          "version": "6.7.0"
+        },
+        "raw-body": {
+          "labels": { "scope": "prod" },
+          "name": "raw-body",
+          "version": "2.4.0",
+          "dependencies": {
+            "bytes": {
+              "labels": { "scope": "prod" },
+              "name": "bytes",
+              "version": "3.1.0"
+            },
+            "http-errors": {
+              "labels": { "scope": "prod" },
+              "name": "http-errors",
+              "version": "1.7.2",
+              "dependencies": {
+                "depd": {
+                  "labels": { "scope": "prod" },
+                  "name": "depd",
+                  "version": "1.1.2"
+                },
+                "inherits": {
+                  "labels": { "scope": "prod" },
+                  "name": "inherits",
+                  "version": "2.0.3"
+                },
+                "setprototypeof": {
+                  "labels": { "scope": "prod" },
+                  "name": "setprototypeof",
+                  "version": "1.1.1"
+                },
+                "statuses": {
+                  "labels": { "scope": "prod" },
+                  "name": "statuses",
+                  "version": "1.5.0"
+                },
+                "toidentifier": {
+                  "labels": { "scope": "prod" },
+                  "name": "toidentifier",
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "iconv-lite": {
+              "labels": { "scope": "prod" },
+              "name": "iconv-lite",
+              "version": "0.4.24",
+              "dependencies": {
+                "safer-buffer": {
+                  "labels": { "scope": "prod" },
+                  "name": "safer-buffer",
+                  "version": "2.1.2"
+                }
+              }
+            },
+            "unpipe": {
+              "labels": { "scope": "prod" },
+              "name": "unpipe",
+              "version": "1.0.0"
+            }
+          }
+        },
+        "type-is": {
+          "labels": { "scope": "prod" },
+          "name": "type-is",
+          "version": "1.6.18",
+          "dependencies": {
+            "media-typer": {
+              "labels": { "scope": "prod" },
+              "name": "media-typer",
+              "version": "0.3.0"
+            },
+            "mime-types": {
+              "labels": { "scope": "prod" },
+              "name": "mime-types",
+              "version": "2.1.33",
+              "dependencies": {
+                "mime-db": {
+                  "labels": { "scope": "prod" },
+                  "name": "mime-db",
+                  "version": "1.50.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "hasDevDependencies": false,
+  "name": "goof",
+  "size": 33,
+  "version": "0.0.3",
+  "meta": { "lockfileVersion": 2, "packageManager": "npm" }
+}

--- a/test/fixtures/optional-peer-deps-npm7/direct-optional-installed/package-lock.json
+++ b/test/fixtures/optional-peer-deps-npm7/direct-optional-installed/package-lock.json
@@ -1,0 +1,375 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goof",
+      "version": "0.0.3",
+      "dependencies": {
+        "body-parser": "^1.19.0"
+      },
+      "peerDependencies": {
+        "body-parser": "^1.19.0"
+      },
+      "peerDependenciesMeta": {
+        "body-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
+      "dependencies": {
+        "mime-db": "1.50.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "dependencies": {
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mime-db": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A=="
+    },
+    "mime-types": {
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
+      "requires": {
+        "mime-db": "1.50.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    }
+  }
+}

--- a/test/fixtures/optional-peer-deps-npm7/direct-optional-installed/package.json
+++ b/test/fixtures/optional-peer-deps-npm7/direct-optional-installed/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "dependencies": {
+    "body-parser": "^1.19.0"
+  },
+  "peerDependencies": {
+    "body-parser": "^1.19.0"
+  },
+  "peerDependenciesMeta": {
+    "body-parser": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/optional-peer-deps-npm7/direct-optional-not-installed/expected-tree.json
+++ b/test/fixtures/optional-peer-deps-npm7/direct-optional-not-installed/expected-tree.json
@@ -1,0 +1,1 @@
+{"dependencies":{},"hasDevDependencies":false,"name":"goof","size":1,"version":"0.0.3","meta":{"lockfileVersion":2,"packageManager":"npm"}}

--- a/test/fixtures/optional-peer-deps-npm7/direct-optional-not-installed/package-lock.json
+++ b/test/fixtures/optional-peer-deps-npm7/direct-optional-not-installed/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goof",
+      "version": "0.0.3",
+      "peerDependencies": {
+        "body-parser": "^1.19.0"
+      },
+      "peerDependenciesMeta": {
+        "body-parser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/optional-peer-deps-npm7/direct-optional-not-installed/package.json
+++ b/test/fixtures/optional-peer-deps-npm7/direct-optional-not-installed/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "peerDependencies": {
+    "body-parser": "^1.19.0"
+  },
+  "peerDependenciesMeta": {
+    "body-parser": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/optional-peer-deps-npm7/transitive-optional-installed/expected-tree.json
+++ b/test/fixtures/optional-peer-deps-npm7/transitive-optional-installed/expected-tree.json
@@ -1,0 +1,38 @@
+{
+  "dependencies": {
+    "test-peer-deps-optional": {
+      "labels": { "scope": "prod" },
+      "name": "test-peer-deps-optional",
+      "version": "1.0.0"
+    },
+    "react": {
+      "labels": { "scope": "prod" },
+      "name": "react",
+      "version": "17.0.2",
+      "dependencies": {
+        "loose-envify": {
+          "labels": { "scope": "prod" },
+          "name": "loose-envify",
+          "version": "1.4.0",
+          "dependencies": {
+            "js-tokens": {
+              "labels": { "scope": "prod" },
+              "name": "js-tokens",
+              "version": "4.0.0"
+            }
+          }
+        },
+        "object-assign": {
+          "labels": { "scope": "prod" },
+          "name": "object-assign",
+          "version": "4.1.1"
+        }
+      }
+    }
+  },
+  "hasDevDependencies": false,
+  "name": "goof",
+  "size": 6,
+  "version": "0.0.3",
+  "meta": { "lockfileVersion": 2, "packageManager": "npm" }
+}

--- a/test/fixtures/optional-peer-deps-npm7/transitive-optional-installed/package-lock.json
+++ b/test/fixtures/optional-peer-deps-npm7/transitive-optional-installed/package-lock.json
@@ -1,0 +1,100 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goof",
+      "version": "0.0.3",
+      "dependencies": {
+        "react": "^17.0.2",
+        "test-peer-deps-optional": "1.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/test-peer-deps-optional": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/test-peer-deps-optional/-/test-peer-deps-optional-1.0.0.tgz",
+      "integrity": "sha512-mXwLorPrb/ZucRuJC21zkr3JMddhicmn9t4pLDzcYROhP3vKEtxwNGxfJGphCViEtMMOQmSgHc8e/4Q8a9JvSQ==",
+      "peerDependencies": {
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "test-peer-deps-optional": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/test-peer-deps-optional/-/test-peer-deps-optional-1.0.0.tgz",
+      "integrity": "sha512-mXwLorPrb/ZucRuJC21zkr3JMddhicmn9t4pLDzcYROhP3vKEtxwNGxfJGphCViEtMMOQmSgHc8e/4Q8a9JvSQ==",
+      "requires": {}
+    }
+  }
+}

--- a/test/fixtures/optional-peer-deps-npm7/transitive-optional-installed/package.json
+++ b/test/fixtures/optional-peer-deps-npm7/transitive-optional-installed/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "dependencies": {
+    "test-peer-deps-optional": "1.0.0",
+    "react": "^17.0.2"
+  }
+}

--- a/test/fixtures/optional-peer-deps-npm7/transitive-optional-not-installed/expected-tree.json
+++ b/test/fixtures/optional-peer-deps-npm7/transitive-optional-not-installed/expected-tree.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "test-peer-deps-optional": {
+      "labels": { "scope": "prod" },
+      "name": "test-peer-deps-optional",
+      "version": "1.0.0"
+    }
+  },
+  "hasDevDependencies": false,
+  "name": "goof",
+  "size": 2,
+  "version": "0.0.3",
+  "meta": { "lockfileVersion": 2, "packageManager": "npm" }
+}

--- a/test/fixtures/optional-peer-deps-npm7/transitive-optional-not-installed/package-lock.json
+++ b/test/fixtures/optional-peer-deps-npm7/transitive-optional-not-installed/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goof",
+      "version": "0.0.3",
+      "dependencies": {
+        "test-peer-deps-optional": "1.0.0"
+      }
+    },
+    "node_modules/test-peer-deps-optional": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/test-peer-deps-optional/-/test-peer-deps-optional-1.0.0.tgz",
+      "integrity": "sha512-mXwLorPrb/ZucRuJC21zkr3JMddhicmn9t4pLDzcYROhP3vKEtxwNGxfJGphCViEtMMOQmSgHc8e/4Q8a9JvSQ==",
+      "peerDependencies": {
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "test-peer-deps-optional": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/test-peer-deps-optional/-/test-peer-deps-optional-1.0.0.tgz",
+      "integrity": "sha512-mXwLorPrb/ZucRuJC21zkr3JMddhicmn9t4pLDzcYROhP3vKEtxwNGxfJGphCViEtMMOQmSgHc8e/4Q8a9JvSQ==",
+      "requires": {}
+    }
+  }
+}

--- a/test/fixtures/optional-peer-deps-npm7/transitive-optional-not-installed/package.json
+++ b/test/fixtures/optional-peer-deps-npm7/transitive-optional-not-installed/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "dependencies": {
+    "test-peer-deps-optional": "1.0.0"
+  }
+}

--- a/test/fixtures/peer-deps/npm7/package-lock.json
+++ b/test/fixtures/peer-deps/npm7/package-lock.json
@@ -14,7 +14,13 @@
         "debug": "^2.2.0"
       },
       "peerDependencies": {
+        "body-parser": "^1.19.0",
         "has": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "body-parser": {
+          "optional": true
+        }
       }
     },
     "node_modules/adm-zip": {

--- a/test/lib/package-lock-depTree.test.ts
+++ b/test/lib/package-lock-depTree.test.ts
@@ -342,3 +342,59 @@ test('Npm Tree size exceeds the allowed limit of 500 dependencies.', async (t) =
     'Expected error is thrown',
   );
 });
+
+test('`package.json` with direct optional peer (npm7) installed', async (t) => {
+  const expectedDepTree = load(
+    'optional-peer-deps-npm7/direct-optional-installed/expected-tree.json',
+  );
+
+  const depTree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/optional-peer-deps-npm7/direct-optional-installed`,
+    'package.json',
+    'package-lock.json',
+  );
+
+  t.deepEqual(depTree, expectedDepTree, 'Tree generated as expected');
+});
+
+test('`package.json` with direct optional peer (npm7) not installed', async (t) => {
+  const expectedDepTree = load(
+    'optional-peer-deps-npm7/direct-optional-not-installed/expected-tree.json',
+  );
+
+  const depTree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/optional-peer-deps-npm7/direct-optional-not-installed`,
+    'package.json',
+    'package-lock.json',
+  );
+
+  t.deepEqual(depTree, expectedDepTree, 'Tree generated as expected');
+});
+
+test('`package.json` with transitive optional peer (npm7) installed', async (t) => {
+  const expectedDepTree = load(
+    'optional-peer-deps-npm7/transitive-optional-installed/expected-tree.json',
+  );
+
+  const depTree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/optional-peer-deps-npm7/transitive-optional-installed`,
+    'package.json',
+    'package-lock.json',
+  );
+
+  t.deepEqual(depTree, expectedDepTree, 'Tree generated as expected');
+});
+
+test('`package.json` with transitive optional peer (npm7) not installed', async (t) => {
+  const expectedDepTree = load(
+    'optional-peer-deps-npm7/transitive-optional-not-installed/expected-tree.json',
+  );
+
+  const depTree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/optional-peer-deps-npm7/transitive-optional-not-installed`,
+    'package.json',
+    'package-lock.json',
+  );
+
+  t.deepEqual(depTree, expectedDepTree, 'Tree generated as expected');
+});


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i); Not Applicable
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md); 
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i); test are split on purpose to showcase a fail build.
- [x] Reviewed by Snyk team

### What this does

This PR aims to correct that by excluding the optional peer dependencies from the generated top-level dependency tree.

### Notes for the reviewer

- Currently, Snyk considers that a peer dependency should be part of the lockfile if there is such dependency and the `lockfileVersion !==2`. This does not take into account the `peerDependencyMeta` and the possibility that a peer dependency can be optional (see [npm doc](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta)).
- The proposed behaviour assumes that Snyk should 'dismiss' optional peer dependency.
- Should fix #121 

### More information
- [npm, peerDependenciesMeta](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta).

### Screenshots

_Visuals that may help the reviewer_
