### PR TITLE
fix: display unknown-version instead of truncating package name when …

### DIFF
--- a/lib/cli-parsers/cli-parser-utils.ts
+++ b/lib/cli-parsers/cli-parser-utils.ts
@@ -1,12 +1,11 @@
 import * as semver from 'semver';
+import * as npa from 'npm-package-arg';
 
 export const extractNameAndIdentifier = (
   candidate: string,
 ): { name: string; identifier: string } => {
-  const index = candidate.indexOf('@', 1);
-  const name = candidate.slice(0, index);
-  const identifier = candidate.slice(index + 1);
-  return { name, identifier };
+  const parsed = npa(candidate);
+  return { name: parsed.name, identifier: parsed.rawSpec };
 };
 
 // This function will choose an item in a particular list that satisfies the semver provided

--- a/lib/parsers/lock-parser-base.ts
+++ b/lib/parsers/lock-parser-base.ts
@@ -5,6 +5,7 @@ import * as graphlib from '@snyk/graphlib';
 import { v4 as uuid } from 'uuid';
 import { eventLoopSpinner } from 'event-loop-spinner';
 import * as baseDebug from 'debug';
+import { extractNameAndIdentifier } from '../cli-parsers/cli-parser-utils';
 
 import {
   createDepTreeDepFromDep,
@@ -416,18 +417,18 @@ export abstract class LockParserBase implements LockfileParser {
         }
         if (!subDep) {
           debug(`Missing entry for ${subDepPath}`);
-          const index = subDepPath.indexOf('@', 1);
-          const name = subDepPath.slice(0, index);
-          const identifier = subDepPath.slice(index + 1);
+
+          const { name, identifier } = extractNameAndIdentifier(subDepPath);
 
           subDep = {
             name: name,
-            version: identifier,
+            version: identifier || 'unknown-version',
             dependencies: {},
             labels: {
               missingLockFileEntry: 'true',
             },
           };
+
           treeSize += 1;
         } else {
           treeSize += depTreesSizes[subDepPath];

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.isempty": "^4.4.0",
     "lodash.topairs": "^4.3.0",
+    "npm-package-arg": "^9.0.2",
     "semver": "^7.3.5",
     "snyk-config": "^4.0.0-rc.2",
     "tslib": "^1.9.3",

--- a/test/fixtures/missing-required-deps-in-lock/expected-tree.json
+++ b/test/fixtures/missing-required-deps-in-lock/expected-tree.json
@@ -1,0 +1,36 @@
+{
+  "dependencies": {
+    "adm-zip": {
+      "labels": {
+        "scope": "prod"
+      },
+      "name": "adm-zip",
+      "version": "0.4.7"
+    },
+    "debug": {
+      "labels": {
+        "scope": "prod"
+      },
+      "name": "debug",
+      "version": "2.6.9",
+      "dependencies": {
+        "ms": {
+          "name": "ms",
+          "version": "unknown-version",
+          "dependencies": {},
+          "labels": {
+            "missingLockFileEntry": "true"
+          }
+        }
+      }
+    }
+  },
+  "hasDevDependencies": false,
+  "name": "goof",
+  "size": 4,
+  "version": "0.0.3",
+  "meta": {
+    "lockfileVersion": 1,
+    "packageManager": "npm"
+  }
+}

--- a/test/fixtures/missing-required-deps-in-lock/package-lock.json
+++ b/test/fixtures/missing-required-deps-in-lock/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "adm-zip": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "optional": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    }
+  }
+}

--- a/test/fixtures/missing-required-deps-in-lock/package.json
+++ b/test/fixtures/missing-required-deps-in-lock/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "goof",
+  "version": "0.0.3",
+  "description": "A vulnerable todo demo application",
+  "homepage": "https://snyk.io/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Snyk/snyk-todo-list-demo-app/"
+  },
+  "dependencies": {
+    "adm-zip": "0.4.7",
+    "debug": "^2.2.0"
+  },
+  "devDependencies": {}
+}

--- a/test/lib/package-lock-depTree.test.ts
+++ b/test/lib/package-lock-depTree.test.ts
@@ -100,6 +100,24 @@ test('Parse npm package-lock.json with empty dependencies and includeDev = false
   t.deepEqual(depTree, expectedDepTree, 'Tree is created with empty deps');
 });
 
+test('Parse npm package-lock.json with missing required dependencies', async (t) => {
+  const expectedDepTree = load(
+    'missing-required-deps-in-lock/expected-tree.json',
+  );
+  const depTree = await buildDepTreeFromFiles(
+    `${__dirname}/../fixtures/missing-required-deps-in-lock/`,
+    'package.json',
+    'package-lock.json',
+    false,
+    false,
+  );
+  t.deepEqual(
+    depTree,
+    expectedDepTree,
+    'Tree is created with missing required deps',
+  );
+});
+
 test('Parse npm package-lock.json with empty dependencies and includeDev = true', async (t) => {
   const expectedDepTree = load('missing-deps/expected-tree.json');
   const depTree = await buildDepTreeFromFiles(


### PR DESCRIPTION
- [x] Tests written and linted

### What this does

For the following npm lock file where packages exist in `requires` list but miss the lock entries, the package resolution displays weirdly:

```
"parentPackage": {
  "version": "0.0.1",
    "requires": {
      "childPackage1": "^1.0.0",
      "childPackage2": "^1.0.0"
    }
}

// no package resolution for childPackage1, childPackage2
```

It displays as `childPackage@childPackage1` and `childPackage@childPackage2`. This is due to that we take away the version info (the `"^1.0.0"` part) from the package in `requires` list when constructing the dep map, which makes sense because in theory there should be corresponding lock entries in the lock file for these packages which would contain the actual resolved version. Then `indexOf('@')` for the `childPackage1` resolves to `-1`.

This PR slightly improves the display by showing `unknown-version`, i.e. `childPackage1@unknown-version` and `childPackage2@unknown-version`.

This PR also uses the [npm-package-arg](https://github.com/npm/npm-package-arg) to parse the package name instead of relying on `indexOf('@')`.

### Screenshots
![Screenshot 2022-06-02 at 17 56 57](https://user-images.githubusercontent.com/102186579/171674726-e4787ffb-7d02-4ede-af1b-ed4347281286.png)