### PR TITLE
chore: use 'unknown' to be consistent with other ecosystems

### DIFF
--- a/lib/parsers/lock-parser-base.ts
+++ b/lib/parsers/lock-parser-base.ts
@@ -422,7 +422,7 @@ export abstract class LockParserBase implements LockfileParser {
 
           subDep = {
             name: name,
-            version: identifier || 'unknown-version',
+            version: identifier || 'unknown',
             dependencies: {},
             labels: {
               missingLockFileEntry: 'true',

--- a/test/fixtures/missing-required-deps-in-lock/expected-tree.json
+++ b/test/fixtures/missing-required-deps-in-lock/expected-tree.json
@@ -16,7 +16,7 @@
       "dependencies": {
         "ms": {
           "name": "ms",
-          "version": "unknown-version",
+          "version": "unknown",
           "dependencies": {},
           "labels": {
             "missingLockFileEntry": "true"


### PR DESCRIPTION
Maven seems to use 'unknown' (https://support.snyk.io/hc/en-us/articles/4934749708829). It would be nice to keep the wording consistent.