### PR TITLE
feat: remove npa package name parser and revert to old method

### DIFF
--- a/lib/cli-parsers/cli-parser-utils.ts
+++ b/lib/cli-parsers/cli-parser-utils.ts
@@ -1,11 +1,20 @@
 import * as semver from 'semver';
-import * as npa from 'npm-package-arg';
 
 export const extractNameAndIdentifier = (
   candidate: string,
 ): { name: string; identifier: string } => {
-  const parsed = npa(candidate);
-  return { name: parsed.name, identifier: parsed.rawSpec };
+  let name, identifier;
+
+  if (candidate.includes('@')) {
+    const index = candidate.indexOf('@', 1);
+    name = candidate.slice(0, index);
+    identifier = candidate.slice(index + 1);
+  } else {
+    name = candidate;
+    identifier = 'unknown';
+  }
+
+  return { name, identifier };
 };
 
 // This function will choose an item in a particular list that satisfies the semver provided

--- a/lib/parsers/lock-parser-base.ts
+++ b/lib/parsers/lock-parser-base.ts
@@ -422,7 +422,7 @@ export abstract class LockParserBase implements LockfileParser {
 
           subDep = {
             name: name,
-            version: identifier || 'unknown',
+            version: identifier,
             dependencies: {},
             labels: {
               missingLockFileEntry: 'true',

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.isempty": "^4.4.0",
     "lodash.topairs": "^4.3.0",
-    "npm-package-arg": "^9.0.2",
     "semver": "^7.3.5",
     "snyk-config": "^4.0.0-rc.2",
     "tslib": "^1.9.3",


### PR DESCRIPTION
This PR removes the `npm-package-arg` package and reverts to the old method when parsing package name. The reason is, `npm-package-arg` is excellent in parsing package names in `package-lock.json`, but it couldn't parse certain complicated package names in `yarn2.lock`, e.g. `resolve@patch:resolve@^1.10.0#builtin<compat/resolve>` which is using the compat plugin.