### PR TITLE
feat: new @snyk/dep-graph (no more node 8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "homepage": "https://github.com/snyk/nodejs-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/dep-graph": "^1.28.0",
+    "@snyk/dep-graph": "^2.3.0",
     "@snyk/graphlib": "2.1.9-patch.3",
     "@yarnpkg/core": "^2.4.0",
     "@yarnpkg/lockfile": "^1.1.0",


### PR DESCRIPTION
### What this does

Upgrade to the recent version of @snyk/dep-graph, which has dropped support for node 8, which we haven't cared about for a long time.