### PR TITLE
fix: apply array type check for workspace configs

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -175,11 +175,15 @@ export function getYarnWorkspaces(targetFile: string): string[] | false {
   try {
     const packageJson: ManifestFile = parseManifestFile(targetFile);
     if (!!packageJson.workspaces && !!packageJson.private) {
-      const workspacesPackages = packageJson.workspaces as string[];
-      const workspacesAlternateConfigPackages = (
-        packageJson.workspaces as WorkspacesAlternateConfig
-      ).packages;
-      return [...(workspacesAlternateConfigPackages || workspacesPackages)];
+      if (Array.isArray(packageJson.workspaces)) {
+        return packageJson.workspaces;
+      }
+      if (
+        'packages' in packageJson.workspaces &&
+        Array.isArray(packageJson.workspaces.packages)
+      ) {
+        return packageJson.workspaces.packages;
+      }
     }
     return false;
   } catch (e) {

--- a/test/fixtures/yarn-workspace-missing-packages-config/package.json
+++ b/test/fixtures/yarn-workspace-missing-packages-config/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "jest",
+  "devDependencies": {
+    "chalk": "^2.0.1"
+  },
+  "workspaces": {
+    "nohoist": ["packages/*", "libs/*"]
+  }
+}

--- a/test/lib/yarn-workflows.test.ts
+++ b/test/lib/yarn-workflows.test.ts
@@ -4,7 +4,7 @@
 import { test } from 'tap';
 import { getYarnWorkspacesFromFiles } from '../../lib';
 
-test('Identify package.json as a yarn workspace', async (t) => {
+test('identify package.json as a yarn workspace', async (t) => {
   const workspaces = getYarnWorkspacesFromFiles(
     `${__dirname}/../fixtures/yarn-workspace/`,
     'package.json',
@@ -16,7 +16,7 @@ test('Identify package.json as a yarn workspace', async (t) => {
   );
 });
 
-test('Identify package.json as a yarn workspace when using alternate configuration format', async (t) => {
+test('identify package.json as a yarn workspace when using alternate configuration format', async (t) => {
   const workspaces = getYarnWorkspacesFromFiles(
     `${__dirname}/../fixtures/yarn-workspace-alternate-config/`,
     'package.json',
@@ -27,6 +27,14 @@ test('Identify package.json as a yarn workspace when using alternate configurati
 test('identify package.json as Not a workspace project', async (t) => {
   const workspaces = getYarnWorkspacesFromFiles(
     `${__dirname}/../fixtures/external-tarball/`,
+    'package.json',
+  );
+  t.is(workspaces, false, 'Not a yarn workspace');
+});
+
+test('identify package.json as non workspace project when workspaces config does not have managed packages', async (t) => {
+  const workspaces = getYarnWorkspacesFromFiles(
+    `${__dirname}/../fixtures/yarn-workspace-missing-packages-config/`,
     'package.json',
   );
   t.is(workspaces, false, 'Not a yarn workspace');


### PR DESCRIPTION
In our old logic, we assume that the `workspaces` section in the `package.json` file would be one of the following:
```
{
  "workspaces": ["packageA/**", "packageB/**"]
}

{
  workspaces: {
    "packages":  ["packageA/**", "packageB/**"]
  }
}

```

But there could be situations that this assumption doesn't hold, in which case our code fails because we can't iterate on a non-array object. For example, it is possible that one declares only information about `nohoist`, e.g.

```
{
  "workspaces":
    {
      "nohoist": ["packageA/**", "packageB/**"]
    }
}
```

This PR strengthens the array type check on `workspaces` and `workspaces.packages` to make sure no error would be thrown.