### PR TITLE
fix: detect yarn.lock files in bin command

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const inspect = require('../dist/index')
 
-inspect.buildDepTreeFromFiles('./', 'package.json', 'package-lock.json')
+inspect.buildDepTreeFromFiles('./', 'package.json', 'package-lock.json', 'yarn.lock')
   .then((tree) => {
     console.log(JSON.stringify(tree));
   })


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

In the bin command, detect `yarn.lock` files in addition to the existing support for `package.json` and `package-lock.json`.

### Notes for the reviewer

`node bin/index.js` from a directory containing a `yarn.lock` file now display results.

### More information

### Screenshots

_Visuals that may help the reviewer_
