### PR TITLE
fix: make sure to use pkgJson to pick the root package name

### DIFF
--- a/lib/dep-graph-builders/npm-lock-v2/index.ts
+++ b/lib/dep-graph-builders/npm-lock-v2/index.ts
@@ -44,11 +44,9 @@ export const buildDepGraphNpmLockV2 = (
 ) => {
   const { includeDevDeps, strictOutOfSync, includeOptionalDeps } = options;
 
-  const rootPkg = npmLockPkgs[''];
-
   const depGraphBuilder = new DepGraphBuilder(
     { name: 'npm' },
-    { name: rootPkg.name as string, version: rootPkg.version },
+    { name: pkgJson.name as string, version: pkgJson.version },
   );
 
   const topLevelDeps = getTopLevelDeps(pkgJson, {
@@ -59,8 +57,8 @@ export const buildDepGraphNpmLockV2 = (
 
   const rootNode: PkgNode = {
     id: 'root-node',
-    name: rootPkg.name as string,
-    version: rootPkg.version,
+    name: pkgJson.name,
+    version: pkgJson.version,
     dependencies: topLevelDeps,
     isDev: false,
   };


### PR DESCRIPTION
Initially I was using data from the package-lock.json to get root package information but the presence of [this fixture](https://github.com/snyk/cli/blob/master/test/fixtures/npm/with-vulnerable-lodash-dep/package-lock.json) made me realise this isn't always possible. 

This uses logic that we have previously used to get root package information.
