### PR TITLE
fix: handles npm lock v2 bundled dependencies

### DIFF
--- a/lib/dep-graph-builders/npm-lock-v2/extract-npm-lock-v2-pkgs.ts
+++ b/lib/dep-graph-builders/npm-lock-v2/extract-npm-lock-v2-pkgs.ts
@@ -10,6 +10,7 @@ export type NpmLockPkg = {
   resolved?: string;
   license?: string;
   engines?: Record<string, string>;
+  inBundle?: boolean;
 };
 
 export const extractPkgsFromNpmLockV2 = (

--- a/lib/dep-graph-builders/util.ts
+++ b/lib/dep-graph-builders/util.ts
@@ -14,6 +14,7 @@ export interface PkgNode {
   dependencies: Dependencies;
   isDev: boolean;
   missingLockFileEntry?: boolean;
+  inBundle?: boolean;
 }
 
 export const addPkgNodeToGraph = (

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/deeply-nested-packages/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/deeply-nested-packages/expected.json
@@ -1,0 +1,9081 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "npm"
+  },
+  "pkgs": [
+    {
+      "id": "deeply-nested-packages@1.0.0",
+      "info": {
+        "name": "deeply-nested-packages",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "npm@6.14.17",
+      "info": {
+        "name": "npm",
+        "version": "6.14.17"
+      }
+    },
+    {
+      "id": "abbrev@1.1.1",
+      "info": {
+        "name": "abbrev",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "ansicolors@0.3.2",
+      "info": {
+        "name": "ansicolors",
+        "version": "0.3.2"
+      }
+    },
+    {
+      "id": "ansistyles@0.1.3",
+      "info": {
+        "name": "ansistyles",
+        "version": "0.1.3"
+      }
+    },
+    {
+      "id": "aproba@2.0.0",
+      "info": {
+        "name": "aproba",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "archy@1.0.0",
+      "info": {
+        "name": "archy",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "bin-links@1.1.8",
+      "info": {
+        "name": "bin-links",
+        "version": "1.1.8"
+      }
+    },
+    {
+      "id": "bluebird@3.5.5",
+      "info": {
+        "name": "bluebird",
+        "version": "3.5.5"
+      }
+    },
+    {
+      "id": "cmd-shim@3.0.3",
+      "info": {
+        "name": "cmd-shim",
+        "version": "3.0.3"
+      }
+    },
+    {
+      "id": "graceful-fs@4.2.4",
+      "info": {
+        "name": "graceful-fs",
+        "version": "4.2.4"
+      }
+    },
+    {
+      "id": "mkdirp@0.5.5",
+      "info": {
+        "name": "mkdirp",
+        "version": "0.5.5"
+      }
+    },
+    {
+      "id": "minimist@1.2.6",
+      "info": {
+        "name": "minimist",
+        "version": "1.2.6"
+      }
+    },
+    {
+      "id": "gentle-fs@2.3.1",
+      "info": {
+        "name": "gentle-fs",
+        "version": "2.3.1"
+      }
+    },
+    {
+      "id": "aproba@1.2.0",
+      "info": {
+        "name": "aproba",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "chownr@1.1.4",
+      "info": {
+        "name": "chownr",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "fs-vacuum@1.2.10",
+      "info": {
+        "name": "fs-vacuum",
+        "version": "1.2.10"
+      }
+    },
+    {
+      "id": "path-is-inside@1.0.2",
+      "info": {
+        "name": "path-is-inside",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "rimraf@2.7.1",
+      "info": {
+        "name": "rimraf",
+        "version": "2.7.1"
+      }
+    },
+    {
+      "id": "glob@7.1.6",
+      "info": {
+        "name": "glob",
+        "version": "7.1.6"
+      }
+    },
+    {
+      "id": "fs.realpath@1.0.0",
+      "info": {
+        "name": "fs.realpath",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "inflight@1.0.6",
+      "info": {
+        "name": "inflight",
+        "version": "1.0.6"
+      }
+    },
+    {
+      "id": "once@1.4.0",
+      "info": {
+        "name": "once",
+        "version": "1.4.0"
+      }
+    },
+    {
+      "id": "wrappy@1.0.2",
+      "info": {
+        "name": "wrappy",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "minimatch@3.0.4",
+      "info": {
+        "name": "minimatch",
+        "version": "3.0.4"
+      }
+    },
+    {
+      "id": "brace-expansion@1.1.11",
+      "info": {
+        "name": "brace-expansion",
+        "version": "1.1.11"
+      }
+    },
+    {
+      "id": "balanced-match@1.0.0",
+      "info": {
+        "name": "balanced-match",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "concat-map@0.0.1",
+      "info": {
+        "name": "concat-map",
+        "version": "0.0.1"
+      }
+    },
+    {
+      "id": "path-is-absolute@1.0.1",
+      "info": {
+        "name": "path-is-absolute",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iferr@0.1.5",
+      "info": {
+        "name": "iferr",
+        "version": "0.1.5"
+      }
+    },
+    {
+      "id": "infer-owner@1.0.4",
+      "info": {
+        "name": "infer-owner",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "read-cmd-shim@1.0.5",
+      "info": {
+        "name": "read-cmd-shim",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "slide@1.1.6",
+      "info": {
+        "name": "slide",
+        "version": "1.1.6"
+      }
+    },
+    {
+      "id": "npm-normalize-package-bin@1.0.1",
+      "info": {
+        "name": "npm-normalize-package-bin",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "write-file-atomic@2.4.3",
+      "info": {
+        "name": "write-file-atomic",
+        "version": "2.4.3"
+      }
+    },
+    {
+      "id": "imurmurhash@0.1.4",
+      "info": {
+        "name": "imurmurhash",
+        "version": "0.1.4"
+      }
+    },
+    {
+      "id": "signal-exit@3.0.2",
+      "info": {
+        "name": "signal-exit",
+        "version": "3.0.2"
+      }
+    },
+    {
+      "id": "byte-size@5.0.1",
+      "info": {
+        "name": "byte-size",
+        "version": "5.0.1"
+      }
+    },
+    {
+      "id": "cacache@12.0.3",
+      "info": {
+        "name": "cacache",
+        "version": "12.0.3"
+      }
+    },
+    {
+      "id": "figgy-pudding@3.5.1",
+      "info": {
+        "name": "figgy-pudding",
+        "version": "3.5.1"
+      }
+    },
+    {
+      "id": "lru-cache@5.1.1",
+      "info": {
+        "name": "lru-cache",
+        "version": "5.1.1"
+      }
+    },
+    {
+      "id": "yallist@3.0.3",
+      "info": {
+        "name": "yallist",
+        "version": "3.0.3"
+      }
+    },
+    {
+      "id": "mississippi@3.0.0",
+      "info": {
+        "name": "mississippi",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "concat-stream@1.6.2",
+      "info": {
+        "name": "concat-stream",
+        "version": "1.6.2"
+      }
+    },
+    {
+      "id": "buffer-from@1.0.0",
+      "info": {
+        "name": "buffer-from",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "readable-stream@2.3.6",
+      "info": {
+        "name": "readable-stream",
+        "version": "2.3.6"
+      }
+    },
+    {
+      "id": "core-util-is@1.0.2",
+      "info": {
+        "name": "core-util-is",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "isarray@1.0.0",
+      "info": {
+        "name": "isarray",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "process-nextick-args@2.0.0",
+      "info": {
+        "name": "process-nextick-args",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "safe-buffer@5.1.2",
+      "info": {
+        "name": "safe-buffer",
+        "version": "5.1.2"
+      }
+    },
+    {
+      "id": "string_decoder@1.1.1",
+      "info": {
+        "name": "string_decoder",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "safe-buffer@5.2.0",
+      "info": {
+        "name": "safe-buffer",
+        "version": "5.2.0"
+      }
+    },
+    {
+      "id": "util-deprecate@1.0.2",
+      "info": {
+        "name": "util-deprecate",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "typedarray@0.0.6",
+      "info": {
+        "name": "typedarray",
+        "version": "0.0.6"
+      }
+    },
+    {
+      "id": "duplexify@3.6.0",
+      "info": {
+        "name": "duplexify",
+        "version": "3.6.0"
+      }
+    },
+    {
+      "id": "end-of-stream@1.4.1",
+      "info": {
+        "name": "end-of-stream",
+        "version": "1.4.1"
+      }
+    },
+    {
+      "id": "stream-shift@1.0.0",
+      "info": {
+        "name": "stream-shift",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "flush-write-stream@1.0.3",
+      "info": {
+        "name": "flush-write-stream",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "from2@2.3.0",
+      "info": {
+        "name": "from2",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "parallel-transform@1.1.0",
+      "info": {
+        "name": "parallel-transform",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "cyclist@0.2.2",
+      "info": {
+        "name": "cyclist",
+        "version": "0.2.2"
+      }
+    },
+    {
+      "id": "pump@3.0.0",
+      "info": {
+        "name": "pump",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "pumpify@1.5.1",
+      "info": {
+        "name": "pumpify",
+        "version": "1.5.1"
+      }
+    },
+    {
+      "id": "pump@2.0.1",
+      "info": {
+        "name": "pump",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "stream-each@1.2.2",
+      "info": {
+        "name": "stream-each",
+        "version": "1.2.2"
+      }
+    },
+    {
+      "id": "through2@2.0.3",
+      "info": {
+        "name": "through2",
+        "version": "2.0.3"
+      }
+    },
+    {
+      "id": "xtend@4.0.1",
+      "info": {
+        "name": "xtend",
+        "version": "4.0.1"
+      }
+    },
+    {
+      "id": "move-concurrently@1.0.1",
+      "info": {
+        "name": "move-concurrently",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "copy-concurrently@1.0.5",
+      "info": {
+        "name": "copy-concurrently",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "fs-write-stream-atomic@1.0.10",
+      "info": {
+        "name": "fs-write-stream-atomic",
+        "version": "1.0.10"
+      }
+    },
+    {
+      "id": "run-queue@1.0.3",
+      "info": {
+        "name": "run-queue",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "promise-inflight@1.0.1",
+      "info": {
+        "name": "promise-inflight",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "ssri@6.0.2",
+      "info": {
+        "name": "ssri",
+        "version": "6.0.2"
+      }
+    },
+    {
+      "id": "unique-filename@1.1.1",
+      "info": {
+        "name": "unique-filename",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "unique-slug@2.0.0",
+      "info": {
+        "name": "unique-slug",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "y18n@4.0.1",
+      "info": {
+        "name": "y18n",
+        "version": "4.0.1"
+      }
+    },
+    {
+      "id": "call-limit@1.1.1",
+      "info": {
+        "name": "call-limit",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "ci-info@2.0.0",
+      "info": {
+        "name": "ci-info",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "cli-columns@3.1.2",
+      "info": {
+        "name": "cli-columns",
+        "version": "3.1.2"
+      }
+    },
+    {
+      "id": "string-width@2.1.1",
+      "info": {
+        "name": "string-width",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "is-fullwidth-code-point@2.0.0",
+      "info": {
+        "name": "is-fullwidth-code-point",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "strip-ansi@4.0.0",
+      "info": {
+        "name": "strip-ansi",
+        "version": "4.0.0"
+      }
+    },
+    {
+      "id": "ansi-regex@3.0.0",
+      "info": {
+        "name": "ansi-regex",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "strip-ansi@3.0.1",
+      "info": {
+        "name": "strip-ansi",
+        "version": "3.0.1"
+      }
+    },
+    {
+      "id": "ansi-regex@2.1.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "cli-table3@0.5.1",
+      "info": {
+        "name": "cli-table3",
+        "version": "0.5.1"
+      }
+    },
+    {
+      "id": "object-assign@4.1.1",
+      "info": {
+        "name": "object-assign",
+        "version": "4.1.1"
+      }
+    },
+    {
+      "id": "colors@1.3.3",
+      "info": {
+        "name": "colors",
+        "version": "1.3.3"
+      }
+    },
+    {
+      "id": "columnify@1.5.4",
+      "info": {
+        "name": "columnify",
+        "version": "1.5.4"
+      }
+    },
+    {
+      "id": "wcwidth@1.0.1",
+      "info": {
+        "name": "wcwidth",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "defaults@1.0.3",
+      "info": {
+        "name": "defaults",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "clone@1.0.4",
+      "info": {
+        "name": "clone",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "config-chain@1.1.12",
+      "info": {
+        "name": "config-chain",
+        "version": "1.1.12"
+      }
+    },
+    {
+      "id": "ini@1.3.8",
+      "info": {
+        "name": "ini",
+        "version": "1.3.8"
+      }
+    },
+    {
+      "id": "proto-list@1.2.4",
+      "info": {
+        "name": "proto-list",
+        "version": "1.2.4"
+      }
+    },
+    {
+      "id": "debuglog@1.0.1",
+      "info": {
+        "name": "debuglog",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "detect-indent@5.0.0",
+      "info": {
+        "name": "detect-indent",
+        "version": "5.0.0"
+      }
+    },
+    {
+      "id": "detect-newline@2.1.0",
+      "info": {
+        "name": "detect-newline",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "dezalgo@1.0.3",
+      "info": {
+        "name": "dezalgo",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "asap@2.0.6",
+      "info": {
+        "name": "asap",
+        "version": "2.0.6"
+      }
+    },
+    {
+      "id": "editor@1.0.0",
+      "info": {
+        "name": "editor",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "find-npm-prefix@1.0.2",
+      "info": {
+        "name": "find-npm-prefix",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "has-unicode@2.0.1",
+      "info": {
+        "name": "has-unicode",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "hosted-git-info@2.8.9",
+      "info": {
+        "name": "hosted-git-info",
+        "version": "2.8.9"
+      }
+    },
+    {
+      "id": "iferr@1.0.2",
+      "info": {
+        "name": "iferr",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "init-package-json@1.10.3",
+      "info": {
+        "name": "init-package-json",
+        "version": "1.10.3"
+      }
+    },
+    {
+      "id": "npm-package-arg@6.1.1",
+      "info": {
+        "name": "npm-package-arg",
+        "version": "6.1.1"
+      }
+    },
+    {
+      "id": "osenv@0.1.5",
+      "info": {
+        "name": "osenv",
+        "version": "0.1.5"
+      }
+    },
+    {
+      "id": "os-homedir@1.0.2",
+      "info": {
+        "name": "os-homedir",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "os-tmpdir@1.0.2",
+      "info": {
+        "name": "os-tmpdir",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "semver@5.7.1",
+      "info": {
+        "name": "semver",
+        "version": "5.7.1"
+      }
+    },
+    {
+      "id": "validate-npm-package-name@3.0.0",
+      "info": {
+        "name": "validate-npm-package-name",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "builtins@1.0.3",
+      "info": {
+        "name": "builtins",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "promzard@0.3.0",
+      "info": {
+        "name": "promzard",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "read@1.0.7",
+      "info": {
+        "name": "read",
+        "version": "1.0.7"
+      }
+    },
+    {
+      "id": "mute-stream@0.0.7",
+      "info": {
+        "name": "mute-stream",
+        "version": "0.0.7"
+      }
+    },
+    {
+      "id": "read-package-json@2.1.1",
+      "info": {
+        "name": "read-package-json",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "json-parse-better-errors@1.0.2",
+      "info": {
+        "name": "json-parse-better-errors",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "normalize-package-data@2.5.0",
+      "info": {
+        "name": "normalize-package-data",
+        "version": "2.5.0"
+      }
+    },
+    {
+      "id": "resolve@1.10.0",
+      "info": {
+        "name": "resolve",
+        "version": "1.10.0"
+      }
+    },
+    {
+      "id": "path-parse@1.0.7",
+      "info": {
+        "name": "path-parse",
+        "version": "1.0.7"
+      }
+    },
+    {
+      "id": "validate-npm-package-license@3.0.4",
+      "info": {
+        "name": "validate-npm-package-license",
+        "version": "3.0.4"
+      }
+    },
+    {
+      "id": "spdx-correct@3.0.0",
+      "info": {
+        "name": "spdx-correct",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "spdx-expression-parse@3.0.0",
+      "info": {
+        "name": "spdx-expression-parse",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "spdx-exceptions@2.1.0",
+      "info": {
+        "name": "spdx-exceptions",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "spdx-license-ids@3.0.5",
+      "info": {
+        "name": "spdx-license-ids",
+        "version": "3.0.5"
+      }
+    },
+    {
+      "id": "is-cidr@3.0.0",
+      "info": {
+        "name": "is-cidr",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "cidr-regex@2.0.10",
+      "info": {
+        "name": "cidr-regex",
+        "version": "2.0.10"
+      }
+    },
+    {
+      "id": "ip-regex@2.1.0",
+      "info": {
+        "name": "ip-regex",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "JSONStream@1.3.5",
+      "info": {
+        "name": "JSONStream",
+        "version": "1.3.5"
+      }
+    },
+    {
+      "id": "jsonparse@1.3.1",
+      "info": {
+        "name": "jsonparse",
+        "version": "1.3.1"
+      }
+    },
+    {
+      "id": "through@2.3.8",
+      "info": {
+        "name": "through",
+        "version": "2.3.8"
+      }
+    },
+    {
+      "id": "lazy-property@1.0.0",
+      "info": {
+        "name": "lazy-property",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "libcipm@4.0.8",
+      "info": {
+        "name": "libcipm",
+        "version": "4.0.8"
+      }
+    },
+    {
+      "id": "lock-verify@2.1.0",
+      "info": {
+        "name": "lock-verify",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "npm-lifecycle@3.1.5",
+      "info": {
+        "name": "npm-lifecycle",
+        "version": "3.1.5"
+      }
+    },
+    {
+      "id": "byline@5.0.0",
+      "info": {
+        "name": "byline",
+        "version": "5.0.0"
+      }
+    },
+    {
+      "id": "node-gyp@5.1.0",
+      "info": {
+        "name": "node-gyp",
+        "version": "5.1.0"
+      }
+    },
+    {
+      "id": "env-paths@2.2.0",
+      "info": {
+        "name": "env-paths",
+        "version": "2.2.0"
+      }
+    },
+    {
+      "id": "nopt@4.0.3",
+      "info": {
+        "name": "nopt",
+        "version": "4.0.3"
+      }
+    },
+    {
+      "id": "npmlog@4.1.2",
+      "info": {
+        "name": "npmlog",
+        "version": "4.1.2"
+      }
+    },
+    {
+      "id": "are-we-there-yet@1.1.4",
+      "info": {
+        "name": "are-we-there-yet",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "delegates@1.0.0",
+      "info": {
+        "name": "delegates",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "console-control-strings@1.1.0",
+      "info": {
+        "name": "console-control-strings",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "gauge@2.7.4",
+      "info": {
+        "name": "gauge",
+        "version": "2.7.4"
+      }
+    },
+    {
+      "id": "string-width@1.0.2",
+      "info": {
+        "name": "string-width",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "code-point-at@1.1.0",
+      "info": {
+        "name": "code-point-at",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "wide-align@1.1.2",
+      "info": {
+        "name": "wide-align",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "set-blocking@2.0.0",
+      "info": {
+        "name": "set-blocking",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "request@2.88.0",
+      "info": {
+        "name": "request",
+        "version": "2.88.0"
+      }
+    },
+    {
+      "id": "aws-sign2@0.7.0",
+      "info": {
+        "name": "aws-sign2",
+        "version": "0.7.0"
+      }
+    },
+    {
+      "id": "aws4@1.8.0",
+      "info": {
+        "name": "aws4",
+        "version": "1.8.0"
+      }
+    },
+    {
+      "id": "caseless@0.12.0",
+      "info": {
+        "name": "caseless",
+        "version": "0.12.0"
+      }
+    },
+    {
+      "id": "combined-stream@1.0.6",
+      "info": {
+        "name": "combined-stream",
+        "version": "1.0.6"
+      }
+    },
+    {
+      "id": "delayed-stream@1.0.0",
+      "info": {
+        "name": "delayed-stream",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "extend@3.0.2",
+      "info": {
+        "name": "extend",
+        "version": "3.0.2"
+      }
+    },
+    {
+      "id": "forever-agent@0.6.1",
+      "info": {
+        "name": "forever-agent",
+        "version": "0.6.1"
+      }
+    },
+    {
+      "id": "form-data@2.3.2",
+      "info": {
+        "name": "form-data",
+        "version": "2.3.2"
+      }
+    },
+    {
+      "id": "asynckit@0.4.0",
+      "info": {
+        "name": "asynckit",
+        "version": "0.4.0"
+      }
+    },
+    {
+      "id": "mime-types@2.1.19",
+      "info": {
+        "name": "mime-types",
+        "version": "2.1.19"
+      }
+    },
+    {
+      "id": "mime-db@1.35.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.35.0"
+      }
+    },
+    {
+      "id": "har-validator@5.1.5",
+      "info": {
+        "name": "har-validator",
+        "version": "5.1.5"
+      }
+    },
+    {
+      "id": "ajv@6.12.6",
+      "info": {
+        "name": "ajv",
+        "version": "6.12.6"
+      }
+    },
+    {
+      "id": "fast-deep-equal@3.1.3",
+      "info": {
+        "name": "fast-deep-equal",
+        "version": "3.1.3"
+      }
+    },
+    {
+      "id": "fast-json-stable-stringify@2.0.0",
+      "info": {
+        "name": "fast-json-stable-stringify",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "json-schema-traverse@0.4.1",
+      "info": {
+        "name": "json-schema-traverse",
+        "version": "0.4.1"
+      }
+    },
+    {
+      "id": "uri-js@4.4.0",
+      "info": {
+        "name": "uri-js",
+        "version": "4.4.0"
+      }
+    },
+    {
+      "id": "punycode@2.1.1",
+      "info": {
+        "name": "punycode",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "har-schema@2.0.0",
+      "info": {
+        "name": "har-schema",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "http-signature@1.2.0",
+      "info": {
+        "name": "http-signature",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "assert-plus@1.0.0",
+      "info": {
+        "name": "assert-plus",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "jsprim@1.4.2",
+      "info": {
+        "name": "jsprim",
+        "version": "1.4.2"
+      }
+    },
+    {
+      "id": "extsprintf@1.3.0",
+      "info": {
+        "name": "extsprintf",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "json-schema@0.4.0",
+      "info": {
+        "name": "json-schema",
+        "version": "0.4.0"
+      }
+    },
+    {
+      "id": "verror@1.10.0",
+      "info": {
+        "name": "verror",
+        "version": "1.10.0"
+      }
+    },
+    {
+      "id": "sshpk@1.14.2",
+      "info": {
+        "name": "sshpk",
+        "version": "1.14.2"
+      }
+    },
+    {
+      "id": "asn1@0.2.4",
+      "info": {
+        "name": "asn1",
+        "version": "0.2.4"
+      }
+    },
+    {
+      "id": "safer-buffer@2.1.2",
+      "info": {
+        "name": "safer-buffer",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "dashdash@1.14.1",
+      "info": {
+        "name": "dashdash",
+        "version": "1.14.1"
+      }
+    },
+    {
+      "id": "getpass@0.1.7",
+      "info": {
+        "name": "getpass",
+        "version": "0.1.7"
+      }
+    },
+    {
+      "id": "bcrypt-pbkdf@1.0.2",
+      "info": {
+        "name": "bcrypt-pbkdf",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "tweetnacl@0.14.5",
+      "info": {
+        "name": "tweetnacl",
+        "version": "0.14.5"
+      }
+    },
+    {
+      "id": "ecc-jsbn@0.1.2",
+      "info": {
+        "name": "ecc-jsbn",
+        "version": "0.1.2"
+      }
+    },
+    {
+      "id": "jsbn@0.1.1",
+      "info": {
+        "name": "jsbn",
+        "version": "0.1.1"
+      }
+    },
+    {
+      "id": "is-typedarray@1.0.0",
+      "info": {
+        "name": "is-typedarray",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "isstream@0.1.2",
+      "info": {
+        "name": "isstream",
+        "version": "0.1.2"
+      }
+    },
+    {
+      "id": "json-stringify-safe@5.0.1",
+      "info": {
+        "name": "json-stringify-safe",
+        "version": "5.0.1"
+      }
+    },
+    {
+      "id": "oauth-sign@0.9.0",
+      "info": {
+        "name": "oauth-sign",
+        "version": "0.9.0"
+      }
+    },
+    {
+      "id": "performance-now@2.1.0",
+      "info": {
+        "name": "performance-now",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "qs@6.5.2",
+      "info": {
+        "name": "qs",
+        "version": "6.5.2"
+      }
+    },
+    {
+      "id": "tough-cookie@2.4.3",
+      "info": {
+        "name": "tough-cookie",
+        "version": "2.4.3"
+      }
+    },
+    {
+      "id": "psl@1.1.29",
+      "info": {
+        "name": "psl",
+        "version": "1.1.29"
+      }
+    },
+    {
+      "id": "punycode@1.4.1",
+      "info": {
+        "name": "punycode",
+        "version": "1.4.1"
+      }
+    },
+    {
+      "id": "tunnel-agent@0.6.0",
+      "info": {
+        "name": "tunnel-agent",
+        "version": "0.6.0"
+      }
+    },
+    {
+      "id": "uuid@3.3.3",
+      "info": {
+        "name": "uuid",
+        "version": "3.3.3"
+      }
+    },
+    {
+      "id": "tar@4.4.19",
+      "info": {
+        "name": "tar",
+        "version": "4.4.19"
+      }
+    },
+    {
+      "id": "fs-minipass@1.2.7",
+      "info": {
+        "name": "fs-minipass",
+        "version": "1.2.7"
+      }
+    },
+    {
+      "id": "minipass@2.9.0",
+      "info": {
+        "name": "minipass",
+        "version": "2.9.0"
+      }
+    },
+    {
+      "id": "safe-buffer@5.2.1",
+      "info": {
+        "name": "safe-buffer",
+        "version": "5.2.1"
+      }
+    },
+    {
+      "id": "yallist@3.1.1",
+      "info": {
+        "name": "yallist",
+        "version": "3.1.1"
+      }
+    },
+    {
+      "id": "minizlib@1.3.3",
+      "info": {
+        "name": "minizlib",
+        "version": "1.3.3"
+      }
+    },
+    {
+      "id": "which@1.3.1",
+      "info": {
+        "name": "which",
+        "version": "1.3.1"
+      }
+    },
+    {
+      "id": "isexe@2.0.0",
+      "info": {
+        "name": "isexe",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "resolve-from@4.0.0",
+      "info": {
+        "name": "resolve-from",
+        "version": "4.0.0"
+      }
+    },
+    {
+      "id": "uid-number@0.0.6",
+      "info": {
+        "name": "uid-number",
+        "version": "0.0.6"
+      }
+    },
+    {
+      "id": "umask@1.1.0",
+      "info": {
+        "name": "umask",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "npm-logical-tree@1.2.1",
+      "info": {
+        "name": "npm-logical-tree",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "pacote@9.5.12",
+      "info": {
+        "name": "pacote",
+        "version": "9.5.12"
+      }
+    },
+    {
+      "id": "get-stream@4.1.0",
+      "info": {
+        "name": "get-stream",
+        "version": "4.1.0"
+      }
+    },
+    {
+      "id": "make-fetch-happen@5.0.2",
+      "info": {
+        "name": "make-fetch-happen",
+        "version": "5.0.2"
+      }
+    },
+    {
+      "id": "agentkeepalive@3.5.2",
+      "info": {
+        "name": "agentkeepalive",
+        "version": "3.5.2"
+      }
+    },
+    {
+      "id": "humanize-ms@1.2.1",
+      "info": {
+        "name": "humanize-ms",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "http-cache-semantics@3.8.1",
+      "info": {
+        "name": "http-cache-semantics",
+        "version": "3.8.1"
+      }
+    },
+    {
+      "id": "http-proxy-agent@2.1.0",
+      "info": {
+        "name": "http-proxy-agent",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "agent-base@4.3.0",
+      "info": {
+        "name": "agent-base",
+        "version": "4.3.0"
+      }
+    },
+    {
+      "id": "es6-promisify@5.0.0",
+      "info": {
+        "name": "es6-promisify",
+        "version": "5.0.0"
+      }
+    },
+    {
+      "id": "es6-promise@4.2.8",
+      "info": {
+        "name": "es6-promise",
+        "version": "4.2.8"
+      }
+    },
+    {
+      "id": "debug@3.1.0",
+      "info": {
+        "name": "debug",
+        "version": "3.1.0"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "https-proxy-agent@2.2.4",
+      "info": {
+        "name": "https-proxy-agent",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "node-fetch-npm@2.0.2",
+      "info": {
+        "name": "node-fetch-npm",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "encoding@0.1.12",
+      "info": {
+        "name": "encoding",
+        "version": "0.1.12"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.23",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.23"
+      }
+    },
+    {
+      "id": "promise-retry@1.1.1",
+      "info": {
+        "name": "promise-retry",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "err-code@1.1.2",
+      "info": {
+        "name": "err-code",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "retry@0.10.1",
+      "info": {
+        "name": "retry",
+        "version": "0.10.1"
+      }
+    },
+    {
+      "id": "socks-proxy-agent@4.0.2",
+      "info": {
+        "name": "socks-proxy-agent",
+        "version": "4.0.2"
+      }
+    },
+    {
+      "id": "agent-base@4.2.1",
+      "info": {
+        "name": "agent-base",
+        "version": "4.2.1"
+      }
+    },
+    {
+      "id": "socks@2.3.3",
+      "info": {
+        "name": "socks",
+        "version": "2.3.3"
+      }
+    },
+    {
+      "id": "ip@1.1.5",
+      "info": {
+        "name": "ip",
+        "version": "1.1.5"
+      }
+    },
+    {
+      "id": "smart-buffer@4.1.0",
+      "info": {
+        "name": "smart-buffer",
+        "version": "4.1.0"
+      }
+    },
+    {
+      "id": "npm-packlist@1.4.8",
+      "info": {
+        "name": "npm-packlist",
+        "version": "1.4.8"
+      }
+    },
+    {
+      "id": "ignore-walk@3.0.3",
+      "info": {
+        "name": "ignore-walk",
+        "version": "3.0.3"
+      }
+    },
+    {
+      "id": "npm-bundled@1.1.1",
+      "info": {
+        "name": "npm-bundled",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "npm-pick-manifest@3.0.2",
+      "info": {
+        "name": "npm-pick-manifest",
+        "version": "3.0.2"
+      }
+    },
+    {
+      "id": "npm-registry-fetch@4.0.7",
+      "info": {
+        "name": "npm-registry-fetch",
+        "version": "4.0.7"
+      }
+    },
+    {
+      "id": "protoduck@5.0.1",
+      "info": {
+        "name": "protoduck",
+        "version": "5.0.1"
+      }
+    },
+    {
+      "id": "genfun@5.0.0",
+      "info": {
+        "name": "genfun",
+        "version": "5.0.0"
+      }
+    },
+    {
+      "id": "worker-farm@1.7.0",
+      "info": {
+        "name": "worker-farm",
+        "version": "1.7.0"
+      }
+    },
+    {
+      "id": "errno@0.1.7",
+      "info": {
+        "name": "errno",
+        "version": "0.1.7"
+      }
+    },
+    {
+      "id": "prr@1.0.1",
+      "info": {
+        "name": "prr",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "libnpm@3.0.1",
+      "info": {
+        "name": "libnpm",
+        "version": "3.0.1"
+      }
+    },
+    {
+      "id": "libnpmaccess@3.0.2",
+      "info": {
+        "name": "libnpmaccess",
+        "version": "3.0.2"
+      }
+    },
+    {
+      "id": "libnpmconfig@1.2.1",
+      "info": {
+        "name": "libnpmconfig",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "find-up@3.0.0",
+      "info": {
+        "name": "find-up",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "locate-path@3.0.0",
+      "info": {
+        "name": "locate-path",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "p-locate@3.0.0",
+      "info": {
+        "name": "p-locate",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "p-limit@2.2.0",
+      "info": {
+        "name": "p-limit",
+        "version": "2.2.0"
+      }
+    },
+    {
+      "id": "p-try@2.2.0",
+      "info": {
+        "name": "p-try",
+        "version": "2.2.0"
+      }
+    },
+    {
+      "id": "path-exists@3.0.0",
+      "info": {
+        "name": "path-exists",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "libnpmhook@5.0.3",
+      "info": {
+        "name": "libnpmhook",
+        "version": "5.0.3"
+      }
+    },
+    {
+      "id": "libnpmorg@1.0.1",
+      "info": {
+        "name": "libnpmorg",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "libnpmpublish@1.1.2",
+      "info": {
+        "name": "libnpmpublish",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "lodash.clonedeep@4.5.0",
+      "info": {
+        "name": "lodash.clonedeep",
+        "version": "4.5.0"
+      }
+    },
+    {
+      "id": "libnpmsearch@2.0.2",
+      "info": {
+        "name": "libnpmsearch",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "libnpmteam@1.0.2",
+      "info": {
+        "name": "libnpmteam",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "npm-profile@4.0.4",
+      "info": {
+        "name": "npm-profile",
+        "version": "4.0.4"
+      }
+    },
+    {
+      "id": "stringify-package@1.0.1",
+      "info": {
+        "name": "stringify-package",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "libnpx@10.2.4",
+      "info": {
+        "name": "libnpx",
+        "version": "10.2.4"
+      }
+    },
+    {
+      "id": "dotenv@5.0.1",
+      "info": {
+        "name": "dotenv",
+        "version": "5.0.1"
+      }
+    },
+    {
+      "id": "update-notifier@2.5.0",
+      "info": {
+        "name": "update-notifier",
+        "version": "2.5.0"
+      }
+    },
+    {
+      "id": "boxen@1.3.0",
+      "info": {
+        "name": "boxen",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "ansi-align@2.0.0",
+      "info": {
+        "name": "ansi-align",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "camelcase@4.1.0",
+      "info": {
+        "name": "camelcase",
+        "version": "4.1.0"
+      }
+    },
+    {
+      "id": "chalk@2.4.1",
+      "info": {
+        "name": "chalk",
+        "version": "2.4.1"
+      }
+    },
+    {
+      "id": "ansi-styles@3.2.1",
+      "info": {
+        "name": "ansi-styles",
+        "version": "3.2.1"
+      }
+    },
+    {
+      "id": "color-convert@1.9.1",
+      "info": {
+        "name": "color-convert",
+        "version": "1.9.1"
+      }
+    },
+    {
+      "id": "color-name@1.1.3",
+      "info": {
+        "name": "color-name",
+        "version": "1.1.3"
+      }
+    },
+    {
+      "id": "escape-string-regexp@1.0.5",
+      "info": {
+        "name": "escape-string-regexp",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "supports-color@5.4.0",
+      "info": {
+        "name": "supports-color",
+        "version": "5.4.0"
+      }
+    },
+    {
+      "id": "has-flag@3.0.0",
+      "info": {
+        "name": "has-flag",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "cli-boxes@1.0.0",
+      "info": {
+        "name": "cli-boxes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "term-size@1.2.0",
+      "info": {
+        "name": "term-size",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "execa@0.7.0",
+      "info": {
+        "name": "execa",
+        "version": "0.7.0"
+      }
+    },
+    {
+      "id": "cross-spawn@5.1.0",
+      "info": {
+        "name": "cross-spawn",
+        "version": "5.1.0"
+      }
+    },
+    {
+      "id": "lru-cache@4.1.5",
+      "info": {
+        "name": "lru-cache",
+        "version": "4.1.5"
+      }
+    },
+    {
+      "id": "pseudomap@1.0.2",
+      "info": {
+        "name": "pseudomap",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "yallist@2.1.2",
+      "info": {
+        "name": "yallist",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "shebang-command@1.2.0",
+      "info": {
+        "name": "shebang-command",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "shebang-regex@1.0.0",
+      "info": {
+        "name": "shebang-regex",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "get-stream@3.0.0",
+      "info": {
+        "name": "get-stream",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "is-stream@1.1.0",
+      "info": {
+        "name": "is-stream",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "npm-run-path@2.0.2",
+      "info": {
+        "name": "npm-run-path",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "path-key@2.0.1",
+      "info": {
+        "name": "path-key",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "p-finally@1.0.0",
+      "info": {
+        "name": "p-finally",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "strip-eof@1.0.0",
+      "info": {
+        "name": "strip-eof",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "widest-line@2.0.1",
+      "info": {
+        "name": "widest-line",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "configstore@3.1.5",
+      "info": {
+        "name": "configstore",
+        "version": "3.1.5"
+      }
+    },
+    {
+      "id": "dot-prop@4.2.1",
+      "info": {
+        "name": "dot-prop",
+        "version": "4.2.1"
+      }
+    },
+    {
+      "id": "is-obj@1.0.1",
+      "info": {
+        "name": "is-obj",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "make-dir@1.3.0",
+      "info": {
+        "name": "make-dir",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "pify@3.0.0",
+      "info": {
+        "name": "pify",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "unique-string@1.0.0",
+      "info": {
+        "name": "unique-string",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "crypto-random-string@1.0.0",
+      "info": {
+        "name": "crypto-random-string",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "xdg-basedir@3.0.0",
+      "info": {
+        "name": "xdg-basedir",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "import-lazy@2.1.0",
+      "info": {
+        "name": "import-lazy",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "is-ci@1.2.1",
+      "info": {
+        "name": "is-ci",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "ci-info@1.6.0",
+      "info": {
+        "name": "ci-info",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "is-installed-globally@0.1.0",
+      "info": {
+        "name": "is-installed-globally",
+        "version": "0.1.0"
+      }
+    },
+    {
+      "id": "global-dirs@0.1.1",
+      "info": {
+        "name": "global-dirs",
+        "version": "0.1.1"
+      }
+    },
+    {
+      "id": "is-path-inside@1.0.1",
+      "info": {
+        "name": "is-path-inside",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "is-npm@1.0.0",
+      "info": {
+        "name": "is-npm",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "latest-version@3.1.0",
+      "info": {
+        "name": "latest-version",
+        "version": "3.1.0"
+      }
+    },
+    {
+      "id": "package-json@4.0.1",
+      "info": {
+        "name": "package-json",
+        "version": "4.0.1"
+      }
+    },
+    {
+      "id": "got@6.7.1",
+      "info": {
+        "name": "got",
+        "version": "6.7.1"
+      }
+    },
+    {
+      "id": "create-error-class@3.0.2",
+      "info": {
+        "name": "create-error-class",
+        "version": "3.0.2"
+      }
+    },
+    {
+      "id": "capture-stack-trace@1.0.0",
+      "info": {
+        "name": "capture-stack-trace",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "duplexer3@0.1.4",
+      "info": {
+        "name": "duplexer3",
+        "version": "0.1.4"
+      }
+    },
+    {
+      "id": "is-redirect@1.0.0",
+      "info": {
+        "name": "is-redirect",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "is-retry-allowed@1.2.0",
+      "info": {
+        "name": "is-retry-allowed",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "lowercase-keys@1.0.1",
+      "info": {
+        "name": "lowercase-keys",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "timed-out@4.0.1",
+      "info": {
+        "name": "timed-out",
+        "version": "4.0.1"
+      }
+    },
+    {
+      "id": "unzip-response@2.0.1",
+      "info": {
+        "name": "unzip-response",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "url-parse-lax@1.0.0",
+      "info": {
+        "name": "url-parse-lax",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "prepend-http@1.0.4",
+      "info": {
+        "name": "prepend-http",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "registry-auth-token@3.4.0",
+      "info": {
+        "name": "registry-auth-token",
+        "version": "3.4.0"
+      }
+    },
+    {
+      "id": "rc@1.2.8",
+      "info": {
+        "name": "rc",
+        "version": "1.2.8"
+      }
+    },
+    {
+      "id": "deep-extend@0.6.0",
+      "info": {
+        "name": "deep-extend",
+        "version": "0.6.0"
+      }
+    },
+    {
+      "id": "strip-json-comments@2.0.1",
+      "info": {
+        "name": "strip-json-comments",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "registry-url@3.1.0",
+      "info": {
+        "name": "registry-url",
+        "version": "3.1.0"
+      }
+    },
+    {
+      "id": "semver-diff@2.1.0",
+      "info": {
+        "name": "semver-diff",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "yargs@14.2.3",
+      "info": {
+        "name": "yargs",
+        "version": "14.2.3"
+      }
+    },
+    {
+      "id": "cliui@5.0.0",
+      "info": {
+        "name": "cliui",
+        "version": "5.0.0"
+      }
+    },
+    {
+      "id": "string-width@3.1.0",
+      "info": {
+        "name": "string-width",
+        "version": "3.1.0"
+      }
+    },
+    {
+      "id": "emoji-regex@7.0.3",
+      "info": {
+        "name": "emoji-regex",
+        "version": "7.0.3"
+      }
+    },
+    {
+      "id": "strip-ansi@5.2.0",
+      "info": {
+        "name": "strip-ansi",
+        "version": "5.2.0"
+      }
+    },
+    {
+      "id": "ansi-regex@4.1.0",
+      "info": {
+        "name": "ansi-regex",
+        "version": "4.1.0"
+      }
+    },
+    {
+      "id": "wrap-ansi@5.1.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "5.1.0"
+      }
+    },
+    {
+      "id": "decamelize@1.2.0",
+      "info": {
+        "name": "decamelize",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "get-caller-file@2.0.5",
+      "info": {
+        "name": "get-caller-file",
+        "version": "2.0.5"
+      }
+    },
+    {
+      "id": "require-directory@2.1.1",
+      "info": {
+        "name": "require-directory",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "require-main-filename@2.0.0",
+      "info": {
+        "name": "require-main-filename",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "which-module@2.0.0",
+      "info": {
+        "name": "which-module",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "yargs-parser@15.0.1",
+      "info": {
+        "name": "yargs-parser",
+        "version": "15.0.1"
+      }
+    },
+    {
+      "id": "camelcase@5.3.1",
+      "info": {
+        "name": "camelcase",
+        "version": "5.3.1"
+      }
+    },
+    {
+      "id": "lockfile@1.0.4",
+      "info": {
+        "name": "lockfile",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "lodash._baseindexof@3.1.0",
+      "info": {
+        "name": "lodash._baseindexof",
+        "version": "3.1.0"
+      }
+    },
+    {
+      "id": "lodash._baseuniq@4.6.0",
+      "info": {
+        "name": "lodash._baseuniq",
+        "version": "4.6.0"
+      }
+    },
+    {
+      "id": "lodash._createset@4.0.3",
+      "info": {
+        "name": "lodash._createset",
+        "version": "4.0.3"
+      }
+    },
+    {
+      "id": "lodash._root@3.0.1",
+      "info": {
+        "name": "lodash._root",
+        "version": "3.0.1"
+      }
+    },
+    {
+      "id": "lodash._bindcallback@3.0.1",
+      "info": {
+        "name": "lodash._bindcallback",
+        "version": "3.0.1"
+      }
+    },
+    {
+      "id": "lodash._cacheindexof@3.0.2",
+      "info": {
+        "name": "lodash._cacheindexof",
+        "version": "3.0.2"
+      }
+    },
+    {
+      "id": "lodash._createcache@3.1.2",
+      "info": {
+        "name": "lodash._createcache",
+        "version": "3.1.2"
+      }
+    },
+    {
+      "id": "lodash._getnative@3.9.1",
+      "info": {
+        "name": "lodash._getnative",
+        "version": "3.9.1"
+      }
+    },
+    {
+      "id": "lodash.restparam@3.6.1",
+      "info": {
+        "name": "lodash.restparam",
+        "version": "3.6.1"
+      }
+    },
+    {
+      "id": "lodash.union@4.6.0",
+      "info": {
+        "name": "lodash.union",
+        "version": "4.6.0"
+      }
+    },
+    {
+      "id": "lodash.uniq@4.5.0",
+      "info": {
+        "name": "lodash.uniq",
+        "version": "4.5.0"
+      }
+    },
+    {
+      "id": "lodash.without@4.4.0",
+      "info": {
+        "name": "lodash.without",
+        "version": "4.4.0"
+      }
+    },
+    {
+      "id": "meant@1.0.2",
+      "info": {
+        "name": "meant",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "npm-audit-report@1.3.3",
+      "info": {
+        "name": "npm-audit-report",
+        "version": "1.3.3"
+      }
+    },
+    {
+      "id": "npm-cache-filename@1.0.2",
+      "info": {
+        "name": "npm-cache-filename",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "npm-install-checks@3.0.2",
+      "info": {
+        "name": "npm-install-checks",
+        "version": "3.0.2"
+      }
+    },
+    {
+      "id": "npm-user-validate@1.0.1",
+      "info": {
+        "name": "npm-user-validate",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "opener@1.5.2",
+      "info": {
+        "name": "opener",
+        "version": "1.5.2"
+      }
+    },
+    {
+      "id": "qrcode-terminal@0.12.0",
+      "info": {
+        "name": "qrcode-terminal",
+        "version": "0.12.0"
+      }
+    },
+    {
+      "id": "query-string@6.8.2",
+      "info": {
+        "name": "query-string",
+        "version": "6.8.2"
+      }
+    },
+    {
+      "id": "decode-uri-component@0.2.0",
+      "info": {
+        "name": "decode-uri-component",
+        "version": "0.2.0"
+      }
+    },
+    {
+      "id": "split-on-first@1.1.0",
+      "info": {
+        "name": "split-on-first",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "strict-uri-encode@2.0.0",
+      "info": {
+        "name": "strict-uri-encode",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "qw@1.0.1",
+      "info": {
+        "name": "qw",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "read-installed@4.0.3",
+      "info": {
+        "name": "read-installed",
+        "version": "4.0.3"
+      }
+    },
+    {
+      "id": "readdir-scoped-modules@1.1.0",
+      "info": {
+        "name": "readdir-scoped-modules",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "util-extend@1.0.3",
+      "info": {
+        "name": "util-extend",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "read-package-tree@5.3.1",
+      "info": {
+        "name": "read-package-tree",
+        "version": "5.3.1"
+      }
+    },
+    {
+      "id": "util-promisify@2.1.0",
+      "info": {
+        "name": "util-promisify",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "object.getownpropertydescriptors@2.0.3",
+      "info": {
+        "name": "object.getownpropertydescriptors",
+        "version": "2.0.3"
+      }
+    },
+    {
+      "id": "define-properties@1.1.3",
+      "info": {
+        "name": "define-properties",
+        "version": "1.1.3"
+      }
+    },
+    {
+      "id": "object-keys@1.0.12",
+      "info": {
+        "name": "object-keys",
+        "version": "1.0.12"
+      }
+    },
+    {
+      "id": "es-abstract@1.12.0",
+      "info": {
+        "name": "es-abstract",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "es-to-primitive@1.2.0",
+      "info": {
+        "name": "es-to-primitive",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "is-callable@1.1.4",
+      "info": {
+        "name": "is-callable",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "is-date-object@1.0.1",
+      "info": {
+        "name": "is-date-object",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "is-symbol@1.0.2",
+      "info": {
+        "name": "is-symbol",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "has-symbols@1.0.0",
+      "info": {
+        "name": "has-symbols",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "function-bind@1.1.1",
+      "info": {
+        "name": "function-bind",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "has@1.0.3",
+      "info": {
+        "name": "has",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "is-regex@1.0.4",
+      "info": {
+        "name": "is-regex",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "readable-stream@3.6.0",
+      "info": {
+        "name": "readable-stream",
+        "version": "3.6.0"
+      }
+    },
+    {
+      "id": "string_decoder@1.3.0",
+      "info": {
+        "name": "string_decoder",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "retry@0.12.0",
+      "info": {
+        "name": "retry",
+        "version": "0.12.0"
+      }
+    },
+    {
+      "id": "sha@3.0.0",
+      "info": {
+        "name": "sha",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "sorted-object@2.0.1",
+      "info": {
+        "name": "sorted-object",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "sorted-union-stream@2.1.3",
+      "info": {
+        "name": "sorted-union-stream",
+        "version": "2.1.3"
+      }
+    },
+    {
+      "id": "from2@1.3.0",
+      "info": {
+        "name": "from2",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "readable-stream@1.1.14",
+      "info": {
+        "name": "readable-stream",
+        "version": "1.1.14"
+      }
+    },
+    {
+      "id": "isarray@0.0.1",
+      "info": {
+        "name": "isarray",
+        "version": "0.0.1"
+      }
+    },
+    {
+      "id": "string_decoder@0.10.31",
+      "info": {
+        "name": "string_decoder",
+        "version": "0.10.31"
+      }
+    },
+    {
+      "id": "stream-iterate@1.2.0",
+      "info": {
+        "name": "stream-iterate",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "text-table@0.2.0",
+      "info": {
+        "name": "text-table",
+        "version": "0.2.0"
+      }
+    },
+    {
+      "id": "tiny-relative-date@1.3.0",
+      "info": {
+        "name": "tiny-relative-date",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "unpipe@1.0.0",
+      "info": {
+        "name": "unpipe",
+        "version": "1.0.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "deeply-nested-packages@1.0.0",
+        "deps": [
+          {
+            "nodeId": "npm@6.14.17"
+          }
+        ]
+      },
+      {
+        "nodeId": "npm@6.14.17",
+        "pkgId": "npm@6.14.17",
+        "deps": [
+          {
+            "nodeId": "abbrev@1.1.1"
+          },
+          {
+            "nodeId": "ansicolors@0.3.2"
+          },
+          {
+            "nodeId": "ansistyles@0.1.3"
+          },
+          {
+            "nodeId": "aproba@2.0.0"
+          },
+          {
+            "nodeId": "archy@1.0.0"
+          },
+          {
+            "nodeId": "bin-links@1.1.8"
+          },
+          {
+            "nodeId": "bluebird@3.5.5"
+          },
+          {
+            "nodeId": "byte-size@5.0.1"
+          },
+          {
+            "nodeId": "cacache@12.0.3"
+          },
+          {
+            "nodeId": "call-limit@1.1.1"
+          },
+          {
+            "nodeId": "chownr@1.1.4"
+          },
+          {
+            "nodeId": "ci-info@2.0.0"
+          },
+          {
+            "nodeId": "cli-columns@3.1.2"
+          },
+          {
+            "nodeId": "cli-table3@0.5.1"
+          },
+          {
+            "nodeId": "cmd-shim@3.0.3"
+          },
+          {
+            "nodeId": "columnify@1.5.4"
+          },
+          {
+            "nodeId": "config-chain@1.1.12"
+          },
+          {
+            "nodeId": "debuglog@1.0.1"
+          },
+          {
+            "nodeId": "detect-indent@5.0.0"
+          },
+          {
+            "nodeId": "detect-newline@2.1.0"
+          },
+          {
+            "nodeId": "dezalgo@1.0.3"
+          },
+          {
+            "nodeId": "editor@1.0.0"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "find-npm-prefix@1.0.2"
+          },
+          {
+            "nodeId": "fs-vacuum@1.2.10"
+          },
+          {
+            "nodeId": "fs-write-stream-atomic@1.0.10"
+          },
+          {
+            "nodeId": "gentle-fs@2.3.1"
+          },
+          {
+            "nodeId": "glob@7.1.6"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "has-unicode@2.0.1"
+          },
+          {
+            "nodeId": "hosted-git-info@2.8.9"
+          },
+          {
+            "nodeId": "iferr@1.0.2"
+          },
+          {
+            "nodeId": "imurmurhash@0.1.4"
+          },
+          {
+            "nodeId": "infer-owner@1.0.4"
+          },
+          {
+            "nodeId": "inflight@1.0.6"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "ini@1.3.8"
+          },
+          {
+            "nodeId": "init-package-json@1.10.3"
+          },
+          {
+            "nodeId": "is-cidr@3.0.0"
+          },
+          {
+            "nodeId": "json-parse-better-errors@1.0.2"
+          },
+          {
+            "nodeId": "JSONStream@1.3.5"
+          },
+          {
+            "nodeId": "lazy-property@1.0.0"
+          },
+          {
+            "nodeId": "libcipm@4.0.8"
+          },
+          {
+            "nodeId": "libnpm@3.0.1"
+          },
+          {
+            "nodeId": "libnpmaccess@3.0.2"
+          },
+          {
+            "nodeId": "libnpmhook@5.0.3"
+          },
+          {
+            "nodeId": "libnpmorg@1.0.1"
+          },
+          {
+            "nodeId": "libnpmsearch@2.0.2"
+          },
+          {
+            "nodeId": "libnpmteam@1.0.2"
+          },
+          {
+            "nodeId": "libnpx@10.2.4"
+          },
+          {
+            "nodeId": "lock-verify@2.1.0"
+          },
+          {
+            "nodeId": "lockfile@1.0.4"
+          },
+          {
+            "nodeId": "lodash._baseindexof@3.1.0"
+          },
+          {
+            "nodeId": "lodash._baseuniq@4.6.0"
+          },
+          {
+            "nodeId": "lodash._bindcallback@3.0.1"
+          },
+          {
+            "nodeId": "lodash._cacheindexof@3.0.2"
+          },
+          {
+            "nodeId": "lodash._createcache@3.1.2"
+          },
+          {
+            "nodeId": "lodash._getnative@3.9.1"
+          },
+          {
+            "nodeId": "lodash.clonedeep@4.5.0"
+          },
+          {
+            "nodeId": "lodash.restparam@3.6.1"
+          },
+          {
+            "nodeId": "lodash.union@4.6.0"
+          },
+          {
+            "nodeId": "lodash.uniq@4.5.0"
+          },
+          {
+            "nodeId": "lodash.without@4.4.0"
+          },
+          {
+            "nodeId": "lru-cache@5.1.1"
+          },
+          {
+            "nodeId": "meant@1.0.2"
+          },
+          {
+            "nodeId": "mississippi@3.0.0"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "move-concurrently@1.0.1"
+          },
+          {
+            "nodeId": "node-gyp@5.1.0"
+          },
+          {
+            "nodeId": "nopt@4.0.3"
+          },
+          {
+            "nodeId": "normalize-package-data@2.5.0"
+          },
+          {
+            "nodeId": "npm-audit-report@1.3.3"
+          },
+          {
+            "nodeId": "npm-cache-filename@1.0.2"
+          },
+          {
+            "nodeId": "npm-install-checks@3.0.2"
+          },
+          {
+            "nodeId": "npm-lifecycle@3.1.5"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "npm-packlist@1.4.8"
+          },
+          {
+            "nodeId": "npm-pick-manifest@3.0.2"
+          },
+          {
+            "nodeId": "npm-profile@4.0.4"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          },
+          {
+            "nodeId": "npm-user-validate@1.0.1"
+          },
+          {
+            "nodeId": "npmlog@4.1.2"
+          },
+          {
+            "nodeId": "once@1.4.0"
+          },
+          {
+            "nodeId": "opener@1.5.2"
+          },
+          {
+            "nodeId": "osenv@0.1.5"
+          },
+          {
+            "nodeId": "pacote@9.5.12"
+          },
+          {
+            "nodeId": "path-is-inside@1.0.2"
+          },
+          {
+            "nodeId": "promise-inflight@1.0.1"
+          },
+          {
+            "nodeId": "qrcode-terminal@0.12.0"
+          },
+          {
+            "nodeId": "query-string@6.8.2"
+          },
+          {
+            "nodeId": "qw@1.0.1"
+          },
+          {
+            "nodeId": "read@1.0.7"
+          },
+          {
+            "nodeId": "read-cmd-shim@1.0.5"
+          },
+          {
+            "nodeId": "read-installed@4.0.3"
+          },
+          {
+            "nodeId": "read-package-json@2.1.1"
+          },
+          {
+            "nodeId": "read-package-tree@5.3.1"
+          },
+          {
+            "nodeId": "readable-stream@3.6.0"
+          },
+          {
+            "nodeId": "readdir-scoped-modules@1.1.0"
+          },
+          {
+            "nodeId": "request@2.88.0"
+          },
+          {
+            "nodeId": "retry@0.12.0"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          },
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "sha@3.0.0"
+          },
+          {
+            "nodeId": "slide@1.1.6"
+          },
+          {
+            "nodeId": "sorted-object@2.0.1"
+          },
+          {
+            "nodeId": "sorted-union-stream@2.1.3"
+          },
+          {
+            "nodeId": "ssri@6.0.2"
+          },
+          {
+            "nodeId": "stringify-package@1.0.1"
+          },
+          {
+            "nodeId": "tar@4.4.19"
+          },
+          {
+            "nodeId": "text-table@0.2.0"
+          },
+          {
+            "nodeId": "tiny-relative-date@1.3.0"
+          },
+          {
+            "nodeId": "uid-number@0.0.6"
+          },
+          {
+            "nodeId": "umask@1.1.0"
+          },
+          {
+            "nodeId": "unique-filename@1.1.1"
+          },
+          {
+            "nodeId": "unpipe@1.0.0"
+          },
+          {
+            "nodeId": "update-notifier@2.5.0"
+          },
+          {
+            "nodeId": "uuid@3.3.3"
+          },
+          {
+            "nodeId": "validate-npm-package-license@3.0.4"
+          },
+          {
+            "nodeId": "validate-npm-package-name@3.0.0"
+          },
+          {
+            "nodeId": "which@1.3.1"
+          },
+          {
+            "nodeId": "worker-farm@1.7.0"
+          },
+          {
+            "nodeId": "write-file-atomic@2.4.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "abbrev@1.1.1",
+        "pkgId": "abbrev@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansicolors@0.3.2",
+        "pkgId": "ansicolors@0.3.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansistyles@0.1.3",
+        "pkgId": "ansistyles@0.1.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "aproba@2.0.0",
+        "pkgId": "aproba@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "archy@1.0.0",
+        "pkgId": "archy@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bin-links@1.1.8",
+        "pkgId": "bin-links@1.1.8",
+        "deps": [
+          {
+            "nodeId": "bluebird@3.5.5"
+          },
+          {
+            "nodeId": "cmd-shim@3.0.3"
+          },
+          {
+            "nodeId": "gentle-fs@2.3.1"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "npm-normalize-package-bin@1.0.1"
+          },
+          {
+            "nodeId": "write-file-atomic@2.4.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bluebird@3.5.5",
+        "pkgId": "bluebird@3.5.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cmd-shim@3.0.3",
+        "pkgId": "cmd-shim@3.0.3",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "graceful-fs@4.2.4",
+        "pkgId": "graceful-fs@4.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mkdirp@0.5.5",
+        "pkgId": "mkdirp@0.5.5",
+        "deps": [
+          {
+            "nodeId": "minimist@1.2.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "minimist@1.2.6",
+        "pkgId": "minimist@1.2.6",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "gentle-fs@2.3.1",
+        "pkgId": "gentle-fs@2.3.1",
+        "deps": [
+          {
+            "nodeId": "aproba@1.2.0"
+          },
+          {
+            "nodeId": "chownr@1.1.4"
+          },
+          {
+            "nodeId": "cmd-shim@3.0.3"
+          },
+          {
+            "nodeId": "fs-vacuum@1.2.10"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "iferr@0.1.5"
+          },
+          {
+            "nodeId": "infer-owner@1.0.4"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "path-is-inside@1.0.2"
+          },
+          {
+            "nodeId": "read-cmd-shim@1.0.5"
+          },
+          {
+            "nodeId": "slide@1.1.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "aproba@1.2.0",
+        "pkgId": "aproba@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "chownr@1.1.4",
+        "pkgId": "chownr@1.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fs-vacuum@1.2.10",
+        "pkgId": "fs-vacuum@1.2.10",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "path-is-inside@1.0.2"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "path-is-inside@1.0.2",
+        "pkgId": "path-is-inside@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "rimraf@2.7.1",
+        "pkgId": "rimraf@2.7.1",
+        "deps": [
+          {
+            "nodeId": "glob@7.1.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "glob@7.1.6",
+        "pkgId": "glob@7.1.6",
+        "deps": [
+          {
+            "nodeId": "fs.realpath@1.0.0"
+          },
+          {
+            "nodeId": "inflight@1.0.6"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "minimatch@3.0.4"
+          },
+          {
+            "nodeId": "once@1.4.0"
+          },
+          {
+            "nodeId": "path-is-absolute@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fs.realpath@1.0.0",
+        "pkgId": "fs.realpath@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "inflight@1.0.6",
+        "pkgId": "inflight@1.0.6",
+        "deps": [
+          {
+            "nodeId": "once@1.4.0"
+          },
+          {
+            "nodeId": "wrappy@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "once@1.4.0",
+        "pkgId": "once@1.4.0",
+        "deps": [
+          {
+            "nodeId": "wrappy@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrappy@1.0.2",
+        "pkgId": "wrappy@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "minimatch@3.0.4",
+        "pkgId": "minimatch@3.0.4",
+        "deps": [
+          {
+            "nodeId": "brace-expansion@1.1.11"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "brace-expansion@1.1.11",
+        "pkgId": "brace-expansion@1.1.11",
+        "deps": [
+          {
+            "nodeId": "balanced-match@1.0.0"
+          },
+          {
+            "nodeId": "concat-map@0.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "balanced-match@1.0.0",
+        "pkgId": "balanced-match@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "concat-map@0.0.1",
+        "pkgId": "concat-map@0.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "path-is-absolute@1.0.1",
+        "pkgId": "path-is-absolute@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iferr@0.1.5",
+        "pkgId": "iferr@0.1.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "infer-owner@1.0.4",
+        "pkgId": "infer-owner@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "read-cmd-shim@1.0.5",
+        "pkgId": "read-cmd-shim@1.0.5",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "slide@1.1.6",
+        "pkgId": "slide@1.1.6",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-normalize-package-bin@1.0.1",
+        "pkgId": "npm-normalize-package-bin@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "write-file-atomic@2.4.3",
+        "pkgId": "write-file-atomic@2.4.3",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "imurmurhash@0.1.4"
+          },
+          {
+            "nodeId": "signal-exit@3.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "imurmurhash@0.1.4",
+        "pkgId": "imurmurhash@0.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "signal-exit@3.0.2",
+        "pkgId": "signal-exit@3.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "byte-size@5.0.1",
+        "pkgId": "byte-size@5.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cacache@12.0.3",
+        "pkgId": "cacache@12.0.3",
+        "deps": [
+          {
+            "nodeId": "bluebird@3.5.5"
+          },
+          {
+            "nodeId": "chownr@1.1.4"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "glob@7.1.6"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "infer-owner@1.0.4"
+          },
+          {
+            "nodeId": "lru-cache@5.1.1"
+          },
+          {
+            "nodeId": "mississippi@3.0.0"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "move-concurrently@1.0.1"
+          },
+          {
+            "nodeId": "promise-inflight@1.0.1"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          },
+          {
+            "nodeId": "ssri@6.0.2"
+          },
+          {
+            "nodeId": "unique-filename@1.1.1"
+          },
+          {
+            "nodeId": "y18n@4.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "figgy-pudding@3.5.1",
+        "pkgId": "figgy-pudding@3.5.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lru-cache@5.1.1",
+        "pkgId": "lru-cache@5.1.1",
+        "deps": [
+          {
+            "nodeId": "yallist@3.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "yallist@3.0.3",
+        "pkgId": "yallist@3.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mississippi@3.0.0",
+        "pkgId": "mississippi@3.0.0",
+        "deps": [
+          {
+            "nodeId": "concat-stream@1.6.2"
+          },
+          {
+            "nodeId": "duplexify@3.6.0"
+          },
+          {
+            "nodeId": "end-of-stream@1.4.1"
+          },
+          {
+            "nodeId": "flush-write-stream@1.0.3"
+          },
+          {
+            "nodeId": "from2@2.3.0"
+          },
+          {
+            "nodeId": "parallel-transform@1.1.0"
+          },
+          {
+            "nodeId": "pump@3.0.0"
+          },
+          {
+            "nodeId": "pumpify@1.5.1"
+          },
+          {
+            "nodeId": "stream-each@1.2.2"
+          },
+          {
+            "nodeId": "through2@2.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "concat-stream@1.6.2",
+        "pkgId": "concat-stream@1.6.2",
+        "deps": [
+          {
+            "nodeId": "buffer-from@1.0.0"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "readable-stream@2.3.6"
+          },
+          {
+            "nodeId": "typedarray@0.0.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "buffer-from@1.0.0",
+        "pkgId": "buffer-from@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "readable-stream@2.3.6",
+        "pkgId": "readable-stream@2.3.6",
+        "deps": [
+          {
+            "nodeId": "core-util-is@1.0.2"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "isarray@1.0.0"
+          },
+          {
+            "nodeId": "process-nextick-args@2.0.0"
+          },
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          },
+          {
+            "nodeId": "string_decoder@1.1.1"
+          },
+          {
+            "nodeId": "util-deprecate@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "core-util-is@1.0.2",
+        "pkgId": "core-util-is@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "isarray@1.0.0",
+        "pkgId": "isarray@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "process-nextick-args@2.0.0",
+        "pkgId": "process-nextick-args@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "safe-buffer@5.1.2",
+        "pkgId": "safe-buffer@5.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string_decoder@1.1.1",
+        "pkgId": "string_decoder@1.1.1",
+        "deps": [
+          {
+            "nodeId": "safe-buffer@5.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "safe-buffer@5.2.0",
+        "pkgId": "safe-buffer@5.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "util-deprecate@1.0.2",
+        "pkgId": "util-deprecate@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "typedarray@0.0.6",
+        "pkgId": "typedarray@0.0.6",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "duplexify@3.6.0",
+        "pkgId": "duplexify@3.6.0",
+        "deps": [
+          {
+            "nodeId": "end-of-stream@1.4.1"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "readable-stream@2.3.6"
+          },
+          {
+            "nodeId": "stream-shift@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "end-of-stream@1.4.1",
+        "pkgId": "end-of-stream@1.4.1",
+        "deps": [
+          {
+            "nodeId": "once@1.4.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "stream-shift@1.0.0",
+        "pkgId": "stream-shift@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "flush-write-stream@1.0.3",
+        "pkgId": "flush-write-stream@1.0.3",
+        "deps": [
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "readable-stream@2.3.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "from2@2.3.0",
+        "pkgId": "from2@2.3.0",
+        "deps": [
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "readable-stream@2.3.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "parallel-transform@1.1.0",
+        "pkgId": "parallel-transform@1.1.0",
+        "deps": [
+          {
+            "nodeId": "cyclist@0.2.2"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "readable-stream@2.3.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cyclist@0.2.2",
+        "pkgId": "cyclist@0.2.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pump@3.0.0",
+        "pkgId": "pump@3.0.0",
+        "deps": [
+          {
+            "nodeId": "end-of-stream@1.4.1"
+          },
+          {
+            "nodeId": "once@1.4.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pumpify@1.5.1",
+        "pkgId": "pumpify@1.5.1",
+        "deps": [
+          {
+            "nodeId": "duplexify@3.6.0"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "pump@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pump@2.0.1",
+        "pkgId": "pump@2.0.1",
+        "deps": [
+          {
+            "nodeId": "end-of-stream@1.4.1"
+          },
+          {
+            "nodeId": "once@1.4.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "stream-each@1.2.2",
+        "pkgId": "stream-each@1.2.2",
+        "deps": [
+          {
+            "nodeId": "end-of-stream@1.4.1"
+          },
+          {
+            "nodeId": "stream-shift@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "through2@2.0.3",
+        "pkgId": "through2@2.0.3",
+        "deps": [
+          {
+            "nodeId": "readable-stream@2.3.6"
+          },
+          {
+            "nodeId": "xtend@4.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "xtend@4.0.1",
+        "pkgId": "xtend@4.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "move-concurrently@1.0.1",
+        "pkgId": "move-concurrently@1.0.1",
+        "deps": [
+          {
+            "nodeId": "aproba@1.2.0"
+          },
+          {
+            "nodeId": "copy-concurrently@1.0.5"
+          },
+          {
+            "nodeId": "fs-write-stream-atomic@1.0.10"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          },
+          {
+            "nodeId": "run-queue@1.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "copy-concurrently@1.0.5",
+        "pkgId": "copy-concurrently@1.0.5",
+        "deps": [
+          {
+            "nodeId": "aproba@1.2.0"
+          },
+          {
+            "nodeId": "fs-write-stream-atomic@1.0.10"
+          },
+          {
+            "nodeId": "iferr@0.1.5"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          },
+          {
+            "nodeId": "run-queue@1.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fs-write-stream-atomic@1.0.10",
+        "pkgId": "fs-write-stream-atomic@1.0.10",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "iferr@0.1.5"
+          },
+          {
+            "nodeId": "imurmurhash@0.1.4"
+          },
+          {
+            "nodeId": "readable-stream@2.3.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "run-queue@1.0.3",
+        "pkgId": "run-queue@1.0.3",
+        "deps": [
+          {
+            "nodeId": "aproba@1.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "promise-inflight@1.0.1",
+        "pkgId": "promise-inflight@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ssri@6.0.2",
+        "pkgId": "ssri@6.0.2",
+        "deps": [
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "unique-filename@1.1.1",
+        "pkgId": "unique-filename@1.1.1",
+        "deps": [
+          {
+            "nodeId": "unique-slug@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "unique-slug@2.0.0",
+        "pkgId": "unique-slug@2.0.0",
+        "deps": [
+          {
+            "nodeId": "imurmurhash@0.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "y18n@4.0.1",
+        "pkgId": "y18n@4.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "call-limit@1.1.1",
+        "pkgId": "call-limit@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ci-info@2.0.0",
+        "pkgId": "ci-info@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cli-columns@3.1.2",
+        "pkgId": "cli-columns@3.1.2",
+        "deps": [
+          {
+            "nodeId": "string-width@2.1.1"
+          },
+          {
+            "nodeId": "strip-ansi@3.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@2.1.1",
+        "pkgId": "string-width@2.1.1",
+        "deps": [
+          {
+            "nodeId": "is-fullwidth-code-point@2.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@4.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-fullwidth-code-point@2.0.0",
+        "pkgId": "is-fullwidth-code-point@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@4.0.0",
+        "pkgId": "strip-ansi@4.0.0",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@3.0.0",
+        "pkgId": "ansi-regex@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@3.0.1",
+        "pkgId": "strip-ansi@3.0.1",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@2.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@2.1.1",
+        "pkgId": "ansi-regex@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cli-table3@0.5.1",
+        "pkgId": "cli-table3@0.5.1",
+        "deps": [
+          {
+            "nodeId": "object-assign@4.1.1"
+          },
+          {
+            "nodeId": "string-width@2.1.1"
+          },
+          {
+            "nodeId": "colors@1.3.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object-assign@4.1.1",
+        "pkgId": "object-assign@4.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "colors@1.3.3",
+        "pkgId": "colors@1.3.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "columnify@1.5.4",
+        "pkgId": "columnify@1.5.4",
+        "deps": [
+          {
+            "nodeId": "strip-ansi@3.0.1"
+          },
+          {
+            "nodeId": "wcwidth@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wcwidth@1.0.1",
+        "pkgId": "wcwidth@1.0.1",
+        "deps": [
+          {
+            "nodeId": "defaults@1.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "defaults@1.0.3",
+        "pkgId": "defaults@1.0.3",
+        "deps": [
+          {
+            "nodeId": "clone@1.0.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "clone@1.0.4",
+        "pkgId": "clone@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "config-chain@1.1.12",
+        "pkgId": "config-chain@1.1.12",
+        "deps": [
+          {
+            "nodeId": "ini@1.3.8"
+          },
+          {
+            "nodeId": "proto-list@1.2.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ini@1.3.8",
+        "pkgId": "ini@1.3.8",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "proto-list@1.2.4",
+        "pkgId": "proto-list@1.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debuglog@1.0.1",
+        "pkgId": "debuglog@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "detect-indent@5.0.0",
+        "pkgId": "detect-indent@5.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "detect-newline@2.1.0",
+        "pkgId": "detect-newline@2.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "dezalgo@1.0.3",
+        "pkgId": "dezalgo@1.0.3",
+        "deps": [
+          {
+            "nodeId": "asap@2.0.6"
+          },
+          {
+            "nodeId": "wrappy@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "asap@2.0.6",
+        "pkgId": "asap@2.0.6",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "editor@1.0.0",
+        "pkgId": "editor@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "find-npm-prefix@1.0.2",
+        "pkgId": "find-npm-prefix@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-unicode@2.0.1",
+        "pkgId": "has-unicode@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "hosted-git-info@2.8.9",
+        "pkgId": "hosted-git-info@2.8.9",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iferr@1.0.2",
+        "pkgId": "iferr@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "init-package-json@1.10.3",
+        "pkgId": "init-package-json@1.10.3",
+        "deps": [
+          {
+            "nodeId": "glob@7.1.6"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "promzard@0.3.0"
+          },
+          {
+            "nodeId": "read@1.0.7"
+          },
+          {
+            "nodeId": "read-package-json@2.1.1"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "validate-npm-package-license@3.0.4"
+          },
+          {
+            "nodeId": "validate-npm-package-name@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-package-arg@6.1.1",
+        "pkgId": "npm-package-arg@6.1.1",
+        "deps": [
+          {
+            "nodeId": "hosted-git-info@2.8.9"
+          },
+          {
+            "nodeId": "osenv@0.1.5"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "validate-npm-package-name@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "osenv@0.1.5",
+        "pkgId": "osenv@0.1.5",
+        "deps": [
+          {
+            "nodeId": "os-homedir@1.0.2"
+          },
+          {
+            "nodeId": "os-tmpdir@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "os-homedir@1.0.2",
+        "pkgId": "os-homedir@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "os-tmpdir@1.0.2",
+        "pkgId": "os-tmpdir@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "semver@5.7.1",
+        "pkgId": "semver@5.7.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "validate-npm-package-name@3.0.0",
+        "pkgId": "validate-npm-package-name@3.0.0",
+        "deps": [
+          {
+            "nodeId": "builtins@1.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "builtins@1.0.3",
+        "pkgId": "builtins@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "promzard@0.3.0",
+        "pkgId": "promzard@0.3.0",
+        "deps": [
+          {
+            "nodeId": "read@1.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "read@1.0.7",
+        "pkgId": "read@1.0.7",
+        "deps": [
+          {
+            "nodeId": "mute-stream@0.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mute-stream@0.0.7",
+        "pkgId": "mute-stream@0.0.7",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "read-package-json@2.1.1",
+        "pkgId": "read-package-json@2.1.1",
+        "deps": [
+          {
+            "nodeId": "glob@7.1.6"
+          },
+          {
+            "nodeId": "json-parse-better-errors@1.0.2"
+          },
+          {
+            "nodeId": "normalize-package-data@2.5.0"
+          },
+          {
+            "nodeId": "npm-normalize-package-bin@1.0.1"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "json-parse-better-errors@1.0.2",
+        "pkgId": "json-parse-better-errors@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "normalize-package-data@2.5.0",
+        "pkgId": "normalize-package-data@2.5.0",
+        "deps": [
+          {
+            "nodeId": "hosted-git-info@2.8.9"
+          },
+          {
+            "nodeId": "resolve@1.10.0"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "validate-npm-package-license@3.0.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "resolve@1.10.0",
+        "pkgId": "resolve@1.10.0",
+        "deps": [
+          {
+            "nodeId": "path-parse@1.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "path-parse@1.0.7",
+        "pkgId": "path-parse@1.0.7",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "validate-npm-package-license@3.0.4",
+        "pkgId": "validate-npm-package-license@3.0.4",
+        "deps": [
+          {
+            "nodeId": "spdx-correct@3.0.0"
+          },
+          {
+            "nodeId": "spdx-expression-parse@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-correct@3.0.0",
+        "pkgId": "spdx-correct@3.0.0",
+        "deps": [
+          {
+            "nodeId": "spdx-expression-parse@3.0.0"
+          },
+          {
+            "nodeId": "spdx-license-ids@3.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-expression-parse@3.0.0",
+        "pkgId": "spdx-expression-parse@3.0.0",
+        "deps": [
+          {
+            "nodeId": "spdx-exceptions@2.1.0"
+          },
+          {
+            "nodeId": "spdx-license-ids@3.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-exceptions@2.1.0",
+        "pkgId": "spdx-exceptions@2.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-license-ids@3.0.5",
+        "pkgId": "spdx-license-ids@3.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-cidr@3.0.0",
+        "pkgId": "is-cidr@3.0.0",
+        "deps": [
+          {
+            "nodeId": "cidr-regex@2.0.10"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cidr-regex@2.0.10",
+        "pkgId": "cidr-regex@2.0.10",
+        "deps": [
+          {
+            "nodeId": "ip-regex@2.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ip-regex@2.1.0",
+        "pkgId": "ip-regex@2.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "JSONStream@1.3.5",
+        "pkgId": "JSONStream@1.3.5",
+        "deps": [
+          {
+            "nodeId": "jsonparse@1.3.1"
+          },
+          {
+            "nodeId": "through@2.3.8"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "jsonparse@1.3.1",
+        "pkgId": "jsonparse@1.3.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "through@2.3.8",
+        "pkgId": "through@2.3.8",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lazy-property@1.0.0",
+        "pkgId": "lazy-property@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libcipm@4.0.8",
+        "pkgId": "libcipm@4.0.8",
+        "deps": [
+          {
+            "nodeId": "bin-links@1.1.8"
+          },
+          {
+            "nodeId": "bluebird@3.5.5"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "find-npm-prefix@1.0.2"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "ini@1.3.8"
+          },
+          {
+            "nodeId": "lock-verify@2.1.0"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "npm-lifecycle@3.1.5"
+          },
+          {
+            "nodeId": "npm-logical-tree@1.2.1"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "pacote@9.5.12"
+          },
+          {
+            "nodeId": "read-package-json@2.1.1"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          },
+          {
+            "nodeId": "worker-farm@1.7.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lock-verify@2.1.0",
+        "pkgId": "lock-verify@2.1.0",
+        "deps": [
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-lifecycle@3.1.5",
+        "pkgId": "npm-lifecycle@3.1.5",
+        "deps": [
+          {
+            "nodeId": "byline@5.0.0"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "node-gyp@5.1.0"
+          },
+          {
+            "nodeId": "resolve-from@4.0.0"
+          },
+          {
+            "nodeId": "slide@1.1.6"
+          },
+          {
+            "nodeId": "uid-number@0.0.6"
+          },
+          {
+            "nodeId": "umask@1.1.0"
+          },
+          {
+            "nodeId": "which@1.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "byline@5.0.0",
+        "pkgId": "byline@5.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "node-gyp@5.1.0",
+        "pkgId": "node-gyp@5.1.0",
+        "deps": [
+          {
+            "nodeId": "env-paths@2.2.0"
+          },
+          {
+            "nodeId": "glob@7.1.6"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "nopt@4.0.3"
+          },
+          {
+            "nodeId": "npmlog@4.1.2"
+          },
+          {
+            "nodeId": "request@2.88.0"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "tar@4.4.19"
+          },
+          {
+            "nodeId": "which@1.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "env-paths@2.2.0",
+        "pkgId": "env-paths@2.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "nopt@4.0.3",
+        "pkgId": "nopt@4.0.3",
+        "deps": [
+          {
+            "nodeId": "abbrev@1.1.1"
+          },
+          {
+            "nodeId": "osenv@0.1.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npmlog@4.1.2",
+        "pkgId": "npmlog@4.1.2",
+        "deps": [
+          {
+            "nodeId": "are-we-there-yet@1.1.4"
+          },
+          {
+            "nodeId": "console-control-strings@1.1.0"
+          },
+          {
+            "nodeId": "gauge@2.7.4"
+          },
+          {
+            "nodeId": "set-blocking@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "are-we-there-yet@1.1.4",
+        "pkgId": "are-we-there-yet@1.1.4",
+        "deps": [
+          {
+            "nodeId": "delegates@1.0.0"
+          },
+          {
+            "nodeId": "readable-stream@2.3.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "delegates@1.0.0",
+        "pkgId": "delegates@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "console-control-strings@1.1.0",
+        "pkgId": "console-control-strings@1.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "gauge@2.7.4",
+        "pkgId": "gauge@2.7.4",
+        "deps": [
+          {
+            "nodeId": "aproba@1.2.0"
+          },
+          {
+            "nodeId": "console-control-strings@1.1.0"
+          },
+          {
+            "nodeId": "has-unicode@2.0.1"
+          },
+          {
+            "nodeId": "object-assign@4.1.1"
+          },
+          {
+            "nodeId": "signal-exit@3.0.2"
+          },
+          {
+            "nodeId": "string-width@1.0.2"
+          },
+          {
+            "nodeId": "strip-ansi@3.0.1"
+          },
+          {
+            "nodeId": "wide-align@1.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@1.0.2",
+        "pkgId": "string-width@1.0.2",
+        "deps": [
+          {
+            "nodeId": "code-point-at@1.1.0"
+          },
+          {
+            "nodeId": "is-fullwidth-code-point@2.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@4.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "code-point-at@1.1.0",
+        "pkgId": "code-point-at@1.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wide-align@1.1.2",
+        "pkgId": "wide-align@1.1.2",
+        "deps": [
+          {
+            "nodeId": "string-width@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "set-blocking@2.0.0",
+        "pkgId": "set-blocking@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "request@2.88.0",
+        "pkgId": "request@2.88.0",
+        "deps": [
+          {
+            "nodeId": "aws-sign2@0.7.0"
+          },
+          {
+            "nodeId": "aws4@1.8.0"
+          },
+          {
+            "nodeId": "caseless@0.12.0"
+          },
+          {
+            "nodeId": "combined-stream@1.0.6"
+          },
+          {
+            "nodeId": "extend@3.0.2"
+          },
+          {
+            "nodeId": "forever-agent@0.6.1"
+          },
+          {
+            "nodeId": "form-data@2.3.2"
+          },
+          {
+            "nodeId": "har-validator@5.1.5"
+          },
+          {
+            "nodeId": "http-signature@1.2.0"
+          },
+          {
+            "nodeId": "is-typedarray@1.0.0"
+          },
+          {
+            "nodeId": "isstream@0.1.2"
+          },
+          {
+            "nodeId": "json-stringify-safe@5.0.1"
+          },
+          {
+            "nodeId": "mime-types@2.1.19"
+          },
+          {
+            "nodeId": "oauth-sign@0.9.0"
+          },
+          {
+            "nodeId": "performance-now@2.1.0"
+          },
+          {
+            "nodeId": "qs@6.5.2"
+          },
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          },
+          {
+            "nodeId": "tough-cookie@2.4.3"
+          },
+          {
+            "nodeId": "tunnel-agent@0.6.0"
+          },
+          {
+            "nodeId": "uuid@3.3.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "aws-sign2@0.7.0",
+        "pkgId": "aws-sign2@0.7.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "aws4@1.8.0",
+        "pkgId": "aws4@1.8.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "caseless@0.12.0",
+        "pkgId": "caseless@0.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "combined-stream@1.0.6",
+        "pkgId": "combined-stream@1.0.6",
+        "deps": [
+          {
+            "nodeId": "delayed-stream@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "delayed-stream@1.0.0",
+        "pkgId": "delayed-stream@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "extend@3.0.2",
+        "pkgId": "extend@3.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "forever-agent@0.6.1",
+        "pkgId": "forever-agent@0.6.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "form-data@2.3.2",
+        "pkgId": "form-data@2.3.2",
+        "deps": [
+          {
+            "nodeId": "asynckit@0.4.0"
+          },
+          {
+            "nodeId": "combined-stream@1.0.6"
+          },
+          {
+            "nodeId": "mime-types@2.1.19"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "asynckit@0.4.0",
+        "pkgId": "asynckit@0.4.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.1.19",
+        "pkgId": "mime-types@2.1.19",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.35.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.35.0",
+        "pkgId": "mime-db@1.35.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "har-validator@5.1.5",
+        "pkgId": "har-validator@5.1.5",
+        "deps": [
+          {
+            "nodeId": "ajv@6.12.6"
+          },
+          {
+            "nodeId": "har-schema@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ajv@6.12.6",
+        "pkgId": "ajv@6.12.6",
+        "deps": [
+          {
+            "nodeId": "fast-deep-equal@3.1.3"
+          },
+          {
+            "nodeId": "fast-json-stable-stringify@2.0.0"
+          },
+          {
+            "nodeId": "json-schema-traverse@0.4.1"
+          },
+          {
+            "nodeId": "uri-js@4.4.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fast-deep-equal@3.1.3",
+        "pkgId": "fast-deep-equal@3.1.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fast-json-stable-stringify@2.0.0",
+        "pkgId": "fast-json-stable-stringify@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "json-schema-traverse@0.4.1",
+        "pkgId": "json-schema-traverse@0.4.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "uri-js@4.4.0",
+        "pkgId": "uri-js@4.4.0",
+        "deps": [
+          {
+            "nodeId": "punycode@2.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "punycode@2.1.1",
+        "pkgId": "punycode@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "har-schema@2.0.0",
+        "pkgId": "har-schema@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-signature@1.2.0",
+        "pkgId": "http-signature@1.2.0",
+        "deps": [
+          {
+            "nodeId": "assert-plus@1.0.0"
+          },
+          {
+            "nodeId": "jsprim@1.4.2"
+          },
+          {
+            "nodeId": "sshpk@1.14.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "assert-plus@1.0.0",
+        "pkgId": "assert-plus@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "jsprim@1.4.2",
+        "pkgId": "jsprim@1.4.2",
+        "deps": [
+          {
+            "nodeId": "assert-plus@1.0.0"
+          },
+          {
+            "nodeId": "extsprintf@1.3.0"
+          },
+          {
+            "nodeId": "json-schema@0.4.0"
+          },
+          {
+            "nodeId": "verror@1.10.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "extsprintf@1.3.0",
+        "pkgId": "extsprintf@1.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "json-schema@0.4.0",
+        "pkgId": "json-schema@0.4.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "verror@1.10.0",
+        "pkgId": "verror@1.10.0",
+        "deps": [
+          {
+            "nodeId": "assert-plus@1.0.0"
+          },
+          {
+            "nodeId": "core-util-is@1.0.2"
+          },
+          {
+            "nodeId": "extsprintf@1.3.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "sshpk@1.14.2",
+        "pkgId": "sshpk@1.14.2",
+        "deps": [
+          {
+            "nodeId": "asn1@0.2.4"
+          },
+          {
+            "nodeId": "assert-plus@1.0.0"
+          },
+          {
+            "nodeId": "dashdash@1.14.1"
+          },
+          {
+            "nodeId": "getpass@0.1.7"
+          },
+          {
+            "nodeId": "safer-buffer@2.1.2"
+          },
+          {
+            "nodeId": "bcrypt-pbkdf@1.0.2"
+          },
+          {
+            "nodeId": "ecc-jsbn@0.1.2"
+          },
+          {
+            "nodeId": "jsbn@0.1.1"
+          },
+          {
+            "nodeId": "tweetnacl@0.14.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "asn1@0.2.4",
+        "pkgId": "asn1@0.2.4",
+        "deps": [
+          {
+            "nodeId": "safer-buffer@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "safer-buffer@2.1.2",
+        "pkgId": "safer-buffer@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "dashdash@1.14.1",
+        "pkgId": "dashdash@1.14.1",
+        "deps": [
+          {
+            "nodeId": "assert-plus@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "getpass@0.1.7",
+        "pkgId": "getpass@0.1.7",
+        "deps": [
+          {
+            "nodeId": "assert-plus@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bcrypt-pbkdf@1.0.2",
+        "pkgId": "bcrypt-pbkdf@1.0.2",
+        "deps": [
+          {
+            "nodeId": "tweetnacl@0.14.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "tweetnacl@0.14.5",
+        "pkgId": "tweetnacl@0.14.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ecc-jsbn@0.1.2",
+        "pkgId": "ecc-jsbn@0.1.2",
+        "deps": [
+          {
+            "nodeId": "jsbn@0.1.1"
+          },
+          {
+            "nodeId": "safer-buffer@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "jsbn@0.1.1",
+        "pkgId": "jsbn@0.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-typedarray@1.0.0",
+        "pkgId": "is-typedarray@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "isstream@0.1.2",
+        "pkgId": "isstream@0.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "json-stringify-safe@5.0.1",
+        "pkgId": "json-stringify-safe@5.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "oauth-sign@0.9.0",
+        "pkgId": "oauth-sign@0.9.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "performance-now@2.1.0",
+        "pkgId": "performance-now@2.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@6.5.2",
+        "pkgId": "qs@6.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "tough-cookie@2.4.3",
+        "pkgId": "tough-cookie@2.4.3",
+        "deps": [
+          {
+            "nodeId": "psl@1.1.29"
+          },
+          {
+            "nodeId": "punycode@1.4.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "psl@1.1.29",
+        "pkgId": "psl@1.1.29",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "punycode@1.4.1",
+        "pkgId": "punycode@1.4.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "tunnel-agent@0.6.0",
+        "pkgId": "tunnel-agent@0.6.0",
+        "deps": [
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "uuid@3.3.3",
+        "pkgId": "uuid@3.3.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "tar@4.4.19",
+        "pkgId": "tar@4.4.19",
+        "deps": [
+          {
+            "nodeId": "chownr@1.1.4"
+          },
+          {
+            "nodeId": "fs-minipass@1.2.7"
+          },
+          {
+            "nodeId": "minipass@2.9.0"
+          },
+          {
+            "nodeId": "minizlib@1.3.3"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "safe-buffer@5.2.1"
+          },
+          {
+            "nodeId": "yallist@3.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fs-minipass@1.2.7",
+        "pkgId": "fs-minipass@1.2.7",
+        "deps": [
+          {
+            "nodeId": "minipass@2.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "minipass@2.9.0",
+        "pkgId": "minipass@2.9.0",
+        "deps": [
+          {
+            "nodeId": "safe-buffer@5.2.1"
+          },
+          {
+            "nodeId": "yallist@3.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "safe-buffer@5.2.1",
+        "pkgId": "safe-buffer@5.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "yallist@3.1.1",
+        "pkgId": "yallist@3.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "minizlib@1.3.3",
+        "pkgId": "minizlib@1.3.3",
+        "deps": [
+          {
+            "nodeId": "minipass@2.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "which@1.3.1",
+        "pkgId": "which@1.3.1",
+        "deps": [
+          {
+            "nodeId": "isexe@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "isexe@2.0.0",
+        "pkgId": "isexe@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "resolve-from@4.0.0",
+        "pkgId": "resolve-from@4.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "uid-number@0.0.6",
+        "pkgId": "uid-number@0.0.6",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "umask@1.1.0",
+        "pkgId": "umask@1.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-logical-tree@1.2.1",
+        "pkgId": "npm-logical-tree@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pacote@9.5.12",
+        "pkgId": "pacote@9.5.12",
+        "deps": [
+          {
+            "nodeId": "bluebird@3.5.5"
+          },
+          {
+            "nodeId": "cacache@12.0.3"
+          },
+          {
+            "nodeId": "chownr@1.1.4"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "get-stream@4.1.0"
+          },
+          {
+            "nodeId": "glob@7.1.6"
+          },
+          {
+            "nodeId": "infer-owner@1.0.4"
+          },
+          {
+            "nodeId": "lru-cache@5.1.1"
+          },
+          {
+            "nodeId": "make-fetch-happen@5.0.2"
+          },
+          {
+            "nodeId": "minimatch@3.0.4"
+          },
+          {
+            "nodeId": "minipass@2.9.0"
+          },
+          {
+            "nodeId": "mississippi@3.0.0"
+          },
+          {
+            "nodeId": "mkdirp@0.5.5"
+          },
+          {
+            "nodeId": "normalize-package-data@2.5.0"
+          },
+          {
+            "nodeId": "npm-normalize-package-bin@1.0.1"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "npm-packlist@1.4.8"
+          },
+          {
+            "nodeId": "npm-pick-manifest@3.0.2"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          },
+          {
+            "nodeId": "osenv@0.1.5"
+          },
+          {
+            "nodeId": "promise-inflight@1.0.1"
+          },
+          {
+            "nodeId": "promise-retry@1.1.1"
+          },
+          {
+            "nodeId": "protoduck@5.0.1"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          },
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "ssri@6.0.2"
+          },
+          {
+            "nodeId": "tar@4.4.19"
+          },
+          {
+            "nodeId": "unique-filename@1.1.1"
+          },
+          {
+            "nodeId": "which@1.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "get-stream@4.1.0",
+        "pkgId": "get-stream@4.1.0",
+        "deps": [
+          {
+            "nodeId": "pump@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "make-fetch-happen@5.0.2",
+        "pkgId": "make-fetch-happen@5.0.2",
+        "deps": [
+          {
+            "nodeId": "agentkeepalive@3.5.2"
+          },
+          {
+            "nodeId": "cacache@12.0.3"
+          },
+          {
+            "nodeId": "http-cache-semantics@3.8.1"
+          },
+          {
+            "nodeId": "http-proxy-agent@2.1.0"
+          },
+          {
+            "nodeId": "https-proxy-agent@2.2.4"
+          },
+          {
+            "nodeId": "lru-cache@5.1.1"
+          },
+          {
+            "nodeId": "mississippi@3.0.0"
+          },
+          {
+            "nodeId": "node-fetch-npm@2.0.2"
+          },
+          {
+            "nodeId": "promise-retry@1.1.1"
+          },
+          {
+            "nodeId": "socks-proxy-agent@4.0.2"
+          },
+          {
+            "nodeId": "ssri@6.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "agentkeepalive@3.5.2",
+        "pkgId": "agentkeepalive@3.5.2",
+        "deps": [
+          {
+            "nodeId": "humanize-ms@1.2.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "humanize-ms@1.2.1",
+        "pkgId": "humanize-ms@1.2.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-cache-semantics@3.8.1",
+        "pkgId": "http-cache-semantics@3.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-proxy-agent@2.1.0",
+        "pkgId": "http-proxy-agent@2.1.0",
+        "deps": [
+          {
+            "nodeId": "agent-base@4.3.0"
+          },
+          {
+            "nodeId": "debug@3.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "agent-base@4.3.0",
+        "pkgId": "agent-base@4.3.0",
+        "deps": [
+          {
+            "nodeId": "es6-promisify@5.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es6-promisify@5.0.0",
+        "pkgId": "es6-promisify@5.0.0",
+        "deps": [
+          {
+            "nodeId": "es6-promise@4.2.8"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es6-promise@4.2.8",
+        "pkgId": "es6-promise@4.2.8",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@3.1.0",
+        "pkgId": "debug@3.1.0",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "https-proxy-agent@2.2.4",
+        "pkgId": "https-proxy-agent@2.2.4",
+        "deps": [
+          {
+            "nodeId": "agent-base@4.3.0"
+          },
+          {
+            "nodeId": "debug@3.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "node-fetch-npm@2.0.2",
+        "pkgId": "node-fetch-npm@2.0.2",
+        "deps": [
+          {
+            "nodeId": "encoding@0.1.12"
+          },
+          {
+            "nodeId": "json-parse-better-errors@1.0.2"
+          },
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encoding@0.1.12",
+        "pkgId": "encoding@0.1.12",
+        "deps": [
+          {
+            "nodeId": "iconv-lite@0.4.23"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.23",
+        "pkgId": "iconv-lite@0.4.23",
+        "deps": [
+          {
+            "nodeId": "safer-buffer@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "promise-retry@1.1.1",
+        "pkgId": "promise-retry@1.1.1",
+        "deps": [
+          {
+            "nodeId": "err-code@1.1.2"
+          },
+          {
+            "nodeId": "retry@0.10.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "err-code@1.1.2",
+        "pkgId": "err-code@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "retry@0.10.1",
+        "pkgId": "retry@0.10.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "socks-proxy-agent@4.0.2",
+        "pkgId": "socks-proxy-agent@4.0.2",
+        "deps": [
+          {
+            "nodeId": "agent-base@4.2.1"
+          },
+          {
+            "nodeId": "socks@2.3.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "agent-base@4.2.1",
+        "pkgId": "agent-base@4.2.1",
+        "deps": [
+          {
+            "nodeId": "es6-promisify@5.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "socks@2.3.3",
+        "pkgId": "socks@2.3.3",
+        "deps": [
+          {
+            "nodeId": "ip@1.1.5"
+          },
+          {
+            "nodeId": "smart-buffer@4.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ip@1.1.5",
+        "pkgId": "ip@1.1.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "smart-buffer@4.1.0",
+        "pkgId": "smart-buffer@4.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-packlist@1.4.8",
+        "pkgId": "npm-packlist@1.4.8",
+        "deps": [
+          {
+            "nodeId": "ignore-walk@3.0.3"
+          },
+          {
+            "nodeId": "npm-bundled@1.1.1"
+          },
+          {
+            "nodeId": "npm-normalize-package-bin@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ignore-walk@3.0.3",
+        "pkgId": "ignore-walk@3.0.3",
+        "deps": [
+          {
+            "nodeId": "minimatch@3.0.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-bundled@1.1.1",
+        "pkgId": "npm-bundled@1.1.1",
+        "deps": [
+          {
+            "nodeId": "npm-normalize-package-bin@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-pick-manifest@3.0.2",
+        "pkgId": "npm-pick-manifest@3.0.2",
+        "deps": [
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-registry-fetch@4.0.7",
+        "pkgId": "npm-registry-fetch@4.0.7",
+        "deps": [
+          {
+            "nodeId": "bluebird@3.5.5"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "JSONStream@1.3.5"
+          },
+          {
+            "nodeId": "lru-cache@5.1.1"
+          },
+          {
+            "nodeId": "make-fetch-happen@5.0.2"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "safe-buffer@5.2.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "protoduck@5.0.1",
+        "pkgId": "protoduck@5.0.1",
+        "deps": [
+          {
+            "nodeId": "genfun@5.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "genfun@5.0.0",
+        "pkgId": "genfun@5.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "worker-farm@1.7.0",
+        "pkgId": "worker-farm@1.7.0",
+        "deps": [
+          {
+            "nodeId": "errno@0.1.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "errno@0.1.7",
+        "pkgId": "errno@0.1.7",
+        "deps": [
+          {
+            "nodeId": "prr@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "prr@1.0.1",
+        "pkgId": "prr@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpm@3.0.1",
+        "pkgId": "libnpm@3.0.1",
+        "deps": [
+          {
+            "nodeId": "bin-links@1.1.8"
+          },
+          {
+            "nodeId": "bluebird@3.5.5"
+          },
+          {
+            "nodeId": "find-npm-prefix@1.0.2"
+          },
+          {
+            "nodeId": "libnpmaccess@3.0.2"
+          },
+          {
+            "nodeId": "libnpmconfig@1.2.1"
+          },
+          {
+            "nodeId": "libnpmhook@5.0.3"
+          },
+          {
+            "nodeId": "libnpmorg@1.0.1"
+          },
+          {
+            "nodeId": "libnpmpublish@1.1.2"
+          },
+          {
+            "nodeId": "libnpmsearch@2.0.2"
+          },
+          {
+            "nodeId": "libnpmteam@1.0.2"
+          },
+          {
+            "nodeId": "lock-verify@2.1.0"
+          },
+          {
+            "nodeId": "npm-lifecycle@3.1.5"
+          },
+          {
+            "nodeId": "npm-logical-tree@1.2.1"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "npm-profile@4.0.4"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          },
+          {
+            "nodeId": "npmlog@4.1.2"
+          },
+          {
+            "nodeId": "pacote@9.5.12"
+          },
+          {
+            "nodeId": "read-package-json@2.1.1"
+          },
+          {
+            "nodeId": "stringify-package@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpmaccess@3.0.2",
+        "pkgId": "libnpmaccess@3.0.2",
+        "deps": [
+          {
+            "nodeId": "aproba@2.0.0"
+          },
+          {
+            "nodeId": "get-stream@4.1.0"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpmconfig@1.2.1",
+        "pkgId": "libnpmconfig@1.2.1",
+        "deps": [
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "find-up@3.0.0"
+          },
+          {
+            "nodeId": "ini@1.3.8"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "find-up@3.0.0",
+        "pkgId": "find-up@3.0.0",
+        "deps": [
+          {
+            "nodeId": "locate-path@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "locate-path@3.0.0",
+        "pkgId": "locate-path@3.0.0",
+        "deps": [
+          {
+            "nodeId": "p-locate@3.0.0"
+          },
+          {
+            "nodeId": "path-exists@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "p-locate@3.0.0",
+        "pkgId": "p-locate@3.0.0",
+        "deps": [
+          {
+            "nodeId": "p-limit@2.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "p-limit@2.2.0",
+        "pkgId": "p-limit@2.2.0",
+        "deps": [
+          {
+            "nodeId": "p-try@2.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "p-try@2.2.0",
+        "pkgId": "p-try@2.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "path-exists@3.0.0",
+        "pkgId": "path-exists@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpmhook@5.0.3",
+        "pkgId": "libnpmhook@5.0.3",
+        "deps": [
+          {
+            "nodeId": "aproba@2.0.0"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "get-stream@4.1.0"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpmorg@1.0.1",
+        "pkgId": "libnpmorg@1.0.1",
+        "deps": [
+          {
+            "nodeId": "aproba@2.0.0"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "get-stream@4.1.0"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpmpublish@1.1.2",
+        "pkgId": "libnpmpublish@1.1.2",
+        "deps": [
+          {
+            "nodeId": "aproba@2.0.0"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "get-stream@4.1.0"
+          },
+          {
+            "nodeId": "lodash.clonedeep@4.5.0"
+          },
+          {
+            "nodeId": "normalize-package-data@2.5.0"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "ssri@6.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash.clonedeep@4.5.0",
+        "pkgId": "lodash.clonedeep@4.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpmsearch@2.0.2",
+        "pkgId": "libnpmsearch@2.0.2",
+        "deps": [
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "get-stream@4.1.0"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpmteam@1.0.2",
+        "pkgId": "libnpmteam@1.0.2",
+        "deps": [
+          {
+            "nodeId": "aproba@2.0.0"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "get-stream@4.1.0"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-profile@4.0.4",
+        "pkgId": "npm-profile@4.0.4",
+        "deps": [
+          {
+            "nodeId": "aproba@2.0.0"
+          },
+          {
+            "nodeId": "figgy-pudding@3.5.1"
+          },
+          {
+            "nodeId": "npm-registry-fetch@4.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "stringify-package@1.0.1",
+        "pkgId": "stringify-package@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "libnpx@10.2.4",
+        "pkgId": "libnpx@10.2.4",
+        "deps": [
+          {
+            "nodeId": "dotenv@5.0.1"
+          },
+          {
+            "nodeId": "npm-package-arg@6.1.1"
+          },
+          {
+            "nodeId": "rimraf@2.7.1"
+          },
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          },
+          {
+            "nodeId": "update-notifier@2.5.0"
+          },
+          {
+            "nodeId": "which@1.3.1"
+          },
+          {
+            "nodeId": "y18n@4.0.1"
+          },
+          {
+            "nodeId": "yargs@14.2.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "dotenv@5.0.1",
+        "pkgId": "dotenv@5.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "update-notifier@2.5.0",
+        "pkgId": "update-notifier@2.5.0",
+        "deps": [
+          {
+            "nodeId": "boxen@1.3.0"
+          },
+          {
+            "nodeId": "chalk@2.4.1"
+          },
+          {
+            "nodeId": "configstore@3.1.5"
+          },
+          {
+            "nodeId": "import-lazy@2.1.0"
+          },
+          {
+            "nodeId": "is-ci@1.2.1"
+          },
+          {
+            "nodeId": "is-installed-globally@0.1.0"
+          },
+          {
+            "nodeId": "is-npm@1.0.0"
+          },
+          {
+            "nodeId": "latest-version@3.1.0"
+          },
+          {
+            "nodeId": "semver-diff@2.1.0"
+          },
+          {
+            "nodeId": "xdg-basedir@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "boxen@1.3.0",
+        "pkgId": "boxen@1.3.0",
+        "deps": [
+          {
+            "nodeId": "ansi-align@2.0.0"
+          },
+          {
+            "nodeId": "camelcase@4.1.0"
+          },
+          {
+            "nodeId": "chalk@2.4.1"
+          },
+          {
+            "nodeId": "cli-boxes@1.0.0"
+          },
+          {
+            "nodeId": "string-width@2.1.1"
+          },
+          {
+            "nodeId": "term-size@1.2.0"
+          },
+          {
+            "nodeId": "widest-line@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-align@2.0.0",
+        "pkgId": "ansi-align@2.0.0",
+        "deps": [
+          {
+            "nodeId": "string-width@2.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "camelcase@4.1.0",
+        "pkgId": "camelcase@4.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "chalk@2.4.1",
+        "pkgId": "chalk@2.4.1",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@3.2.1"
+          },
+          {
+            "nodeId": "escape-string-regexp@1.0.5"
+          },
+          {
+            "nodeId": "supports-color@5.4.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-styles@3.2.1",
+        "pkgId": "ansi-styles@3.2.1",
+        "deps": [
+          {
+            "nodeId": "color-convert@1.9.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-convert@1.9.1",
+        "pkgId": "color-convert@1.9.1",
+        "deps": [
+          {
+            "nodeId": "color-name@1.1.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-name@1.1.3",
+        "pkgId": "color-name@1.1.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-string-regexp@1.0.5",
+        "pkgId": "escape-string-regexp@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "supports-color@5.4.0",
+        "pkgId": "supports-color@5.4.0",
+        "deps": [
+          {
+            "nodeId": "has-flag@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-flag@3.0.0",
+        "pkgId": "has-flag@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cli-boxes@1.0.0",
+        "pkgId": "cli-boxes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "term-size@1.2.0",
+        "pkgId": "term-size@1.2.0",
+        "deps": [
+          {
+            "nodeId": "execa@0.7.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "execa@0.7.0",
+        "pkgId": "execa@0.7.0",
+        "deps": [
+          {
+            "nodeId": "cross-spawn@5.1.0"
+          },
+          {
+            "nodeId": "get-stream@3.0.0"
+          },
+          {
+            "nodeId": "is-stream@1.1.0"
+          },
+          {
+            "nodeId": "npm-run-path@2.0.2"
+          },
+          {
+            "nodeId": "p-finally@1.0.0"
+          },
+          {
+            "nodeId": "signal-exit@3.0.2"
+          },
+          {
+            "nodeId": "strip-eof@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cross-spawn@5.1.0",
+        "pkgId": "cross-spawn@5.1.0",
+        "deps": [
+          {
+            "nodeId": "lru-cache@4.1.5"
+          },
+          {
+            "nodeId": "shebang-command@1.2.0"
+          },
+          {
+            "nodeId": "which@1.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lru-cache@4.1.5",
+        "pkgId": "lru-cache@4.1.5",
+        "deps": [
+          {
+            "nodeId": "pseudomap@1.0.2"
+          },
+          {
+            "nodeId": "yallist@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pseudomap@1.0.2",
+        "pkgId": "pseudomap@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "yallist@2.1.2",
+        "pkgId": "yallist@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "shebang-command@1.2.0",
+        "pkgId": "shebang-command@1.2.0",
+        "deps": [
+          {
+            "nodeId": "shebang-regex@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "shebang-regex@1.0.0",
+        "pkgId": "shebang-regex@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "get-stream@3.0.0",
+        "pkgId": "get-stream@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-stream@1.1.0",
+        "pkgId": "is-stream@1.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-run-path@2.0.2",
+        "pkgId": "npm-run-path@2.0.2",
+        "deps": [
+          {
+            "nodeId": "path-key@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "path-key@2.0.1",
+        "pkgId": "path-key@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "p-finally@1.0.0",
+        "pkgId": "p-finally@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-eof@1.0.0",
+        "pkgId": "strip-eof@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "widest-line@2.0.1",
+        "pkgId": "widest-line@2.0.1",
+        "deps": [
+          {
+            "nodeId": "string-width@2.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "configstore@3.1.5",
+        "pkgId": "configstore@3.1.5",
+        "deps": [
+          {
+            "nodeId": "dot-prop@4.2.1"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "make-dir@1.3.0"
+          },
+          {
+            "nodeId": "unique-string@1.0.0"
+          },
+          {
+            "nodeId": "write-file-atomic@2.4.3"
+          },
+          {
+            "nodeId": "xdg-basedir@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "dot-prop@4.2.1",
+        "pkgId": "dot-prop@4.2.1",
+        "deps": [
+          {
+            "nodeId": "is-obj@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-obj@1.0.1",
+        "pkgId": "is-obj@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "make-dir@1.3.0",
+        "pkgId": "make-dir@1.3.0",
+        "deps": [
+          {
+            "nodeId": "pify@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pify@3.0.0",
+        "pkgId": "pify@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "unique-string@1.0.0",
+        "pkgId": "unique-string@1.0.0",
+        "deps": [
+          {
+            "nodeId": "crypto-random-string@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "crypto-random-string@1.0.0",
+        "pkgId": "crypto-random-string@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "xdg-basedir@3.0.0",
+        "pkgId": "xdg-basedir@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "import-lazy@2.1.0",
+        "pkgId": "import-lazy@2.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-ci@1.2.1",
+        "pkgId": "is-ci@1.2.1",
+        "deps": [
+          {
+            "nodeId": "ci-info@1.6.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ci-info@1.6.0",
+        "pkgId": "ci-info@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-installed-globally@0.1.0",
+        "pkgId": "is-installed-globally@0.1.0",
+        "deps": [
+          {
+            "nodeId": "global-dirs@0.1.1"
+          },
+          {
+            "nodeId": "is-path-inside@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "global-dirs@0.1.1",
+        "pkgId": "global-dirs@0.1.1",
+        "deps": [
+          {
+            "nodeId": "ini@1.3.8"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-path-inside@1.0.1",
+        "pkgId": "is-path-inside@1.0.1",
+        "deps": [
+          {
+            "nodeId": "path-is-inside@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-npm@1.0.0",
+        "pkgId": "is-npm@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "latest-version@3.1.0",
+        "pkgId": "latest-version@3.1.0",
+        "deps": [
+          {
+            "nodeId": "package-json@4.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "package-json@4.0.1",
+        "pkgId": "package-json@4.0.1",
+        "deps": [
+          {
+            "nodeId": "got@6.7.1"
+          },
+          {
+            "nodeId": "registry-auth-token@3.4.0"
+          },
+          {
+            "nodeId": "registry-url@3.1.0"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "got@6.7.1",
+        "pkgId": "got@6.7.1",
+        "deps": [
+          {
+            "nodeId": "create-error-class@3.0.2"
+          },
+          {
+            "nodeId": "duplexer3@0.1.4"
+          },
+          {
+            "nodeId": "get-stream@3.0.0"
+          },
+          {
+            "nodeId": "is-redirect@1.0.0"
+          },
+          {
+            "nodeId": "is-retry-allowed@1.2.0"
+          },
+          {
+            "nodeId": "is-stream@1.1.0"
+          },
+          {
+            "nodeId": "lowercase-keys@1.0.1"
+          },
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          },
+          {
+            "nodeId": "timed-out@4.0.1"
+          },
+          {
+            "nodeId": "unzip-response@2.0.1"
+          },
+          {
+            "nodeId": "url-parse-lax@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "create-error-class@3.0.2",
+        "pkgId": "create-error-class@3.0.2",
+        "deps": [
+          {
+            "nodeId": "capture-stack-trace@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "capture-stack-trace@1.0.0",
+        "pkgId": "capture-stack-trace@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "duplexer3@0.1.4",
+        "pkgId": "duplexer3@0.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-redirect@1.0.0",
+        "pkgId": "is-redirect@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-retry-allowed@1.2.0",
+        "pkgId": "is-retry-allowed@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lowercase-keys@1.0.1",
+        "pkgId": "lowercase-keys@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "timed-out@4.0.1",
+        "pkgId": "timed-out@4.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "unzip-response@2.0.1",
+        "pkgId": "unzip-response@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "url-parse-lax@1.0.0",
+        "pkgId": "url-parse-lax@1.0.0",
+        "deps": [
+          {
+            "nodeId": "prepend-http@1.0.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "prepend-http@1.0.4",
+        "pkgId": "prepend-http@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "registry-auth-token@3.4.0",
+        "pkgId": "registry-auth-token@3.4.0",
+        "deps": [
+          {
+            "nodeId": "rc@1.2.8"
+          },
+          {
+            "nodeId": "safe-buffer@5.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "rc@1.2.8",
+        "pkgId": "rc@1.2.8",
+        "deps": [
+          {
+            "nodeId": "deep-extend@0.6.0"
+          },
+          {
+            "nodeId": "ini@1.3.8"
+          },
+          {
+            "nodeId": "minimist@1.2.6"
+          },
+          {
+            "nodeId": "strip-json-comments@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "deep-extend@0.6.0",
+        "pkgId": "deep-extend@0.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-json-comments@2.0.1",
+        "pkgId": "strip-json-comments@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "registry-url@3.1.0",
+        "pkgId": "registry-url@3.1.0",
+        "deps": [
+          {
+            "nodeId": "rc@1.2.8"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "semver-diff@2.1.0",
+        "pkgId": "semver-diff@2.1.0",
+        "deps": [
+          {
+            "nodeId": "semver@5.7.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "yargs@14.2.3",
+        "pkgId": "yargs@14.2.3",
+        "deps": [
+          {
+            "nodeId": "cliui@5.0.0"
+          },
+          {
+            "nodeId": "decamelize@1.2.0"
+          },
+          {
+            "nodeId": "find-up@3.0.0"
+          },
+          {
+            "nodeId": "get-caller-file@2.0.5"
+          },
+          {
+            "nodeId": "require-directory@2.1.1"
+          },
+          {
+            "nodeId": "require-main-filename@2.0.0"
+          },
+          {
+            "nodeId": "set-blocking@2.0.0"
+          },
+          {
+            "nodeId": "string-width@3.1.0"
+          },
+          {
+            "nodeId": "which-module@2.0.0"
+          },
+          {
+            "nodeId": "y18n@4.0.1"
+          },
+          {
+            "nodeId": "yargs-parser@15.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cliui@5.0.0",
+        "pkgId": "cliui@5.0.0",
+        "deps": [
+          {
+            "nodeId": "string-width@3.1.0"
+          },
+          {
+            "nodeId": "strip-ansi@5.2.0"
+          },
+          {
+            "nodeId": "wrap-ansi@5.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@3.1.0",
+        "pkgId": "string-width@3.1.0",
+        "deps": [
+          {
+            "nodeId": "emoji-regex@7.0.3"
+          },
+          {
+            "nodeId": "is-fullwidth-code-point@2.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@5.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "emoji-regex@7.0.3",
+        "pkgId": "emoji-regex@7.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@5.2.0",
+        "pkgId": "strip-ansi@5.2.0",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@4.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@4.1.0",
+        "pkgId": "ansi-regex@4.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrap-ansi@5.1.0",
+        "pkgId": "wrap-ansi@5.1.0",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@3.2.1"
+          },
+          {
+            "nodeId": "string-width@3.1.0"
+          },
+          {
+            "nodeId": "strip-ansi@5.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "decamelize@1.2.0",
+        "pkgId": "decamelize@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "get-caller-file@2.0.5",
+        "pkgId": "get-caller-file@2.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "require-directory@2.1.1",
+        "pkgId": "require-directory@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "require-main-filename@2.0.0",
+        "pkgId": "require-main-filename@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "which-module@2.0.0",
+        "pkgId": "which-module@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "yargs-parser@15.0.1",
+        "pkgId": "yargs-parser@15.0.1",
+        "deps": [
+          {
+            "nodeId": "camelcase@5.3.1"
+          },
+          {
+            "nodeId": "decamelize@1.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "camelcase@5.3.1",
+        "pkgId": "camelcase@5.3.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lockfile@1.0.4",
+        "pkgId": "lockfile@1.0.4",
+        "deps": [
+          {
+            "nodeId": "signal-exit@3.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash._baseindexof@3.1.0",
+        "pkgId": "lodash._baseindexof@3.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash._baseuniq@4.6.0",
+        "pkgId": "lodash._baseuniq@4.6.0",
+        "deps": [
+          {
+            "nodeId": "lodash._createset@4.0.3"
+          },
+          {
+            "nodeId": "lodash._root@3.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash._createset@4.0.3",
+        "pkgId": "lodash._createset@4.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash._root@3.0.1",
+        "pkgId": "lodash._root@3.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash._bindcallback@3.0.1",
+        "pkgId": "lodash._bindcallback@3.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash._cacheindexof@3.0.2",
+        "pkgId": "lodash._cacheindexof@3.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash._createcache@3.1.2",
+        "pkgId": "lodash._createcache@3.1.2",
+        "deps": [
+          {
+            "nodeId": "lodash._getnative@3.9.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash._getnative@3.9.1",
+        "pkgId": "lodash._getnative@3.9.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash.restparam@3.6.1",
+        "pkgId": "lodash.restparam@3.6.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash.union@4.6.0",
+        "pkgId": "lodash.union@4.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash.uniq@4.5.0",
+        "pkgId": "lodash.uniq@4.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash.without@4.4.0",
+        "pkgId": "lodash.without@4.4.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "meant@1.0.2",
+        "pkgId": "meant@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-audit-report@1.3.3",
+        "pkgId": "npm-audit-report@1.3.3",
+        "deps": [
+          {
+            "nodeId": "cli-table3@0.5.1"
+          },
+          {
+            "nodeId": "console-control-strings@1.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-cache-filename@1.0.2",
+        "pkgId": "npm-cache-filename@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-install-checks@3.0.2",
+        "pkgId": "npm-install-checks@3.0.2",
+        "deps": [
+          {
+            "nodeId": "semver@5.7.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-user-validate@1.0.1",
+        "pkgId": "npm-user-validate@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "opener@1.5.2",
+        "pkgId": "opener@1.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qrcode-terminal@0.12.0",
+        "pkgId": "qrcode-terminal@0.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "query-string@6.8.2",
+        "pkgId": "query-string@6.8.2",
+        "deps": [
+          {
+            "nodeId": "decode-uri-component@0.2.0"
+          },
+          {
+            "nodeId": "split-on-first@1.1.0"
+          },
+          {
+            "nodeId": "strict-uri-encode@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "decode-uri-component@0.2.0",
+        "pkgId": "decode-uri-component@0.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "split-on-first@1.1.0",
+        "pkgId": "split-on-first@1.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strict-uri-encode@2.0.0",
+        "pkgId": "strict-uri-encode@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qw@1.0.1",
+        "pkgId": "qw@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "read-installed@4.0.3",
+        "pkgId": "read-installed@4.0.3",
+        "deps": [
+          {
+            "nodeId": "debuglog@1.0.1"
+          },
+          {
+            "nodeId": "read-package-json@2.1.1"
+          },
+          {
+            "nodeId": "readdir-scoped-modules@1.1.0"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "slide@1.1.6"
+          },
+          {
+            "nodeId": "util-extend@1.0.3"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "readdir-scoped-modules@1.1.0",
+        "pkgId": "readdir-scoped-modules@1.1.0",
+        "deps": [
+          {
+            "nodeId": "debuglog@1.0.1"
+          },
+          {
+            "nodeId": "dezalgo@1.0.3"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          },
+          {
+            "nodeId": "once@1.4.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "util-extend@1.0.3",
+        "pkgId": "util-extend@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "read-package-tree@5.3.1",
+        "pkgId": "read-package-tree@5.3.1",
+        "deps": [
+          {
+            "nodeId": "read-package-json@2.1.1"
+          },
+          {
+            "nodeId": "readdir-scoped-modules@1.1.0"
+          },
+          {
+            "nodeId": "util-promisify@2.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "util-promisify@2.1.0",
+        "pkgId": "util-promisify@2.1.0",
+        "deps": [
+          {
+            "nodeId": "object.getownpropertydescriptors@2.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object.getownpropertydescriptors@2.0.3",
+        "pkgId": "object.getownpropertydescriptors@2.0.3",
+        "deps": [
+          {
+            "nodeId": "define-properties@1.1.3"
+          },
+          {
+            "nodeId": "es-abstract@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "define-properties@1.1.3",
+        "pkgId": "define-properties@1.1.3",
+        "deps": [
+          {
+            "nodeId": "object-keys@1.0.12"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object-keys@1.0.12",
+        "pkgId": "object-keys@1.0.12",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-abstract@1.12.0",
+        "pkgId": "es-abstract@1.12.0",
+        "deps": [
+          {
+            "nodeId": "es-to-primitive@1.2.0"
+          },
+          {
+            "nodeId": "function-bind@1.1.1"
+          },
+          {
+            "nodeId": "has@1.0.3"
+          },
+          {
+            "nodeId": "is-callable@1.1.4"
+          },
+          {
+            "nodeId": "is-regex@1.0.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-to-primitive@1.2.0",
+        "pkgId": "es-to-primitive@1.2.0",
+        "deps": [
+          {
+            "nodeId": "is-callable@1.1.4"
+          },
+          {
+            "nodeId": "is-date-object@1.0.1"
+          },
+          {
+            "nodeId": "is-symbol@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-callable@1.1.4",
+        "pkgId": "is-callable@1.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-date-object@1.0.1",
+        "pkgId": "is-date-object@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-symbol@1.0.2",
+        "pkgId": "is-symbol@1.0.2",
+        "deps": [
+          {
+            "nodeId": "has-symbols@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-symbols@1.0.0",
+        "pkgId": "has-symbols@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "function-bind@1.1.1",
+        "pkgId": "function-bind@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has@1.0.3",
+        "pkgId": "has@1.0.3",
+        "deps": [
+          {
+            "nodeId": "function-bind@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-regex@1.0.4",
+        "pkgId": "is-regex@1.0.4",
+        "deps": [
+          {
+            "nodeId": "has@1.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "readable-stream@3.6.0",
+        "pkgId": "readable-stream@3.6.0",
+        "deps": [
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "string_decoder@1.3.0"
+          },
+          {
+            "nodeId": "util-deprecate@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string_decoder@1.3.0",
+        "pkgId": "string_decoder@1.3.0",
+        "deps": [
+          {
+            "nodeId": "safe-buffer@5.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "retry@0.12.0",
+        "pkgId": "retry@0.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "sha@3.0.0",
+        "pkgId": "sha@3.0.0",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.2.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "sorted-object@2.0.1",
+        "pkgId": "sorted-object@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "sorted-union-stream@2.1.3",
+        "pkgId": "sorted-union-stream@2.1.3",
+        "deps": [
+          {
+            "nodeId": "from2@1.3.0"
+          },
+          {
+            "nodeId": "stream-iterate@1.2.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "from2@1.3.0",
+        "pkgId": "from2@1.3.0",
+        "deps": [
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "readable-stream@1.1.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "readable-stream@1.1.14",
+        "pkgId": "readable-stream@1.1.14",
+        "deps": [
+          {
+            "nodeId": "core-util-is@1.0.2"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "isarray@0.0.1"
+          },
+          {
+            "nodeId": "string_decoder@0.10.31"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "isarray@0.0.1",
+        "pkgId": "isarray@0.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string_decoder@0.10.31",
+        "pkgId": "string_decoder@0.10.31",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "stream-iterate@1.2.0",
+        "pkgId": "stream-iterate@1.2.0",
+        "deps": [
+          {
+            "nodeId": "readable-stream@1.1.14"
+          },
+          {
+            "nodeId": "stream-shift@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "text-table@0.2.0",
+        "pkgId": "text-table@0.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "tiny-relative-date@1.3.0",
+        "pkgId": "tiny-relative-date@1.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "unpipe@1.0.0",
+        "pkgId": "unpipe@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/deeply-nested-packages/package-lock.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/deeply-nested-packages/package-lock.json
@@ -1,0 +1,4223 @@
+{
+  "name": "deeply-nested-packages",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deeply-nested-packages",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "npm": "6.14.17"
+      }
+    },
+    "node_modules/npm": {
+      "version": "6.14.17",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.17.tgz",
+      "integrity": "sha512-CxEDn1ydVRPDl4tHrlnq+WevYAhv4GF2AEHzJKQ4prZDZ96IS3Uo6t0Sy6O9kB6XzqkI+J00WfYCqqk0p6IJ1Q==",
+      "bundleDependencies": [
+        "abbrev",
+        "ansicolors",
+        "ansistyles",
+        "aproba",
+        "archy",
+        "bin-links",
+        "bluebird",
+        "byte-size",
+        "cacache",
+        "call-limit",
+        "chownr",
+        "ci-info",
+        "cli-columns",
+        "cli-table3",
+        "cmd-shim",
+        "columnify",
+        "config-chain",
+        "debuglog",
+        "detect-indent",
+        "detect-newline",
+        "dezalgo",
+        "editor",
+        "figgy-pudding",
+        "find-npm-prefix",
+        "fs-vacuum",
+        "fs-write-stream-atomic",
+        "gentle-fs",
+        "glob",
+        "graceful-fs",
+        "has-unicode",
+        "hosted-git-info",
+        "iferr",
+        "imurmurhash",
+        "infer-owner",
+        "inflight",
+        "inherits",
+        "ini",
+        "init-package-json",
+        "is-cidr",
+        "json-parse-better-errors",
+        "JSONStream",
+        "lazy-property",
+        "libcipm",
+        "libnpm",
+        "libnpmaccess",
+        "libnpmhook",
+        "libnpmorg",
+        "libnpmsearch",
+        "libnpmteam",
+        "libnpx",
+        "lock-verify",
+        "lockfile",
+        "lodash._baseindexof",
+        "lodash._baseuniq",
+        "lodash._bindcallback",
+        "lodash._cacheindexof",
+        "lodash._createcache",
+        "lodash._getnative",
+        "lodash.clonedeep",
+        "lodash.restparam",
+        "lodash.union",
+        "lodash.uniq",
+        "lodash.without",
+        "lru-cache",
+        "meant",
+        "mississippi",
+        "mkdirp",
+        "move-concurrently",
+        "node-gyp",
+        "nopt",
+        "normalize-package-data",
+        "npm-audit-report",
+        "npm-cache-filename",
+        "npm-install-checks",
+        "npm-lifecycle",
+        "npm-package-arg",
+        "npm-packlist",
+        "npm-pick-manifest",
+        "npm-profile",
+        "npm-registry-fetch",
+        "npm-user-validate",
+        "npmlog",
+        "once",
+        "opener",
+        "osenv",
+        "pacote",
+        "path-is-inside",
+        "promise-inflight",
+        "qrcode-terminal",
+        "query-string",
+        "qw",
+        "read-cmd-shim",
+        "read-installed",
+        "read-package-json",
+        "read-package-tree",
+        "read",
+        "readable-stream",
+        "readdir-scoped-modules",
+        "request",
+        "retry",
+        "rimraf",
+        "safe-buffer",
+        "semver",
+        "sha",
+        "slide",
+        "sorted-object",
+        "sorted-union-stream",
+        "ssri",
+        "stringify-package",
+        "tar",
+        "text-table",
+        "tiny-relative-date",
+        "uid-number",
+        "umask",
+        "unique-filename",
+        "unpipe",
+        "update-notifier",
+        "uuid",
+        "validate-npm-package-license",
+        "validate-npm-package-name",
+        "which",
+        "worker-farm",
+        "write-file-atomic"
+      ],
+      "dependencies": {
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "^2.0.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.8",
+        "bluebird": "^3.5.5",
+        "byte-size": "^5.0.1",
+        "cacache": "^12.0.3",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.4",
+        "ci-info": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "^3.0.3",
+        "columnify": "~1.5.4",
+        "config-chain": "^1.1.12",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.5.1",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.3.1",
+        "glob": "^7.1.6",
+        "graceful-fs": "^4.2.4",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.8.9",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
+        "inflight": "~1.0.6",
+        "inherits": "^2.0.4",
+        "ini": "^1.3.8",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^3.0.0",
+        "json-parse-better-errors": "^1.0.2",
+        "JSONStream": "^1.3.5",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^4.0.8",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "libnpx": "^10.2.4",
+        "lock-verify": "^2.1.0",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^5.1.1",
+        "meant": "^1.0.2",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.5",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^5.1.0",
+        "nopt": "^4.0.3",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.3",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.5",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.8",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.4",
+        "npm-registry-fetch": "^4.0.7",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.2",
+        "osenv": "^0.1.5",
+        "pacote": "^9.5.12",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.8.2",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "^1.0.5",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.1.1",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.6.0",
+        "readdir-scoped-modules": "^1.1.0",
+        "request": "^2.88.0",
+        "retry": "^0.12.0",
+        "rimraf": "^2.7.1",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.7.1",
+        "sha": "^3.0.0",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.2",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.19",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "~1.1.0",
+        "unique-filename": "^1.1.1",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.3.3",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": "6 >=6.2.0 || 8 || >=9.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/abbrev": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/agent-base": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/agentkeepalive": {
+      "version": "3.5.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-align": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/ansicolors": {
+      "version": "0.3.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ansistyles": {
+      "version": "0.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/aproba": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/archy": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/are-we-there-yet": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/asap": {
+      "version": "2.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/asn1": {
+      "version": "0.2.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/asynckit": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/aws4": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/balanced-match": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links": {
+      "version": "1.1.8",
+      "inBundle": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "bluebird": "^3.5.3",
+        "cmd-shim": "^3.0.0",
+        "gentle-fs": "^2.3.0",
+        "graceful-fs": "^4.1.15",
+        "npm-normalize-package-bin": "^1.0.0",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/bluebird": {
+      "version": "3.5.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/boxen": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/buffer-from": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/builtins": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/byline": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/byte-size": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/cacache": {
+      "version": "12.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/call-limit": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/camelcase": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/capture-stack-trace": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/caseless": {
+      "version": "0.12.0",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/npm/node_modules/chalk": {
+      "version": "2.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/chownr": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ci-info": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/cidr-regex": {
+      "version": "2.0.10",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cli-boxes": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/cli-table3": {
+      "version": "0.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "optionalDependencies": {
+        "colors": "^1.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/cliui": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/clone": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/cmd-shim": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "~0.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/color-convert": {
+      "version": "1.9.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.1"
+      }
+    },
+    "node_modules/npm/node_modules/color-name": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/colors": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/npm/node_modules/columnify": {
+      "version": "1.5.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/combined-stream": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/concat-stream": {
+      "version": "1.6.2",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/config-chain": {
+      "version": "1.1.12",
+      "inBundle": true,
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/npm/node_modules/configstore": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^4.2.1",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/copy-concurrently": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/copy-concurrently/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/copy-concurrently/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/create-error-class": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "capture-stack-trace": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/yallist": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/crypto-random-string": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/cyclist": {
+      "version": "0.2.2",
+      "inBundle": true
+    },
+    "node_modules/npm/node_modules/dashdash": {
+      "version": "1.14.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm/node_modules/debug": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/debuglog": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/decamelize": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/decode-uri-component": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/npm/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/defaults": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/define-properties": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/delegates": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/detect-indent": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/detect-newline": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/dezalgo": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/dot-prop": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/dotenv": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/duplexer3": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/npm/node_modules/duplexify": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/editor": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/encoding": {
+      "version": "0.1.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "node_modules/npm/node_modules/end-of-stream": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/env-paths": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/err-code": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/errno": {
+      "version": "0.1.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
+    "node_modules/npm/node_modules/es-abstract": {
+      "version": "1.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/es-to-primitive": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/es6-promise": {
+      "version": "4.2.8",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/npm/node_modules/execa": {
+      "version": "0.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/execa/node_modules/get-stream": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/extend": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/extsprintf": {
+      "version": "1.3.0",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/figgy-pudding": {
+      "version": "3.5.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/find-npm-prefix": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/flush-write-stream": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/forever-agent": {
+      "version": "0.6.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/form-data": {
+      "version": "2.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/npm/node_modules/from2": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "1.2.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/fs-vacuum": {
+      "version": "1.2.10",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "path-is-inside": "^1.0.1",
+        "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/function-bind": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/gauge": {
+      "version": "2.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/genfun": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/gentle-fs": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "aproba": "^1.1.2",
+        "chownr": "^1.1.2",
+        "cmd-shim": "^3.0.3",
+        "fs-vacuum": "^1.2.10",
+        "graceful-fs": "^4.1.11",
+        "iferr": "^0.1.5",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^0.5.1",
+        "path-is-inside": "^1.0.2",
+        "read-cmd-shim": "^1.0.1",
+        "slide": "^1.1.6"
+      }
+    },
+    "node_modules/npm/node_modules/gentle-fs/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/gentle-fs/node_modules/iferr": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/npm/node_modules/get-stream": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/getpass": {
+      "version": "0.1.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/glob": {
+      "version": "7.1.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/global-dirs": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/got": {
+      "version": "6.7.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/got/node_modules/get-stream": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/graceful-fs": {
+      "version": "4.2.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/har-schema": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator": {
+      "version": "5.1.5",
+      "deprecated": "this library is no longer supported",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/has": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/npm/node_modules/has-flag": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/has-symbols": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "3.8.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/http-signature": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "2.2.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/iconv-lite": {
+      "version": "0.4.23",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/iferr": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ignore-walk": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/npm/node_modules/import-lazy": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/inflight": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/inherits": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ini": {
+      "version": "1.3.8",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/init-package-json": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "promzard": "^0.3.0",
+        "read": "~1.0.1",
+        "read-package-json": "1 || 2",
+        "semver": "2.x || 3.x || 4 || 5",
+        "validate-npm-package-license": "^3.0.1",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/ip": {
+      "version": "1.1.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ip-regex": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/is-callable": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-ci": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^1.5.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/is-ci/node_modules/ci-info": {
+      "version": "1.6.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/is-cidr": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^2.0.10"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/is-date-object": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-installed-globally": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/is-npm": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-obj": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-path-inside": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-is-inside": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-redirect": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-regex": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-retry-allowed": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-stream": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/is-symbol": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/isarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/isexe": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/isstream": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/npm/node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-schema": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/npm/node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/jsonparse": {
+      "version": "1.3.1",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/JSONStream": {
+      "version": "1.3.5",
+      "inBundle": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/jsprim": {
+      "version": "1.4.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/latest-version": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/lazy-property": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/libcipm": {
+      "version": "4.0.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.5.1",
+        "find-npm-prefix": "^1.0.2",
+        "graceful-fs": "^4.1.11",
+        "ini": "^1.3.5",
+        "lock-verify": "^2.1.0",
+        "mkdirp": "^0.5.1",
+        "npm-lifecycle": "^3.0.0",
+        "npm-logical-tree": "^1.2.1",
+        "npm-package-arg": "^6.1.0",
+        "pacote": "^9.1.0",
+        "read-package-json": "^2.0.13",
+        "rimraf": "^2.6.2",
+        "worker-farm": "^1.6.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpm": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.3",
+        "find-npm-prefix": "^1.0.2",
+        "libnpmaccess": "^3.0.2",
+        "libnpmconfig": "^1.2.1",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmpublish": "^1.1.2",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "lock-verify": "^2.0.2",
+        "npm-lifecycle": "^3.0.0",
+        "npm-logical-tree": "^1.2.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-profile": "^4.0.2",
+        "npm-registry-fetch": "^4.0.0",
+        "npmlog": "^4.1.2",
+        "pacote": "^9.5.3",
+        "read-package-json": "^2.0.13",
+        "stringify-package": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmaccess": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "get-stream": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "find-up": "^3.0.0",
+        "ini": "^1.3.5"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/find-up": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/locate-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-limit": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-locate": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmconfig/node_modules/p-try": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmhook": {
+      "version": "5.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^4.0.0",
+        "semver": "^5.5.1",
+        "ssri": "^6.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmsearch": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmteam": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpx": {
+      "version": "10.2.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^5.0.1",
+        "npm-package-arg": "^6.0.0",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.0",
+        "update-notifier": "^2.3.0",
+        "which": "^1.3.0",
+        "y18n": "^4.0.0",
+        "yargs": "^14.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/lock-verify": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^6.1.0",
+        "semver": "^5.4.1"
+      }
+    },
+    "node_modules/npm/node_modules/lockfile": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._baseindexof": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._baseuniq": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._bindcallback": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._cacheindexof": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._createcache": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash._getnative": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/lodash._createset": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._getnative": {
+      "version": "3.9.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash._root": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.restparam": {
+      "version": "3.6.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.union": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lodash.without": {
+      "version": "4.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/make-dir": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/make-fetch-happen": {
+      "version": "5.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^3.4.1",
+        "cacache": "^12.0.0",
+        "http-cache-semantics": "^3.8.1",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "node-fetch-npm": "^2.0.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^4.0.0",
+        "ssri": "^6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/meant": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/mime-db": {
+      "version": "1.35.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/mime-types": {
+      "version": "2.1.19",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.35.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/minimatch": {
+      "version": "3.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/minimist": {
+      "version": "1.2.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/minizlib": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/mississippi": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/npm/node_modules/mkdirp/node_modules/minimist": {
+      "version": "1.2.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/move-concurrently": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/move-concurrently/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/ms": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/mute-stream": {
+      "version": "0.0.7",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-fetch-npm": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "json-parse-better-errors": "^1.0.0",
+        "safe-buffer": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.0",
+        "rimraf": "^2.6.3",
+        "semver": "^5.7.1",
+        "tar": "^4.4.12",
+        "which": "^1.3.1"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data/node_modules/resolve": {
+      "version": "1.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cli-table3": "^0.5.0",
+        "console-control-strings": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-cache-filename": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-install-checks": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^2.3.0 || 3.x || 4 || 5"
+      }
+    },
+    "node_modules/npm/node_modules/npm-lifecycle": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "byline": "^5.0.0",
+        "graceful-fs": "^4.1.15",
+        "node-gyp": "^5.0.2",
+        "resolve-from": "^4.0.0",
+        "slide": "^1.1.6",
+        "uid-number": "0.0.6",
+        "umask": "^1.1.0",
+        "which": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-logical-tree": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "6.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^2.7.1",
+        "osenv": "^0.1.5",
+        "semver": "^5.6.0",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "1.4.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.0.0",
+        "semver": "^5.4.1"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.2 || 2",
+        "figgy-pudding": "^3.4.1",
+        "npm-registry-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "4.0.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.4.1",
+        "JSONStream": "^1.3.4",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^5.0.0",
+        "npm-package-arg": "^6.1.0",
+        "safe-buffer": "^5.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/npm-user-validate": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/npmlog": {
+      "version": "4.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/object-assign": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/object-keys": {
+      "version": "1.0.12",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/npm/node_modules/object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/once": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/opener": {
+      "version": "1.5.2",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/os-homedir": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/osenv": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/p-finally": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/package-json": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/pacote": {
+      "version": "9.5.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.3",
+        "cacache": "^12.0.2",
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.1.0",
+        "glob": "^7.1.3",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "minipass": "^2.3.5",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "normalize-package-data": "^2.4.0",
+        "npm-normalize-package-bin": "^1.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.12",
+        "npm-pick-manifest": "^3.0.0",
+        "npm-registry-fetch": "^4.0.0",
+        "osenv": "^0.1.5",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^1.1.1",
+        "protoduck": "^5.0.1",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.6.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.10",
+        "unique-filename": "^1.1.1",
+        "which": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/pacote/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/path-exists": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/npm/node_modules/path-key": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/path-parse": {
+      "version": "1.0.7",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/performance-now": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pify": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/prepend-http": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/promise-retry": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/npm/node_modules/promise-retry/node_modules/retry": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/promzard": {
+      "version": "0.3.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read": "1"
+      }
+    },
+    "node_modules/npm/node_modules/proto-list": {
+      "version": "1.2.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/protoduck": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "genfun": "^5.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/prr": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pseudomap": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/psl": {
+      "version": "1.1.29",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/pump": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/pumpify": {
+      "version": "1.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/pumpify/node_modules/pump": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/npm/node_modules/punycode": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "inBundle": true,
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/npm/node_modules/qs": {
+      "version": "6.5.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/npm/node_modules/query-string": {
+      "version": "6.8.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/qw": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/rc": {
+      "version": "1.2.8",
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/npm/node_modules/read": {
+      "version": "1.0.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/read-installed": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-json": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.1",
+        "json-parse-better-errors": "^1.0.1",
+        "normalize-package-data": "^2.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-tree": {
+      "version": "5.3.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "util-promisify": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/npm/node_modules/registry-auth-token": {
+      "version": "3.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/registry-url": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/request": {
+      "version": "2.88.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/require-directory": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/retry": {
+      "version": "0.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm/node_modules/rimraf": {
+      "version": "2.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/npm/node_modules/run-queue": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1"
+      }
+    },
+    "node_modules/npm/node_modules/run-queue/node_modules/aproba": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/semver": {
+      "version": "5.7.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm/node_modules/semver-diff": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/sha": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT)",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/slide": {
+      "version": "1.1.6",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/smart-buffer": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks": {
+      "version": "2.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "4.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-object": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/npm/node_modules/sorted-union-stream": {
+      "version": "2.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "from2": "^1.3.0",
+        "stream-iterate": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/isarray": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/npm/node_modules/sorted-union-stream/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/spdx-correct": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.5",
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/npm/node_modules/split-on-first": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/sshpk": {
+      "version": "1.14.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "getpass": "^0.1.1",
+        "safer-buffer": "^2.0.2"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "optionalDependencies": {
+        "bcrypt-pbkdf": "^1.0.0",
+        "ecc-jsbn": "~0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "node_modules/npm/node_modules/ssri": {
+      "version": "6.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1"
+      }
+    },
+    "node_modules/npm/node_modules/stream-each": {
+      "version": "1.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/stream-shift": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/string-width": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/stringify-package": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/strip-eof": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "5.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/tar": {
+      "version": "4.4.19",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/minipass": {
+      "version": "2.9.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tar/node_modules/yallist": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/term-size": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/text-table": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/through": {
+      "version": "2.3.8",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/through2": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/timed-out": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/tiny-relative-date": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/tough-cookie": {
+      "version": "2.4.3",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "inBundle": true,
+      "license": "Unlicense",
+      "optional": true
+    },
+    "node_modules/npm/node_modules/typedarray": {
+      "version": "0.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/uid-number": {
+      "version": "0.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/umask": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/unique-filename": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/unique-slug": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/npm/node_modules/unique-string": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/unpipe": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/npm/node_modules/unzip-response": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/update-notifier": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/uri-js": {
+      "version": "4.4.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/uri-js/node_modules/punycode": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/url-parse-lax": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prepend-http": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/util-extend": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/util-promisify": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/uuid": {
+      "version": "3.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/npm/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/verror": {
+      "version": "1.10.0",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/npm/node_modules/which": {
+      "version": "1.3.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/npm/node_modules/which-module": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/wide-align": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/wide-align/node_modules/string-width": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/widest-line": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/worker-farm": {
+      "version": "1.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "errno": "~0.1.7"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/wrappy": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/npm/node_modules/xdg-basedir": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/xtend": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/npm/node_modules/y18n": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/yallist": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/yargs": {
+      "version": "14.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^15.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/yargs-parser": {
+      "version": "15.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/npm/node_modules/yargs-parser/node_modules/camelcase": {
+      "version": "5.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/find-up": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/locate-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-locate": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/p-try": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/deeply-nested-packages/package.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/deeply-nested-packages/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "deeply-nested-packages",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "npm": "6.14.17"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/goof/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/goof/expected.json
@@ -1594,10 +1594,24 @@
       }
     },
     {
-      "id": "default-require-extensions@^1.0.0",
+      "id": "default-require-extensions@1.0.0",
       "info": {
         "name": "default-require-extensions",
-        "version": "^1.0.0"
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "strip-bom@2.0.0",
+      "info": {
+        "name": "strip-bom",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "is-utf8@0.2.1",
+      "info": {
+        "name": "is-utf8",
+        "version": "0.2.1"
       }
     },
     {
@@ -1615,181 +1629,6 @@
       }
     },
     {
-      "id": "md5-hex@^1.2.0",
-      "info": {
-        "name": "md5-hex",
-        "version": "^1.2.0"
-      }
-    },
-    {
-      "id": "write-file-atomic@^1.1.4",
-      "info": {
-        "name": "write-file-atomic",
-        "version": "^1.1.4"
-      }
-    },
-    {
-      "id": "convert-source-map@1.2.0",
-      "info": {
-        "name": "convert-source-map",
-        "version": "1.2.0"
-      }
-    },
-    {
-      "id": "default-require-extensions@1.0.0",
-      "info": {
-        "name": "default-require-extensions",
-        "version": "1.0.0"
-      }
-    },
-    {
-      "id": "strip-bom@^2.0.0",
-      "info": {
-        "name": "strip-bom",
-        "version": "^2.0.0"
-      }
-    },
-    {
-      "id": "find-cache-dir@0.1.1",
-      "info": {
-        "name": "find-cache-dir",
-        "version": "0.1.1"
-      }
-    },
-    {
-      "id": "commondir@^1.0.1",
-      "info": {
-        "name": "commondir",
-        "version": "^1.0.1"
-      }
-    },
-    {
-      "id": "pkg-dir@^1.0.0",
-      "info": {
-        "name": "pkg-dir",
-        "version": "^1.0.0"
-      }
-    },
-    {
-      "id": "find-up@1.1.2",
-      "info": {
-        "name": "find-up",
-        "version": "1.1.2"
-      }
-    },
-    {
-      "id": "path-exists@^2.0.0",
-      "info": {
-        "name": "path-exists",
-        "version": "^2.0.0"
-      }
-    },
-    {
-      "id": "foreground-child@1.5.1",
-      "info": {
-        "name": "foreground-child",
-        "version": "1.5.1"
-      }
-    },
-    {
-      "id": "cross-spawn-async@^2.1.1",
-      "info": {
-        "name": "cross-spawn-async",
-        "version": "^2.1.1"
-      }
-    },
-    {
-      "id": "glob@7.0.3",
-      "info": {
-        "name": "glob",
-        "version": "7.0.3"
-      }
-    },
-    {
-      "id": "istanbul@0.4.3",
-      "info": {
-        "name": "istanbul",
-        "version": "0.4.3"
-      }
-    },
-    {
-      "id": "escodegen@1.8.x",
-      "info": {
-        "name": "escodegen",
-        "version": "1.8.x"
-      }
-    },
-    {
-      "id": "fileset@0.2.x",
-      "info": {
-        "name": "fileset",
-        "version": "0.2.x"
-      }
-    },
-    {
-      "id": "handlebars@^4.0.1",
-      "info": {
-        "name": "handlebars",
-        "version": "^4.0.1"
-      }
-    },
-    {
-      "id": "resolve@1.22.1",
-      "info": {
-        "name": "resolve",
-        "version": "1.22.1"
-      }
-    },
-    {
-      "id": "is-core-module@2.11.0",
-      "info": {
-        "name": "is-core-module",
-        "version": "2.11.0"
-      }
-    },
-    {
-      "id": "has@1.0.3",
-      "info": {
-        "name": "has",
-        "version": "1.0.3"
-      }
-    },
-    {
-      "id": "function-bind@1.1.1",
-      "info": {
-        "name": "function-bind",
-        "version": "1.1.1"
-      }
-    },
-    {
-      "id": "path-parse@1.0.7",
-      "info": {
-        "name": "path-parse",
-        "version": "1.0.7"
-      }
-    },
-    {
-      "id": "supports-preserve-symlinks-flag@1.0.0",
-      "info": {
-        "name": "supports-preserve-symlinks-flag",
-        "version": "1.0.0"
-      }
-    },
-    {
-      "id": "supports-color@1.3.1",
-      "info": {
-        "name": "supports-color",
-        "version": "1.3.1"
-      }
-    },
-    {
-      "id": "wordwrap@^1.0.0",
-      "info": {
-        "name": "wordwrap",
-        "version": "^1.0.0"
-      }
-    },
-    {
       "id": "md5-hex@1.3.0",
       "info": {
         "name": "md5-hex",
@@ -1797,108 +1636,10 @@
       }
     },
     {
-      "id": "md5-o-matic@^0.1.1",
+      "id": "md5-o-matic@0.1.1",
       "info": {
         "name": "md5-o-matic",
-        "version": "^0.1.1"
-      }
-    },
-    {
-      "id": "micromatch@2.3.8",
-      "info": {
-        "name": "micromatch",
-        "version": "2.3.8"
-      }
-    },
-    {
-      "id": "arr-diff@^2.0.0",
-      "info": {
-        "name": "arr-diff",
-        "version": "^2.0.0"
-      }
-    },
-    {
-      "id": "array-unique@^0.2.1",
-      "info": {
-        "name": "array-unique",
-        "version": "^0.2.1"
-      }
-    },
-    {
-      "id": "braces@^1.8.2",
-      "info": {
-        "name": "braces",
-        "version": "^1.8.2"
-      }
-    },
-    {
-      "id": "expand-brackets@^0.1.4",
-      "info": {
-        "name": "expand-brackets",
-        "version": "^0.1.4"
-      }
-    },
-    {
-      "id": "extglob@^0.3.1",
-      "info": {
-        "name": "extglob",
-        "version": "^0.3.1"
-      }
-    },
-    {
-      "id": "filename-regex@^2.0.0",
-      "info": {
-        "name": "filename-regex",
-        "version": "^2.0.0"
-      }
-    },
-    {
-      "id": "is-extglob@^1.0.0",
-      "info": {
-        "name": "is-extglob",
-        "version": "^1.0.0"
-      }
-    },
-    {
-      "id": "is-glob@^2.0.1",
-      "info": {
-        "name": "is-glob",
-        "version": "^2.0.1"
-      }
-    },
-    {
-      "id": "kind-of@^3.0.2",
-      "info": {
-        "name": "kind-of",
-        "version": "^3.0.2"
-      }
-    },
-    {
-      "id": "normalize-path@^2.0.1",
-      "info": {
-        "name": "normalize-path",
-        "version": "^2.0.1"
-      }
-    },
-    {
-      "id": "object.omit@^2.0.0",
-      "info": {
-        "name": "object.omit",
-        "version": "^2.0.0"
-      }
-    },
-    {
-      "id": "parse-glob@^3.0.4",
-      "info": {
-        "name": "parse-glob",
-        "version": "^3.0.4"
-      }
-    },
-    {
-      "id": "regex-cache@^0.4.2",
-      "info": {
-        "name": "regex-cache",
-        "version": "^0.4.2"
+        "version": "0.1.1"
       }
     },
     {
@@ -1909,10 +1650,710 @@
       }
     },
     {
-      "id": "minimist@1.2.7",
+      "id": "minimist@0.0.8",
       "info": {
         "name": "minimist",
-        "version": "1.2.7"
+        "version": "0.0.8"
+      }
+    },
+    {
+      "id": "write-file-atomic@1.1.4",
+      "info": {
+        "name": "write-file-atomic",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "graceful-fs@4.1.4",
+      "info": {
+        "name": "graceful-fs",
+        "version": "4.1.4"
+      }
+    },
+    {
+      "id": "imurmurhash@0.1.4",
+      "info": {
+        "name": "imurmurhash",
+        "version": "0.1.4"
+      }
+    },
+    {
+      "id": "slide@1.1.6",
+      "info": {
+        "name": "slide",
+        "version": "1.1.6"
+      }
+    },
+    {
+      "id": "convert-source-map@1.2.0",
+      "info": {
+        "name": "convert-source-map",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "find-cache-dir@0.1.1",
+      "info": {
+        "name": "find-cache-dir",
+        "version": "0.1.1"
+      }
+    },
+    {
+      "id": "commondir@1.0.1",
+      "info": {
+        "name": "commondir",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "pkg-dir@1.0.0",
+      "info": {
+        "name": "pkg-dir",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "find-up@1.1.2",
+      "info": {
+        "name": "find-up",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "path-exists@2.1.0",
+      "info": {
+        "name": "path-exists",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "foreground-child@1.5.1",
+      "info": {
+        "name": "foreground-child",
+        "version": "1.5.1"
+      }
+    },
+    {
+      "id": "cross-spawn-async@2.2.4",
+      "info": {
+        "name": "cross-spawn-async",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "lru-cache@4.0.1",
+      "info": {
+        "name": "lru-cache",
+        "version": "4.0.1"
+      }
+    },
+    {
+      "id": "yallist@2.0.0",
+      "info": {
+        "name": "yallist",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "which@1.2.10",
+      "info": {
+        "name": "which",
+        "version": "1.2.10"
+      }
+    },
+    {
+      "id": "signal-exit@2.1.2",
+      "info": {
+        "name": "signal-exit",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "glob@7.0.3",
+      "info": {
+        "name": "glob",
+        "version": "7.0.3"
+      }
+    },
+    {
+      "id": "inflight@1.0.5",
+      "info": {
+        "name": "inflight",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "once@1.3.3",
+      "info": {
+        "name": "once",
+        "version": "1.3.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.1",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "minimatch@3.0.0",
+      "info": {
+        "name": "minimatch",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "brace-expansion@1.1.4",
+      "info": {
+        "name": "brace-expansion",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "balanced-match@0.4.1",
+      "info": {
+        "name": "balanced-match",
+        "version": "0.4.1"
+      }
+    },
+    {
+      "id": "path-is-absolute@1.0.0",
+      "info": {
+        "name": "path-is-absolute",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "istanbul@0.4.3",
+      "info": {
+        "name": "istanbul",
+        "version": "0.4.3"
+      }
+    },
+    {
+      "id": "abbrev@1.0.7",
+      "info": {
+        "name": "abbrev",
+        "version": "1.0.7"
+      }
+    },
+    {
+      "id": "async@1.5.2",
+      "info": {
+        "name": "async",
+        "version": "1.5.2"
+      }
+    },
+    {
+      "id": "escodegen@1.8.0",
+      "info": {
+        "name": "escodegen",
+        "version": "1.8.0"
+      }
+    },
+    {
+      "id": "esprima@2.7.2",
+      "info": {
+        "name": "esprima",
+        "version": "2.7.2"
+      }
+    },
+    {
+      "id": "estraverse@1.9.3",
+      "info": {
+        "name": "estraverse",
+        "version": "1.9.3"
+      }
+    },
+    {
+      "id": "esutils@2.0.2",
+      "info": {
+        "name": "esutils",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "optionator@0.8.1",
+      "info": {
+        "name": "optionator",
+        "version": "0.8.1"
+      }
+    },
+    {
+      "id": "deep-is@0.1.3",
+      "info": {
+        "name": "deep-is",
+        "version": "0.1.3"
+      }
+    },
+    {
+      "id": "fast-levenshtein@1.1.3",
+      "info": {
+        "name": "fast-levenshtein",
+        "version": "1.1.3"
+      }
+    },
+    {
+      "id": "levn@0.3.0",
+      "info": {
+        "name": "levn",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "prelude-ls@1.1.2",
+      "info": {
+        "name": "prelude-ls",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "type-check@0.3.2",
+      "info": {
+        "name": "type-check",
+        "version": "0.3.2"
+      }
+    },
+    {
+      "id": "wordwrap@1.0.0",
+      "info": {
+        "name": "wordwrap",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "source-map@0.2.0",
+      "info": {
+        "name": "source-map",
+        "version": "0.2.0"
+      }
+    },
+    {
+      "id": "amdefine@1.0.0",
+      "info": {
+        "name": "amdefine",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "fileset@0.2.1",
+      "info": {
+        "name": "fileset",
+        "version": "0.2.1"
+      }
+    },
+    {
+      "id": "glob@5.0.15",
+      "info": {
+        "name": "glob",
+        "version": "5.0.15"
+      }
+    },
+    {
+      "id": "minimatch@2.0.10",
+      "info": {
+        "name": "minimatch",
+        "version": "2.0.10"
+      }
+    },
+    {
+      "id": "handlebars@4.0.5",
+      "info": {
+        "name": "handlebars",
+        "version": "4.0.5"
+      }
+    },
+    {
+      "id": "optimist@0.6.1",
+      "info": {
+        "name": "optimist",
+        "version": "0.6.1"
+      }
+    },
+    {
+      "id": "minimist@0.0.10",
+      "info": {
+        "name": "minimist",
+        "version": "0.0.10"
+      }
+    },
+    {
+      "id": "wordwrap@0.0.3",
+      "info": {
+        "name": "wordwrap",
+        "version": "0.0.3"
+      }
+    },
+    {
+      "id": "source-map@0.4.4",
+      "info": {
+        "name": "source-map",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "uglify-js@2.6.2",
+      "info": {
+        "name": "uglify-js",
+        "version": "2.6.2"
+      }
+    },
+    {
+      "id": "async@0.2.10",
+      "info": {
+        "name": "async",
+        "version": "0.2.10"
+      }
+    },
+    {
+      "id": "source-map@0.5.6",
+      "info": {
+        "name": "source-map",
+        "version": "0.5.6"
+      }
+    },
+    {
+      "id": "uglify-to-browserify@1.0.2",
+      "info": {
+        "name": "uglify-to-browserify",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "yargs@3.10.0",
+      "info": {
+        "name": "yargs",
+        "version": "3.10.0"
+      }
+    },
+    {
+      "id": "camelcase@1.2.1",
+      "info": {
+        "name": "camelcase",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "cliui@2.1.0",
+      "info": {
+        "name": "cliui",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "center-align@0.1.3",
+      "info": {
+        "name": "center-align",
+        "version": "0.1.3"
+      }
+    },
+    {
+      "id": "align-text@0.1.4",
+      "info": {
+        "name": "align-text",
+        "version": "0.1.4"
+      }
+    },
+    {
+      "id": "kind-of@3.0.3",
+      "info": {
+        "name": "kind-of",
+        "version": "3.0.3"
+      }
+    },
+    {
+      "id": "is-buffer@1.1.3",
+      "info": {
+        "name": "is-buffer",
+        "version": "1.1.3"
+      }
+    },
+    {
+      "id": "longest@1.0.1",
+      "info": {
+        "name": "longest",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "repeat-string@1.5.4",
+      "info": {
+        "name": "repeat-string",
+        "version": "1.5.4"
+      }
+    },
+    {
+      "id": "lazy-cache@1.0.4",
+      "info": {
+        "name": "lazy-cache",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "right-align@0.1.3",
+      "info": {
+        "name": "right-align",
+        "version": "0.1.3"
+      }
+    },
+    {
+      "id": "wordwrap@0.0.2",
+      "info": {
+        "name": "wordwrap",
+        "version": "0.0.2"
+      }
+    },
+    {
+      "id": "decamelize@1.2.0",
+      "info": {
+        "name": "decamelize",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "window-size@0.1.0",
+      "info": {
+        "name": "window-size",
+        "version": "0.1.0"
+      }
+    },
+    {
+      "id": "nopt@3.0.6",
+      "info": {
+        "name": "nopt",
+        "version": "3.0.6"
+      }
+    },
+    {
+      "id": "resolve@1.1.7",
+      "info": {
+        "name": "resolve",
+        "version": "1.1.7"
+      }
+    },
+    {
+      "id": "supports-color@3.1.2",
+      "info": {
+        "name": "supports-color",
+        "version": "3.1.2"
+      }
+    },
+    {
+      "id": "has-flag@1.0.0",
+      "info": {
+        "name": "has-flag",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "micromatch@2.3.8",
+      "info": {
+        "name": "micromatch",
+        "version": "2.3.8"
+      }
+    },
+    {
+      "id": "arr-diff@2.0.0",
+      "info": {
+        "name": "arr-diff",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "arr-flatten@1.0.1",
+      "info": {
+        "name": "arr-flatten",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "array-unique@0.2.1",
+      "info": {
+        "name": "array-unique",
+        "version": "0.2.1"
+      }
+    },
+    {
+      "id": "braces@1.8.5",
+      "info": {
+        "name": "braces",
+        "version": "1.8.5"
+      }
+    },
+    {
+      "id": "expand-range@1.8.2",
+      "info": {
+        "name": "expand-range",
+        "version": "1.8.2"
+      }
+    },
+    {
+      "id": "fill-range@2.2.3",
+      "info": {
+        "name": "fill-range",
+        "version": "2.2.3"
+      }
+    },
+    {
+      "id": "is-number@2.1.0",
+      "info": {
+        "name": "is-number",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "isobject@2.1.0",
+      "info": {
+        "name": "isobject",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "randomatic@1.1.5",
+      "info": {
+        "name": "randomatic",
+        "version": "1.1.5"
+      }
+    },
+    {
+      "id": "repeat-element@1.1.2",
+      "info": {
+        "name": "repeat-element",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "preserve@0.2.0",
+      "info": {
+        "name": "preserve",
+        "version": "0.2.0"
+      }
+    },
+    {
+      "id": "expand-brackets@0.1.5",
+      "info": {
+        "name": "expand-brackets",
+        "version": "0.1.5"
+      }
+    },
+    {
+      "id": "is-posix-bracket@0.1.1",
+      "info": {
+        "name": "is-posix-bracket",
+        "version": "0.1.1"
+      }
+    },
+    {
+      "id": "extglob@0.3.2",
+      "info": {
+        "name": "extglob",
+        "version": "0.3.2"
+      }
+    },
+    {
+      "id": "is-extglob@1.0.0",
+      "info": {
+        "name": "is-extglob",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "filename-regex@2.0.0",
+      "info": {
+        "name": "filename-regex",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "is-glob@2.0.1",
+      "info": {
+        "name": "is-glob",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "normalize-path@2.0.1",
+      "info": {
+        "name": "normalize-path",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "object.omit@2.0.0",
+      "info": {
+        "name": "object.omit",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "for-own@0.1.4",
+      "info": {
+        "name": "for-own",
+        "version": "0.1.4"
+      }
+    },
+    {
+      "id": "for-in@0.1.5",
+      "info": {
+        "name": "for-in",
+        "version": "0.1.5"
+      }
+    },
+    {
+      "id": "is-extendable@0.1.1",
+      "info": {
+        "name": "is-extendable",
+        "version": "0.1.1"
+      }
+    },
+    {
+      "id": "parse-glob@3.0.4",
+      "info": {
+        "name": "parse-glob",
+        "version": "3.0.4"
+      }
+    },
+    {
+      "id": "glob-base@0.3.0",
+      "info": {
+        "name": "glob-base",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "glob-parent@2.0.0",
+      "info": {
+        "name": "glob-parent",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "is-dotfile@1.0.2",
+      "info": {
+        "name": "is-dotfile",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "regex-cache@0.4.3",
+      "info": {
+        "name": "regex-cache",
+        "version": "0.4.3"
+      }
+    },
+    {
+      "id": "is-equal-shallow@0.1.3",
+      "info": {
+        "name": "is-equal-shallow",
+        "version": "0.1.3"
+      }
+    },
+    {
+      "id": "is-primitive@2.0.0",
+      "info": {
+        "name": "is-primitive",
+        "version": "2.0.0"
       }
     },
     {
@@ -1920,13 +2361,6 @@
       "info": {
         "name": "pkg-up",
         "version": "1.0.0"
-      }
-    },
-    {
-      "id": "find-up@^1.0.0",
-      "info": {
-        "name": "find-up",
-        "version": "^1.0.0"
       }
     },
     {
@@ -1951,13 +2385,6 @@
       }
     },
     {
-      "id": "source-map@0.5.6",
-      "info": {
-        "name": "source-map",
-        "version": "0.5.6"
-      }
-    },
-    {
       "id": "spawn-wrap@1.2.3",
       "info": {
         "name": "spawn-wrap",
@@ -1965,17 +2392,10 @@
       }
     },
     {
-      "id": "os-homedir@^1.0.1",
+      "id": "os-homedir@1.0.1",
       "info": {
         "name": "os-homedir",
-        "version": "^1.0.1"
-      }
-    },
-    {
-      "id": "signal-exit@2.1.2",
-      "info": {
-        "name": "signal-exit",
-        "version": "2.1.2"
+        "version": "1.0.1"
       }
     },
     {
@@ -1986,38 +2406,157 @@
       }
     },
     {
-      "id": "arrify@^1.0.1",
-      "info": {
-        "name": "arrify",
-        "version": "^1.0.1"
-      }
-    },
-    {
-      "id": "lodash.assign@^4.0.9",
+      "id": "lodash.assign@4.0.9",
       "info": {
         "name": "lodash.assign",
-        "version": "^4.0.9"
+        "version": "4.0.9"
       }
     },
     {
-      "id": "micromatch@^2.3.8",
+      "id": "lodash.keys@4.0.7",
       "info": {
-        "name": "micromatch",
-        "version": "^2.3.8"
+        "name": "lodash.keys",
+        "version": "4.0.7"
       }
     },
     {
-      "id": "read-pkg-up@^1.0.1",
+      "id": "lodash.rest@4.0.3",
+      "info": {
+        "name": "lodash.rest",
+        "version": "4.0.3"
+      }
+    },
+    {
+      "id": "read-pkg-up@1.0.1",
       "info": {
         "name": "read-pkg-up",
-        "version": "^1.0.1"
+        "version": "1.0.1"
       }
     },
     {
-      "id": "require-main-filename@^1.0.1",
+      "id": "read-pkg@1.1.0",
+      "info": {
+        "name": "read-pkg",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "load-json-file@1.1.0",
+      "info": {
+        "name": "load-json-file",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "parse-json@2.2.0",
+      "info": {
+        "name": "parse-json",
+        "version": "2.2.0"
+      }
+    },
+    {
+      "id": "error-ex@1.3.0",
+      "info": {
+        "name": "error-ex",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "is-arrayish@0.2.1",
+      "info": {
+        "name": "is-arrayish",
+        "version": "0.2.1"
+      }
+    },
+    {
+      "id": "pify@2.3.0",
+      "info": {
+        "name": "pify",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "normalize-package-data@2.3.5",
+      "info": {
+        "name": "normalize-package-data",
+        "version": "2.3.5"
+      }
+    },
+    {
+      "id": "hosted-git-info@2.1.5",
+      "info": {
+        "name": "hosted-git-info",
+        "version": "2.1.5"
+      }
+    },
+    {
+      "id": "is-builtin-module@1.0.0",
+      "info": {
+        "name": "is-builtin-module",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "builtin-modules@1.1.1",
+      "info": {
+        "name": "builtin-modules",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "semver@5.1.0",
+      "info": {
+        "name": "semver",
+        "version": "5.1.0"
+      }
+    },
+    {
+      "id": "validate-npm-package-license@3.0.1",
+      "info": {
+        "name": "validate-npm-package-license",
+        "version": "3.0.1"
+      }
+    },
+    {
+      "id": "spdx-correct@1.0.2",
+      "info": {
+        "name": "spdx-correct",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "spdx-license-ids@1.2.1",
+      "info": {
+        "name": "spdx-license-ids",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "spdx-expression-parse@1.0.2",
+      "info": {
+        "name": "spdx-expression-parse",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "spdx-exceptions@1.0.4",
+      "info": {
+        "name": "spdx-exceptions",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "path-type@1.1.0",
+      "info": {
+        "name": "path-type",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "require-main-filename@1.0.1",
       "info": {
         "name": "require-main-filename",
-        "version": "^1.0.1"
+        "version": "1.0.1"
       }
     },
     {
@@ -2028,73 +2567,129 @@
       }
     },
     {
-      "id": "camelcase@^3.0.0",
+      "id": "camelcase@3.0.0",
       "info": {
         "name": "camelcase",
-        "version": "^3.0.0"
+        "version": "3.0.0"
       }
     },
     {
-      "id": "cliui@^3.2.0",
+      "id": "cliui@3.2.0",
       "info": {
         "name": "cliui",
-        "version": "^3.2.0"
+        "version": "3.2.0"
       }
     },
     {
-      "id": "decamelize@^1.1.1",
-      "info": {
-        "name": "decamelize",
-        "version": "^1.1.1"
-      }
-    },
-    {
-      "id": "os-locale@^1.4.0",
-      "info": {
-        "name": "os-locale",
-        "version": "^1.4.0"
-      }
-    },
-    {
-      "id": "pkg-conf@^1.1.2",
-      "info": {
-        "name": "pkg-conf",
-        "version": "^1.1.2"
-      }
-    },
-    {
-      "id": "set-blocking@^1.0.0",
-      "info": {
-        "name": "set-blocking",
-        "version": "^1.0.0"
-      }
-    },
-    {
-      "id": "string-width@^1.0.1",
+      "id": "string-width@1.0.1",
       "info": {
         "name": "string-width",
-        "version": "^1.0.1"
+        "version": "1.0.1"
       }
     },
     {
-      "id": "window-size@^0.2.0",
+      "id": "code-point-at@1.0.0",
+      "info": {
+        "name": "code-point-at",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "number-is-nan@1.0.0",
+      "info": {
+        "name": "number-is-nan",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "is-fullwidth-code-point@1.0.0",
+      "info": {
+        "name": "is-fullwidth-code-point",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "wrap-ansi@2.0.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "os-locale@1.4.0",
+      "info": {
+        "name": "os-locale",
+        "version": "1.4.0"
+      }
+    },
+    {
+      "id": "lcid@1.0.0",
+      "info": {
+        "name": "lcid",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "invert-kv@1.0.0",
+      "info": {
+        "name": "invert-kv",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "pkg-conf@1.1.3",
+      "info": {
+        "name": "pkg-conf",
+        "version": "1.1.3"
+      }
+    },
+    {
+      "id": "object-assign@4.1.0",
+      "info": {
+        "name": "object-assign",
+        "version": "4.1.0"
+      }
+    },
+    {
+      "id": "symbol@0.2.3",
+      "info": {
+        "name": "symbol",
+        "version": "0.2.3"
+      }
+    },
+    {
+      "id": "set-blocking@1.0.0",
+      "info": {
+        "name": "set-blocking",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "window-size@0.2.0",
       "info": {
         "name": "window-size",
-        "version": "^0.2.0"
+        "version": "0.2.0"
       }
     },
     {
-      "id": "y18n@^3.2.1",
+      "id": "y18n@3.2.1",
       "info": {
         "name": "y18n",
-        "version": "^3.2.1"
+        "version": "3.2.1"
       }
     },
     {
-      "id": "yargs-parser@^2.4.0",
+      "id": "yargs-parser@2.4.0",
       "info": {
         "name": "yargs-parser",
-        "version": "^2.4.0"
+        "version": "2.4.0"
+      }
+    },
+    {
+      "id": "camelcase@2.1.1",
+      "info": {
+        "name": "camelcase",
+        "version": "2.1.1"
       }
     },
     {
@@ -2137,6 +2732,13 @@
       "info": {
         "name": "stack-utils",
         "version": "0.4.0"
+      }
+    },
+    {
+      "id": "supports-color@1.3.1",
+      "info": {
+        "name": "supports-color",
+        "version": "1.3.1"
       }
     },
     {
@@ -5562,7 +6164,7 @@
         "pkgId": "append-transform@0.4.0",
         "deps": [
           {
-            "nodeId": "node_modules/default-require-extensions"
+            "nodeId": "default-require-extensions@1.0.0"
           }
         ],
         "info": {
@@ -5572,13 +6174,40 @@
         }
       },
       {
-        "nodeId": "node_modules/default-require-extensions",
-        "pkgId": "default-require-extensions@^1.0.0",
+        "nodeId": "default-require-extensions@1.0.0",
+        "pkgId": "default-require-extensions@1.0.0",
+        "deps": [
+          {
+            "nodeId": "strip-bom@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-bom@2.0.0",
+        "pkgId": "strip-bom@2.0.0",
+        "deps": [
+          {
+            "nodeId": "is-utf8@0.2.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-utf8@0.2.1",
+        "pkgId": "is-utf8@0.2.1",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
@@ -5597,13 +6226,13 @@
         "pkgId": "caching-transform@1.0.1",
         "deps": [
           {
-            "nodeId": "node_modules/md5-hex"
+            "nodeId": "md5-hex@1.3.0"
           },
           {
-            "nodeId": "mkdirp@0.3.5"
+            "nodeId": "mkdirp@0.5.1"
           },
           {
-            "nodeId": "node_modules/write-file-atomic"
+            "nodeId": "write-file-atomic@1.1.4"
           }
         ],
         "info": {
@@ -5613,24 +6242,100 @@
         }
       },
       {
-        "nodeId": "node_modules/md5-hex",
-        "pkgId": "md5-hex@^1.2.0",
-        "deps": [],
+        "nodeId": "md5-hex@1.3.0",
+        "pkgId": "md5-hex@1.3.0",
+        "deps": [
+          {
+            "nodeId": "md5-o-matic@0.1.1"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/write-file-atomic",
-        "pkgId": "write-file-atomic@^1.1.4",
+        "nodeId": "md5-o-matic@0.1.1",
+        "pkgId": "md5-o-matic@0.1.1",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mkdirp@0.5.1",
+        "pkgId": "mkdirp@0.5.1",
+        "deps": [
+          {
+            "nodeId": "minimist@0.0.8"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "minimist@0.0.8",
+        "pkgId": "minimist@0.0.8",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "write-file-atomic@1.1.4",
+        "pkgId": "write-file-atomic@1.1.4",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.1.4"
+          },
+          {
+            "nodeId": "imurmurhash@0.1.4"
+          },
+          {
+            "nodeId": "slide@1.1.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "graceful-fs@4.1.4",
+        "pkgId": "graceful-fs@4.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "imurmurhash@0.1.4",
+        "pkgId": "imurmurhash@0.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "slide@1.1.6",
+        "pkgId": "slide@1.1.6",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
           }
         }
       },
@@ -5645,42 +6350,17 @@
         }
       },
       {
-        "nodeId": "default-require-extensions@1.0.0",
-        "pkgId": "default-require-extensions@1.0.0",
-        "deps": [
-          {
-            "nodeId": "node_modules/strip-bom"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/strip-bom",
-        "pkgId": "strip-bom@^2.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
         "nodeId": "find-cache-dir@0.1.1",
         "pkgId": "find-cache-dir@0.1.1",
         "deps": [
           {
-            "nodeId": "node_modules/commondir"
+            "nodeId": "commondir@1.0.1"
           },
           {
-            "nodeId": "mkdirp@0.3.5"
+            "nodeId": "mkdirp@0.5.1"
           },
           {
-            "nodeId": "node_modules/pkg-dir"
+            "nodeId": "pkg-dir@1.0.0"
           }
         ],
         "info": {
@@ -5690,24 +6370,26 @@
         }
       },
       {
-        "nodeId": "node_modules/commondir",
-        "pkgId": "commondir@^1.0.1",
+        "nodeId": "commondir@1.0.1",
+        "pkgId": "commondir@1.0.1",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/pkg-dir",
-        "pkgId": "pkg-dir@^1.0.0",
-        "deps": [],
+        "nodeId": "pkg-dir@1.0.0",
+        "pkgId": "pkg-dir@1.0.0",
+        "deps": [
+          {
+            "nodeId": "find-up@1.1.2"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
@@ -5716,7 +6398,7 @@
         "pkgId": "find-up@1.1.2",
         "deps": [
           {
-            "nodeId": "node_modules/path-exists"
+            "nodeId": "path-exists@2.1.0"
           },
           {
             "nodeId": "pinkie-promise@2.0.1"
@@ -5729,28 +6411,11 @@
         }
       },
       {
-        "nodeId": "node_modules/path-exists",
-        "pkgId": "path-exists@^2.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "foreground-child@1.5.1",
-        "pkgId": "foreground-child@1.5.1",
+        "nodeId": "path-exists@2.1.0",
+        "pkgId": "path-exists@2.1.0",
         "deps": [
           {
-            "nodeId": "node_modules/cross-spawn-async"
-          },
-          {
-            "nodeId": "signal-exit@3.0.7"
-          },
-          {
-            "nodeId": "which@1.3.1"
+            "nodeId": "pinkie-promise@2.0.1"
           }
         ],
         "info": {
@@ -5760,13 +6425,90 @@
         }
       },
       {
-        "nodeId": "node_modules/cross-spawn-async",
-        "pkgId": "cross-spawn-async@^2.1.1",
+        "nodeId": "foreground-child@1.5.1",
+        "pkgId": "foreground-child@1.5.1",
+        "deps": [
+          {
+            "nodeId": "cross-spawn-async@2.2.4"
+          },
+          {
+            "nodeId": "signal-exit@2.1.2"
+          },
+          {
+            "nodeId": "which@1.2.10"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cross-spawn-async@2.2.4",
+        "pkgId": "cross-spawn-async@2.2.4",
+        "deps": [
+          {
+            "nodeId": "lru-cache@4.0.1"
+          },
+          {
+            "nodeId": "which@1.2.10"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lru-cache@4.0.1",
+        "pkgId": "lru-cache@4.0.1",
+        "deps": [
+          {
+            "nodeId": "pseudomap@1.0.2"
+          },
+          {
+            "nodeId": "yallist@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "yallist@2.0.0",
+        "pkgId": "yallist@2.0.0",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "which@1.2.10",
+        "pkgId": "which@1.2.10",
+        "deps": [
+          {
+            "nodeId": "isexe@1.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "signal-exit@2.1.2",
+        "pkgId": "signal-exit@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
           }
         }
       },
@@ -5775,21 +6517,113 @@
         "pkgId": "glob@7.0.3",
         "deps": [
           {
-            "nodeId": "inflight@1.0.6"
+            "nodeId": "inflight@1.0.5"
           },
           {
-            "nodeId": "inherits@2.0.4"
+            "nodeId": "inherits@2.0.1"
           },
           {
-            "nodeId": "minimatch@3.1.2"
+            "nodeId": "minimatch@3.0.0"
           },
           {
-            "nodeId": "once@1.4.0"
+            "nodeId": "once@1.3.3"
           },
           {
-            "nodeId": "path-is-absolute@1.0.1"
+            "nodeId": "path-is-absolute@1.0.0"
           }
         ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "inflight@1.0.5",
+        "pkgId": "inflight@1.0.5",
+        "deps": [
+          {
+            "nodeId": "once@1.3.3"
+          },
+          {
+            "nodeId": "wrappy@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "once@1.3.3",
+        "pkgId": "once@1.3.3",
+        "deps": [
+          {
+            "nodeId": "wrappy@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.1",
+        "pkgId": "inherits@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "minimatch@3.0.0",
+        "pkgId": "minimatch@3.0.0",
+        "deps": [
+          {
+            "nodeId": "brace-expansion@1.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "brace-expansion@1.1.4",
+        "pkgId": "brace-expansion@1.1.4",
+        "deps": [
+          {
+            "nodeId": "balanced-match@0.4.1"
+          },
+          {
+            "nodeId": "concat-map@0.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "balanced-match@0.4.1",
+        "pkgId": "balanced-match@0.4.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "path-is-absolute@1.0.0",
+        "pkgId": "path-is-absolute@1.0.0",
+        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"
@@ -5801,46 +6635,46 @@
         "pkgId": "istanbul@0.4.3",
         "deps": [
           {
-            "nodeId": "abbrev@1.1.1"
+            "nodeId": "abbrev@1.0.7"
           },
           {
-            "nodeId": "async@0.9.0"
+            "nodeId": "async@1.5.2"
           },
           {
-            "nodeId": "node_modules/escodegen"
+            "nodeId": "escodegen@1.8.0"
           },
           {
-            "nodeId": "esprima@2.7.3"
+            "nodeId": "esprima@2.7.2"
           },
           {
-            "nodeId": "node_modules/fileset"
+            "nodeId": "fileset@0.2.1"
           },
           {
-            "nodeId": "node_modules/handlebars"
+            "nodeId": "handlebars@4.0.5"
           },
           {
-            "nodeId": "js-yaml@4.0.0"
+            "nodeId": "js-yaml@3.6.1"
           },
           {
-            "nodeId": "mkdirp@0.3.5"
+            "nodeId": "mkdirp@0.5.1"
           },
           {
-            "nodeId": "nopt@2.2.1"
+            "nodeId": "nopt@3.0.6"
           },
           {
-            "nodeId": "once@1.4.0"
+            "nodeId": "once@1.3.3"
           },
           {
-            "nodeId": "resolve@1.22.1"
+            "nodeId": "resolve@1.1.7"
           },
           {
-            "nodeId": "supports-color@1.3.1"
+            "nodeId": "supports-color@3.1.2"
           },
           {
-            "nodeId": "which@1.3.1"
+            "nodeId": "which@1.2.10"
           },
           {
-            "nodeId": "node_modules/wordwrap"
+            "nodeId": "wordwrap@1.0.0"
           }
         ],
         "info": {
@@ -5850,50 +6684,43 @@
         }
       },
       {
-        "nodeId": "node_modules/escodegen",
-        "pkgId": "escodegen@1.8.x",
+        "nodeId": "abbrev@1.0.7",
+        "pkgId": "abbrev@1.0.7",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/fileset",
-        "pkgId": "fileset@0.2.x",
+        "nodeId": "async@1.5.2",
+        "pkgId": "async@1.5.2",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/handlebars",
-        "pkgId": "handlebars@^4.0.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "resolve@1.22.1",
-        "pkgId": "resolve@1.22.1",
+        "nodeId": "escodegen@1.8.0",
+        "pkgId": "escodegen@1.8.0",
         "deps": [
           {
-            "nodeId": "is-core-module@2.11.0"
+            "nodeId": "esprima@2.7.2"
           },
           {
-            "nodeId": "path-parse@1.0.7"
+            "nodeId": "estraverse@1.9.3"
           },
           {
-            "nodeId": "supports-preserve-symlinks-flag@1.0.0"
+            "nodeId": "esutils@2.0.2"
+          },
+          {
+            "nodeId": "optionator@0.8.1"
+          },
+          {
+            "nodeId": "source-map@0.2.0"
           }
         ],
         "info": {
@@ -5903,11 +6730,56 @@
         }
       },
       {
-        "nodeId": "is-core-module@2.11.0",
-        "pkgId": "is-core-module@2.11.0",
+        "nodeId": "esprima@2.7.2",
+        "pkgId": "esprima@2.7.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "estraverse@1.9.3",
+        "pkgId": "estraverse@1.9.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "esutils@2.0.2",
+        "pkgId": "esutils@2.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "optionator@0.8.1",
+        "pkgId": "optionator@0.8.1",
         "deps": [
           {
-            "nodeId": "has@1.0.3"
+            "nodeId": "deep-is@0.1.3"
+          },
+          {
+            "nodeId": "fast-levenshtein@1.1.3"
+          },
+          {
+            "nodeId": "levn@0.3.0"
+          },
+          {
+            "nodeId": "prelude-ls@1.1.2"
+          },
+          {
+            "nodeId": "type-check@0.3.2"
+          },
+          {
+            "nodeId": "wordwrap@1.0.0"
           }
         ],
         "info": {
@@ -5917,11 +6789,34 @@
         }
       },
       {
-        "nodeId": "has@1.0.3",
-        "pkgId": "has@1.0.3",
+        "nodeId": "deep-is@0.1.3",
+        "pkgId": "deep-is@0.1.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fast-levenshtein@1.1.3",
+        "pkgId": "fast-levenshtein@1.1.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "levn@0.3.0",
+        "pkgId": "levn@0.3.0",
         "deps": [
           {
-            "nodeId": "function-bind@1.1.1"
+            "nodeId": "prelude-ls@1.1.2"
+          },
+          {
+            "nodeId": "type-check@0.3.2"
           }
         ],
         "info": {
@@ -5931,8 +6826,8 @@
         }
       },
       {
-        "nodeId": "function-bind@1.1.1",
-        "pkgId": "function-bind@1.1.1",
+        "nodeId": "prelude-ls@1.1.2",
+        "pkgId": "prelude-ls@1.1.2",
         "deps": [],
         "info": {
           "labels": {
@@ -5941,52 +6836,11 @@
         }
       },
       {
-        "nodeId": "path-parse@1.0.7",
-        "pkgId": "path-parse@1.0.7",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "supports-preserve-symlinks-flag@1.0.0",
-        "pkgId": "supports-preserve-symlinks-flag@1.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "supports-color@1.3.1",
-        "pkgId": "supports-color@1.3.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/wordwrap",
-        "pkgId": "wordwrap@^1.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "md5-hex@1.3.0",
-        "pkgId": "md5-hex@1.3.0",
+        "nodeId": "type-check@0.3.2",
+        "pkgId": "type-check@0.3.2",
         "deps": [
           {
-            "nodeId": "node_modules/md5-o-matic"
+            "nodeId": "prelude-ls@1.1.2"
           }
         ],
         "info": {
@@ -5996,13 +6850,456 @@
         }
       },
       {
-        "nodeId": "node_modules/md5-o-matic",
-        "pkgId": "md5-o-matic@^0.1.1",
+        "nodeId": "wordwrap@1.0.0",
+        "pkgId": "wordwrap@1.0.0",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "source-map@0.2.0",
+        "pkgId": "source-map@0.2.0",
+        "deps": [
+          {
+            "nodeId": "amdefine@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "amdefine@1.0.0",
+        "pkgId": "amdefine@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fileset@0.2.1",
+        "pkgId": "fileset@0.2.1",
+        "deps": [
+          {
+            "nodeId": "glob@5.0.15"
+          },
+          {
+            "nodeId": "minimatch@2.0.10"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "glob@5.0.15",
+        "pkgId": "glob@5.0.15",
+        "deps": [
+          {
+            "nodeId": "inflight@1.0.5"
+          },
+          {
+            "nodeId": "inherits@2.0.1"
+          },
+          {
+            "nodeId": "minimatch@2.0.10"
+          },
+          {
+            "nodeId": "once@1.3.3"
+          },
+          {
+            "nodeId": "path-is-absolute@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "minimatch@2.0.10",
+        "pkgId": "minimatch@2.0.10",
+        "deps": [
+          {
+            "nodeId": "brace-expansion@1.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "handlebars@4.0.5",
+        "pkgId": "handlebars@4.0.5",
+        "deps": [
+          {
+            "nodeId": "async@1.5.2"
+          },
+          {
+            "nodeId": "optimist@0.6.1"
+          },
+          {
+            "nodeId": "source-map@0.4.4"
+          },
+          {
+            "nodeId": "uglify-js@2.6.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "optimist@0.6.1",
+        "pkgId": "optimist@0.6.1",
+        "deps": [
+          {
+            "nodeId": "minimist@0.0.10"
+          },
+          {
+            "nodeId": "wordwrap@0.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "minimist@0.0.10",
+        "pkgId": "minimist@0.0.10",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wordwrap@0.0.3",
+        "pkgId": "wordwrap@0.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "source-map@0.4.4",
+        "pkgId": "source-map@0.4.4",
+        "deps": [
+          {
+            "nodeId": "amdefine@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "uglify-js@2.6.2",
+        "pkgId": "uglify-js@2.6.2",
+        "deps": [
+          {
+            "nodeId": "async@0.2.10"
+          },
+          {
+            "nodeId": "source-map@0.5.6"
+          },
+          {
+            "nodeId": "uglify-to-browserify@1.0.2"
+          },
+          {
+            "nodeId": "yargs@3.10.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "async@0.2.10",
+        "pkgId": "async@0.2.10",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "source-map@0.5.6",
+        "pkgId": "source-map@0.5.6",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "uglify-to-browserify@1.0.2",
+        "pkgId": "uglify-to-browserify@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "yargs@3.10.0",
+        "pkgId": "yargs@3.10.0",
+        "deps": [
+          {
+            "nodeId": "camelcase@1.2.1"
+          },
+          {
+            "nodeId": "cliui@2.1.0"
+          },
+          {
+            "nodeId": "decamelize@1.2.0"
+          },
+          {
+            "nodeId": "window-size@0.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "camelcase@1.2.1",
+        "pkgId": "camelcase@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cliui@2.1.0",
+        "pkgId": "cliui@2.1.0",
+        "deps": [
+          {
+            "nodeId": "center-align@0.1.3"
+          },
+          {
+            "nodeId": "right-align@0.1.3"
+          },
+          {
+            "nodeId": "wordwrap@0.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "center-align@0.1.3",
+        "pkgId": "center-align@0.1.3",
+        "deps": [
+          {
+            "nodeId": "align-text@0.1.4"
+          },
+          {
+            "nodeId": "lazy-cache@1.0.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "align-text@0.1.4",
+        "pkgId": "align-text@0.1.4",
+        "deps": [
+          {
+            "nodeId": "kind-of@3.0.3"
+          },
+          {
+            "nodeId": "longest@1.0.1"
+          },
+          {
+            "nodeId": "repeat-string@1.5.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "kind-of@3.0.3",
+        "pkgId": "kind-of@3.0.3",
+        "deps": [
+          {
+            "nodeId": "is-buffer@1.1.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-buffer@1.1.3",
+        "pkgId": "is-buffer@1.1.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "longest@1.0.1",
+        "pkgId": "longest@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "repeat-string@1.5.4",
+        "pkgId": "repeat-string@1.5.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lazy-cache@1.0.4",
+        "pkgId": "lazy-cache@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "right-align@0.1.3",
+        "pkgId": "right-align@0.1.3",
+        "deps": [
+          {
+            "nodeId": "align-text@0.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wordwrap@0.0.2",
+        "pkgId": "wordwrap@0.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "decamelize@1.2.0",
+        "pkgId": "decamelize@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "window-size@0.1.0",
+        "pkgId": "window-size@0.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "nopt@3.0.6",
+        "pkgId": "nopt@3.0.6",
+        "deps": [
+          {
+            "nodeId": "abbrev@1.0.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "resolve@1.1.7",
+        "pkgId": "resolve@1.1.7",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "supports-color@3.1.2",
+        "pkgId": "supports-color@3.1.2",
+        "deps": [
+          {
+            "nodeId": "has-flag@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-flag@1.0.0",
+        "pkgId": "has-flag@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
           }
         }
       },
@@ -6011,43 +7308,43 @@
         "pkgId": "micromatch@2.3.8",
         "deps": [
           {
-            "nodeId": "node_modules/arr-diff"
+            "nodeId": "arr-diff@2.0.0"
           },
           {
-            "nodeId": "node_modules/array-unique"
+            "nodeId": "array-unique@0.2.1"
           },
           {
-            "nodeId": "node_modules/braces"
+            "nodeId": "braces@1.8.5"
           },
           {
-            "nodeId": "node_modules/expand-brackets"
+            "nodeId": "expand-brackets@0.1.5"
           },
           {
-            "nodeId": "node_modules/extglob"
+            "nodeId": "extglob@0.3.2"
           },
           {
-            "nodeId": "node_modules/filename-regex"
+            "nodeId": "filename-regex@2.0.0"
           },
           {
-            "nodeId": "node_modules/is-extglob"
+            "nodeId": "is-extglob@1.0.0"
           },
           {
-            "nodeId": "node_modules/is-glob"
+            "nodeId": "is-glob@2.0.1"
           },
           {
-            "nodeId": "node_modules/kind-of"
+            "nodeId": "kind-of@3.0.3"
           },
           {
-            "nodeId": "node_modules/normalize-path"
+            "nodeId": "normalize-path@2.0.1"
           },
           {
-            "nodeId": "node_modules/object.omit"
+            "nodeId": "object.omit@2.0.0"
           },
           {
-            "nodeId": "node_modules/parse-glob"
+            "nodeId": "parse-glob@3.0.4"
           },
           {
-            "nodeId": "node_modules/regex-cache"
+            "nodeId": "regex-cache@0.4.3"
           }
         ],
         "info": {
@@ -6057,154 +7354,11 @@
         }
       },
       {
-        "nodeId": "node_modules/arr-diff",
-        "pkgId": "arr-diff@^2.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/array-unique",
-        "pkgId": "array-unique@^0.2.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/braces",
-        "pkgId": "braces@^1.8.2",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/expand-brackets",
-        "pkgId": "expand-brackets@^0.1.4",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/extglob",
-        "pkgId": "extglob@^0.3.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/filename-regex",
-        "pkgId": "filename-regex@^2.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/is-extglob",
-        "pkgId": "is-extglob@^1.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/is-glob",
-        "pkgId": "is-glob@^2.0.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/kind-of",
-        "pkgId": "kind-of@^3.0.2",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/normalize-path",
-        "pkgId": "normalize-path@^2.0.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/object.omit",
-        "pkgId": "object.omit@^2.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/parse-glob",
-        "pkgId": "parse-glob@^3.0.4",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/regex-cache",
-        "pkgId": "regex-cache@^0.4.2",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "mkdirp@0.5.1",
-        "pkgId": "mkdirp@0.5.1",
+        "nodeId": "arr-diff@2.0.0",
+        "pkgId": "arr-diff@2.0.0",
         "deps": [
           {
-            "nodeId": "minimist@1.2.7"
+            "nodeId": "arr-flatten@1.0.1"
           }
         ],
         "info": {
@@ -6214,8 +7368,381 @@
         }
       },
       {
-        "nodeId": "minimist@1.2.7",
-        "pkgId": "minimist@1.2.7",
+        "nodeId": "arr-flatten@1.0.1",
+        "pkgId": "arr-flatten@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "array-unique@0.2.1",
+        "pkgId": "array-unique@0.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "braces@1.8.5",
+        "pkgId": "braces@1.8.5",
+        "deps": [
+          {
+            "nodeId": "expand-range@1.8.2"
+          },
+          {
+            "nodeId": "preserve@0.2.0"
+          },
+          {
+            "nodeId": "repeat-element@1.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "expand-range@1.8.2",
+        "pkgId": "expand-range@1.8.2",
+        "deps": [
+          {
+            "nodeId": "fill-range@2.2.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fill-range@2.2.3",
+        "pkgId": "fill-range@2.2.3",
+        "deps": [
+          {
+            "nodeId": "is-number@2.1.0"
+          },
+          {
+            "nodeId": "isobject@2.1.0"
+          },
+          {
+            "nodeId": "randomatic@1.1.5"
+          },
+          {
+            "nodeId": "repeat-element@1.1.2"
+          },
+          {
+            "nodeId": "repeat-string@1.5.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-number@2.1.0",
+        "pkgId": "is-number@2.1.0",
+        "deps": [
+          {
+            "nodeId": "kind-of@3.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "isobject@2.1.0",
+        "pkgId": "isobject@2.1.0",
+        "deps": [
+          {
+            "nodeId": "isarray@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "randomatic@1.1.5",
+        "pkgId": "randomatic@1.1.5",
+        "deps": [
+          {
+            "nodeId": "is-number@2.1.0"
+          },
+          {
+            "nodeId": "kind-of@3.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "repeat-element@1.1.2",
+        "pkgId": "repeat-element@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "preserve@0.2.0",
+        "pkgId": "preserve@0.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "expand-brackets@0.1.5",
+        "pkgId": "expand-brackets@0.1.5",
+        "deps": [
+          {
+            "nodeId": "is-posix-bracket@0.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-posix-bracket@0.1.1",
+        "pkgId": "is-posix-bracket@0.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "extglob@0.3.2",
+        "pkgId": "extglob@0.3.2",
+        "deps": [
+          {
+            "nodeId": "is-extglob@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-extglob@1.0.0",
+        "pkgId": "is-extglob@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "filename-regex@2.0.0",
+        "pkgId": "filename-regex@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-glob@2.0.1",
+        "pkgId": "is-glob@2.0.1",
+        "deps": [
+          {
+            "nodeId": "is-extglob@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "normalize-path@2.0.1",
+        "pkgId": "normalize-path@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object.omit@2.0.0",
+        "pkgId": "object.omit@2.0.0",
+        "deps": [
+          {
+            "nodeId": "for-own@0.1.4"
+          },
+          {
+            "nodeId": "is-extendable@0.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "for-own@0.1.4",
+        "pkgId": "for-own@0.1.4",
+        "deps": [
+          {
+            "nodeId": "for-in@0.1.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "for-in@0.1.5",
+        "pkgId": "for-in@0.1.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-extendable@0.1.1",
+        "pkgId": "is-extendable@0.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "parse-glob@3.0.4",
+        "pkgId": "parse-glob@3.0.4",
+        "deps": [
+          {
+            "nodeId": "glob-base@0.3.0"
+          },
+          {
+            "nodeId": "is-dotfile@1.0.2"
+          },
+          {
+            "nodeId": "is-extglob@1.0.0"
+          },
+          {
+            "nodeId": "is-glob@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "glob-base@0.3.0",
+        "pkgId": "glob-base@0.3.0",
+        "deps": [
+          {
+            "nodeId": "glob-parent@2.0.0"
+          },
+          {
+            "nodeId": "is-glob@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "glob-parent@2.0.0",
+        "pkgId": "glob-parent@2.0.0",
+        "deps": [
+          {
+            "nodeId": "is-glob@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-dotfile@1.0.2",
+        "pkgId": "is-dotfile@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "regex-cache@0.4.3",
+        "pkgId": "regex-cache@0.4.3",
+        "deps": [
+          {
+            "nodeId": "is-equal-shallow@0.1.3"
+          },
+          {
+            "nodeId": "is-primitive@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-equal-shallow@0.1.3",
+        "pkgId": "is-equal-shallow@0.1.3",
+        "deps": [
+          {
+            "nodeId": "is-primitive@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-primitive@2.0.0",
+        "pkgId": "is-primitive@2.0.0",
         "deps": [],
         "info": {
           "labels": {
@@ -6228,23 +7755,12 @@
         "pkgId": "pkg-up@1.0.0",
         "deps": [
           {
-            "nodeId": "node_modules/find-up"
+            "nodeId": "find-up@1.1.2"
           }
         ],
         "info": {
           "labels": {
             "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "node_modules/find-up",
-        "pkgId": "find-up@^1.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
           }
         }
       },
@@ -6263,7 +7779,7 @@
         "pkgId": "rimraf@2.5.2",
         "deps": [
           {
-            "nodeId": "glob@7.2.3"
+            "nodeId": "glob@7.0.3"
           }
         ],
         "info": {
@@ -6283,36 +7799,26 @@
         }
       },
       {
-        "nodeId": "source-map@0.5.6",
-        "pkgId": "source-map@0.5.6",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
         "nodeId": "spawn-wrap@1.2.3",
         "pkgId": "spawn-wrap@1.2.3",
         "deps": [
           {
-            "nodeId": "foreground-child@1.5.6"
+            "nodeId": "foreground-child@1.5.1"
           },
           {
-            "nodeId": "mkdirp@0.3.5"
+            "nodeId": "mkdirp@0.5.1"
           },
           {
-            "nodeId": "node_modules/os-homedir"
+            "nodeId": "os-homedir@1.0.1"
           },
           {
-            "nodeId": "rimraf@2.7.1"
+            "nodeId": "rimraf@2.5.2"
           },
           {
             "nodeId": "signal-exit@2.1.2"
           },
           {
-            "nodeId": "which@1.3.1"
+            "nodeId": "which@1.2.10"
           }
         ],
         "info": {
@@ -6322,19 +7828,8 @@
         }
       },
       {
-        "nodeId": "node_modules/os-homedir",
-        "pkgId": "os-homedir@^1.0.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
-          }
-        }
-      },
-      {
-        "nodeId": "signal-exit@2.1.2",
-        "pkgId": "signal-exit@2.1.2",
+        "nodeId": "os-homedir@1.0.1",
+        "pkgId": "os-homedir@1.0.1",
         "deps": [],
         "info": {
           "labels": {
@@ -6347,19 +7842,19 @@
         "pkgId": "test-exclude@1.1.0",
         "deps": [
           {
-            "nodeId": "node_modules/arrify"
+            "nodeId": "arrify@1.0.1"
           },
           {
-            "nodeId": "node_modules/lodash.assign"
+            "nodeId": "lodash.assign@4.0.9"
           },
           {
-            "nodeId": "node_modules/micromatch"
+            "nodeId": "micromatch@2.3.8"
           },
           {
-            "nodeId": "node_modules/read-pkg-up"
+            "nodeId": "read-pkg-up@1.0.1"
           },
           {
-            "nodeId": "node_modules/require-main-filename"
+            "nodeId": "require-main-filename@1.0.1"
           }
         ],
         "info": {
@@ -6369,57 +7864,315 @@
         }
       },
       {
-        "nodeId": "node_modules/arrify",
-        "pkgId": "arrify@^1.0.1",
-        "deps": [],
+        "nodeId": "lodash.assign@4.0.9",
+        "pkgId": "lodash.assign@4.0.9",
+        "deps": [
+          {
+            "nodeId": "lodash.keys@4.0.7"
+          },
+          {
+            "nodeId": "lodash.rest@4.0.3"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/lodash.assign",
-        "pkgId": "lodash.assign@^4.0.9",
+        "nodeId": "lodash.keys@4.0.7",
+        "pkgId": "lodash.keys@4.0.7",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/micromatch",
-        "pkgId": "micromatch@^2.3.8",
+        "nodeId": "lodash.rest@4.0.3",
+        "pkgId": "lodash.rest@4.0.3",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/read-pkg-up",
-        "pkgId": "read-pkg-up@^1.0.1",
-        "deps": [],
+        "nodeId": "read-pkg-up@1.0.1",
+        "pkgId": "read-pkg-up@1.0.1",
+        "deps": [
+          {
+            "nodeId": "find-up@1.1.2"
+          },
+          {
+            "nodeId": "read-pkg@1.1.0"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/require-main-filename",
-        "pkgId": "require-main-filename@^1.0.1",
+        "nodeId": "read-pkg@1.1.0",
+        "pkgId": "read-pkg@1.1.0",
+        "deps": [
+          {
+            "nodeId": "load-json-file@1.1.0"
+          },
+          {
+            "nodeId": "normalize-package-data@2.3.5"
+          },
+          {
+            "nodeId": "path-type@1.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "load-json-file@1.1.0",
+        "pkgId": "load-json-file@1.1.0",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.1.4"
+          },
+          {
+            "nodeId": "parse-json@2.2.0"
+          },
+          {
+            "nodeId": "pify@2.3.0"
+          },
+          {
+            "nodeId": "pinkie-promise@2.0.1"
+          },
+          {
+            "nodeId": "strip-bom@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "parse-json@2.2.0",
+        "pkgId": "parse-json@2.2.0",
+        "deps": [
+          {
+            "nodeId": "error-ex@1.3.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "error-ex@1.3.0",
+        "pkgId": "error-ex@1.3.0",
+        "deps": [
+          {
+            "nodeId": "is-arrayish@0.2.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-arrayish@0.2.1",
+        "pkgId": "is-arrayish@0.2.1",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pify@2.3.0",
+        "pkgId": "pify@2.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "normalize-package-data@2.3.5",
+        "pkgId": "normalize-package-data@2.3.5",
+        "deps": [
+          {
+            "nodeId": "hosted-git-info@2.1.5"
+          },
+          {
+            "nodeId": "is-builtin-module@1.0.0"
+          },
+          {
+            "nodeId": "semver@5.1.0"
+          },
+          {
+            "nodeId": "validate-npm-package-license@3.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "hosted-git-info@2.1.5",
+        "pkgId": "hosted-git-info@2.1.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-builtin-module@1.0.0",
+        "pkgId": "is-builtin-module@1.0.0",
+        "deps": [
+          {
+            "nodeId": "builtin-modules@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "builtin-modules@1.1.1",
+        "pkgId": "builtin-modules@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "semver@5.1.0",
+        "pkgId": "semver@5.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "validate-npm-package-license@3.0.1",
+        "pkgId": "validate-npm-package-license@3.0.1",
+        "deps": [
+          {
+            "nodeId": "spdx-correct@1.0.2"
+          },
+          {
+            "nodeId": "spdx-expression-parse@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-correct@1.0.2",
+        "pkgId": "spdx-correct@1.0.2",
+        "deps": [
+          {
+            "nodeId": "spdx-license-ids@1.2.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-license-ids@1.2.1",
+        "pkgId": "spdx-license-ids@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-expression-parse@1.0.2",
+        "pkgId": "spdx-expression-parse@1.0.2",
+        "deps": [
+          {
+            "nodeId": "spdx-exceptions@1.0.4"
+          },
+          {
+            "nodeId": "spdx-license-ids@1.2.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-exceptions@1.0.4",
+        "pkgId": "spdx-exceptions@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "path-type@1.1.0",
+        "pkgId": "path-type@1.1.0",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.1.4"
+          },
+          {
+            "nodeId": "pify@2.3.0"
+          },
+          {
+            "nodeId": "pinkie-promise@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "require-main-filename@1.0.1",
+        "pkgId": "require-main-filename@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
           }
         }
       },
@@ -6428,43 +8181,43 @@
         "pkgId": "yargs@4.7.1",
         "deps": [
           {
-            "nodeId": "node_modules/camelcase"
+            "nodeId": "camelcase@3.0.0"
           },
           {
-            "nodeId": "node_modules/cliui"
+            "nodeId": "cliui@3.2.0"
           },
           {
-            "nodeId": "node_modules/decamelize"
+            "nodeId": "decamelize@1.2.0"
           },
           {
-            "nodeId": "node_modules/lodash.assign"
+            "nodeId": "lodash.assign@4.0.9"
           },
           {
-            "nodeId": "node_modules/os-locale"
+            "nodeId": "os-locale@1.4.0"
           },
           {
-            "nodeId": "node_modules/pkg-conf"
+            "nodeId": "pkg-conf@1.1.3"
           },
           {
-            "nodeId": "node_modules/read-pkg-up"
+            "nodeId": "read-pkg-up@1.0.1"
           },
           {
-            "nodeId": "node_modules/require-main-filename"
+            "nodeId": "require-main-filename@1.0.1"
           },
           {
-            "nodeId": "node_modules/set-blocking"
+            "nodeId": "set-blocking@1.0.0"
           },
           {
-            "nodeId": "node_modules/string-width"
+            "nodeId": "string-width@1.0.1"
           },
           {
-            "nodeId": "node_modules/window-size"
+            "nodeId": "window-size@0.2.0"
           },
           {
-            "nodeId": "node_modules/y18n"
+            "nodeId": "y18n@3.2.1"
           },
           {
-            "nodeId": "node_modules/yargs-parser"
+            "nodeId": "yargs-parser@2.4.0"
           }
         ],
         "info": {
@@ -6474,112 +8227,242 @@
         }
       },
       {
-        "nodeId": "node_modules/camelcase",
-        "pkgId": "camelcase@^3.0.0",
+        "nodeId": "camelcase@3.0.0",
+        "pkgId": "camelcase@3.0.0",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/cliui",
-        "pkgId": "cliui@^3.2.0",
-        "deps": [],
+        "nodeId": "cliui@3.2.0",
+        "pkgId": "cliui@3.2.0",
+        "deps": [
+          {
+            "nodeId": "string-width@1.0.1"
+          },
+          {
+            "nodeId": "strip-ansi@3.0.1"
+          },
+          {
+            "nodeId": "wrap-ansi@2.0.0"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/decamelize",
-        "pkgId": "decamelize@^1.1.1",
-        "deps": [],
+        "nodeId": "string-width@1.0.1",
+        "pkgId": "string-width@1.0.1",
+        "deps": [
+          {
+            "nodeId": "code-point-at@1.0.0"
+          },
+          {
+            "nodeId": "is-fullwidth-code-point@1.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@3.0.1"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/os-locale",
-        "pkgId": "os-locale@^1.4.0",
-        "deps": [],
+        "nodeId": "code-point-at@1.0.0",
+        "pkgId": "code-point-at@1.0.0",
+        "deps": [
+          {
+            "nodeId": "number-is-nan@1.0.0"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/pkg-conf",
-        "pkgId": "pkg-conf@^1.1.2",
+        "nodeId": "number-is-nan@1.0.0",
+        "pkgId": "number-is-nan@1.0.0",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/set-blocking",
-        "pkgId": "set-blocking@^1.0.0",
-        "deps": [],
+        "nodeId": "is-fullwidth-code-point@1.0.0",
+        "pkgId": "is-fullwidth-code-point@1.0.0",
+        "deps": [
+          {
+            "nodeId": "number-is-nan@1.0.0"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/string-width",
-        "pkgId": "string-width@^1.0.1",
-        "deps": [],
+        "nodeId": "wrap-ansi@2.0.0",
+        "pkgId": "wrap-ansi@2.0.0",
+        "deps": [
+          {
+            "nodeId": "string-width@1.0.1"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/window-size",
-        "pkgId": "window-size@^0.2.0",
-        "deps": [],
+        "nodeId": "os-locale@1.4.0",
+        "pkgId": "os-locale@1.4.0",
+        "deps": [
+          {
+            "nodeId": "lcid@1.0.0"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/y18n",
-        "pkgId": "y18n@^3.2.1",
-        "deps": [],
+        "nodeId": "lcid@1.0.0",
+        "pkgId": "lcid@1.0.0",
+        "deps": [
+          {
+            "nodeId": "invert-kv@1.0.0"
+          }
+        ],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
           }
         }
       },
       {
-        "nodeId": "node_modules/yargs-parser",
-        "pkgId": "yargs-parser@^2.4.0",
+        "nodeId": "invert-kv@1.0.0",
+        "pkgId": "invert-kv@1.0.0",
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod",
-            "missingLockFileEntry": "true"
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pkg-conf@1.1.3",
+        "pkgId": "pkg-conf@1.1.3",
+        "deps": [
+          {
+            "nodeId": "find-up@1.1.2"
+          },
+          {
+            "nodeId": "load-json-file@1.1.0"
+          },
+          {
+            "nodeId": "object-assign@4.1.0"
+          },
+          {
+            "nodeId": "symbol@0.2.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object-assign@4.1.0",
+        "pkgId": "object-assign@4.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "symbol@0.2.3",
+        "pkgId": "symbol@0.2.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "set-blocking@1.0.0",
+        "pkgId": "set-blocking@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "window-size@0.2.0",
+        "pkgId": "window-size@0.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "y18n@3.2.1",
+        "pkgId": "y18n@3.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "yargs-parser@2.4.0",
+        "pkgId": "yargs-parser@2.4.0",
+        "deps": [
+          {
+            "nodeId": "camelcase@2.1.1"
+          },
+          {
+            "nodeId": "lodash.assign@4.0.9"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "camelcase@2.1.1",
+        "pkgId": "camelcase@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
           }
         }
       },
@@ -6658,6 +8541,16 @@
       {
         "nodeId": "stack-utils@0.4.0",
         "pkgId": "stack-utils@0.4.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "supports-color@1.3.1",
+        "pkgId": "supports-color@1.3.1",
         "deps": [],
         "info": {
           "labels": {


### PR DESCRIPTION
This adds support for bundled dependencies inside of npm-lock-v2 projects. Previously these would be flagged as missing in lockfile.