### PR TITLE
fix: npm version parse test & enable logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,26 @@ workflows:
             branches:
               ignore:
                 - master
+      - test-windows:
+          name: Windows Tests for Node v12 support
+          context: nodejs-install
+          node_version: "12.22.12"
+          requires:
+            - Lint
+          filters:
+            branches:
+              ignore:
+                - master
+      - test-unix:
+          name: Unix Tests for Node v12 support
+          context: nodejs-install
+          node_version: "12.22.12"
+          requires:
+            - Lint
+          filters:
+            branches:
+              ignore:
+                - master
       - release:
           name: Release
           context: nodejs-app-release

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,8 @@
 import { readFileSync } from 'fs';
 import { InvalidUserInputError } from './errors';
+import * as baseDebug from 'debug';
+
+const debug = baseDebug('snyk-nodejs-parser');
 
 export enum NodeLockfileVersion {
   NpmLockV1 = 'NPM_LOCK_V1',
@@ -43,6 +46,7 @@ export function getNpmLockfileVersion(
   | NodeLockfileVersion.NpmLockV3 {
   try {
     const lockfileJson = JSON.parse(lockFileContents);
+
     const lockfileVersion: number | null = lockfileJson.lockfileVersion || null;
 
     switch (lockfileVersion) {
@@ -60,6 +64,7 @@ export function getNpmLockfileVersion(
         );
     }
   } catch (e) {
+    debug('Failed to parse lockfile version: ', e);
     throw new InvalidUserInputError(
       `Problem parsing package-lock.json - make sure the package-lock.json is a valid JSON file`,
     );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,5 @@
 import { readFileSync } from 'fs';
 import { InvalidUserInputError } from './errors';
-import * as baseDebug from 'debug';
-
-const debug = baseDebug('snyk-nodejs-parser');
 
 export enum NodeLockfileVersion {
   NpmLockV1 = 'NPM_LOCK_V1',
@@ -46,7 +43,6 @@ export function getNpmLockfileVersion(
   | NodeLockfileVersion.NpmLockV3 {
   try {
     const lockfileJson = JSON.parse(lockFileContents);
-
     const lockfileVersion: number | null = lockfileJson.lockfileVersion || null;
 
     switch (lockfileVersion) {
@@ -64,7 +60,6 @@ export function getNpmLockfileVersion(
         );
     }
   } catch (e) {
-    debug('Failed to parse lockfile version: ', e);
     throw new InvalidUserInputError(
       `Problem parsing package-lock.json - make sure the package-lock.json is a valid JSON file`,
     );

--- a/test/fixtures/bare-npm/package-lock.json
+++ b/test/fixtures/bare-npm/package-lock.json
@@ -1,0 +1,5 @@
+{
+    "name": "Example",
+    "version": "1.0.0",
+    "lockfileVersion": 1
+}

--- a/test/fixtures/bare-npm/package-lock.json
+++ b/test/fixtures/bare-npm/package-lock.json
@@ -1,5 +1,12 @@
 {
-    "name": "Example",
-    "version": "1.0.0",
-    "lockfileVersion": 1
+  "name": "bare-npm",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bare-npm",
+      "version": "1.0.0"
+    }
+  }
 }

--- a/test/fixtures/bare-npm/package.json
+++ b/test/fixtures/bare-npm/package.json
@@ -1,13 +1,4 @@
 {
-    "name": "Example",
-    "version": "1.0.0",
-    "lockfileVersion": 2,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "Example",
-            "version": "1.0.0"
-        }
-    }
+  "name": "bare-npm",
+  "version": "1.0.0"
 }
-

--- a/test/fixtures/bare-npm/package.json
+++ b/test/fixtures/bare-npm/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "Example",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "Example",
+            "version": "1.0.0"
+        }
+    }
+}
+

--- a/test/jest/__snapshots__/get-lockfile-version.test.ts.snap
+++ b/test/jest/__snapshots__/get-lockfile-version.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getLockfileVersionFromFile npm 1`] = `"NPM_LOCK_V1"`;
+exports[`getLockfileVersionFromFile npm 1`] = `"NPM_LOCK_V2"`;

--- a/test/jest/__snapshots__/get-lockfile-version.test.ts.snap
+++ b/test/jest/__snapshots__/get-lockfile-version.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getLockfileVersionFromFile npm 1`] = `"NPM_LOCK_V1"`;

--- a/test/jest/get-lockfile-version.test.ts
+++ b/test/jest/get-lockfile-version.test.ts
@@ -1,0 +1,10 @@
+import { getLockfileVersionFromFile } from '../../lib/utils';
+
+describe('getLockfileVersionFromFile', () => {
+  it('npm', () => {
+    const result = getLockfileVersionFromFile(
+      `${__dirname}/../fixtures/bare-npm/package-lock.json`,
+    );
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does
Log the full error in debug mode when we fail to grab the lockfile version
Add a test for the parsong function to show it works as expected on Node 12
Enable tests on Node 12 as CLI still supports Node 12

![CleanShot 2023-02-20 at 18 59 15@2x](https://user-images.githubusercontent.com/2911613/220182173-3995af1b-2659-4083-8614-ed7a150b567d.png)
