### PR TITLE
fix: quick fix for pkgs not existing

### DIFF
--- a/lib/dep-graph-builders/npm-lock-v2/index.ts
+++ b/lib/dep-graph-builders/npm-lock-v2/index.ts
@@ -166,7 +166,7 @@ const getChildNode = (
 ) => {
   let childNodeKey = getChildNodeKey(name, ancestry, pkgs, pkgKeysByName); //
 
-  if (!childNodeKey) {
+  if (!childNodeKey || !pkgs[childNodeKey]) {
     if (strictOutOfSync) {
       throw new OutOfSyncError(`${name}@${depInfo.version}`, LockfileType.npm);
     } else {


### PR DESCRIPTION
There is a situation where we may not get a working child key, until we fix our key getting functionality this should stop errors. 