### PR TITLE
feat: async-ify all the depgraph builder functions

### DIFF
--- a/lib/c-map.ts
+++ b/lib/c-map.ts
@@ -1,0 +1,27 @@
+import * as pMap from 'p-map';
+import { eventLoopSpinner } from 'event-loop-spinner';
+
+/** Run a function each element in an array, with some level of concurrency.
+ *
+ * Defaults to a small, finite concurrency, so as to not to "overload" the database
+ * connection pool or the http client, both of which have small, internal limits.
+ *
+ * Can be used with async functions that don't yield; will yield for you, if necessary.
+ */
+export async function cMap<F, T>(
+  input: Iterable<F>,
+  mapper: (from: F) => Promise<T>,
+  options?: { concurrency: number },
+): Promise<T[]> {
+  const concurrency = options?.concurrency ?? 6;
+  return await pMap(
+    input,
+    async (from) => {
+      if (eventLoopSpinner.isStarving()) {
+        await eventLoopSpinner.spin();
+      }
+      return await mapper(from);
+    },
+    { concurrency },
+  );
+}

--- a/lib/dep-graph-builders/yarn-lock-v1/simple.ts
+++ b/lib/dep-graph-builders/yarn-lock-v1/simple.ts
@@ -18,12 +18,12 @@ export const parseYarnLockV1Project = async (
   const pkgJson: PackageJsonBase = parsePkgJson(pkgJsonContent);
 
   const depGraph = pruneCycles
-    ? buildDepGraphYarnLockV1SimpleCyclesPruned(pkgs, pkgJson, {
+    ? await buildDepGraphYarnLockV1SimpleCyclesPruned(pkgs, pkgJson, {
         includeDevDeps,
         strictOutOfSync,
         includeOptionalDeps,
       })
-    : buildDepGraphYarnLockV1Simple(pkgs, pkgJson, {
+    : await buildDepGraphYarnLockV1Simple(pkgs, pkgJson, {
         includeDevDeps,
         strictOutOfSync,
         includeOptionalDeps,

--- a/lib/dep-graph-builders/yarn-lock-v1/workspaces.ts
+++ b/lib/dep-graph-builders/yarn-lock-v1/workspaces.ts
@@ -5,6 +5,7 @@ import { buildDepGraphYarnLockV1Workspace } from './build-depgraph-workspace-pac
 import { extractPkgsFromYarnLockV1 } from './extract-yarnlock-v1-pkgs';
 import { parsePkgJson } from '../util';
 import { ProjectParseOptions } from '../types';
+import { cMap } from '../../c-map';
 
 export const parseYarnLockV1WorkspaceProject = async (
   yarnLockContent: string,
@@ -26,9 +27,9 @@ export const parseYarnLockV1WorkspaceProject = async (
     },
   );
 
-  const depGraphs = parsedWorkspacePkgJsons.map((parsedPkgJson) => {
+  const depGraphs = cMap(parsedWorkspacePkgJsons, async (parsedPkgJson) => {
     return pruneCycles
-      ? buildDepGraphYarnLockV1WorkspaceCyclesPruned(
+      ? await buildDepGraphYarnLockV1WorkspaceCyclesPruned(
           extractedYarnLockV1Pkgs,
           parsedPkgJson,
           workspacePkgNameToVersion,
@@ -38,7 +39,7 @@ export const parseYarnLockV1WorkspaceProject = async (
             includeOptionalDeps,
           },
         )
-      : buildDepGraphYarnLockV1Workspace(
+      : await buildDepGraphYarnLockV1Workspace(
           extractedYarnLockV1Pkgs,
           parsedPkgJson,
           workspacePkgNameToVersion,

--- a/lib/dep-graph-builders/yarn-lock-v2/build-depgraph-simple.ts
+++ b/lib/dep-graph-builders/yarn-lock-v2/build-depgraph-simple.ts
@@ -3,8 +3,9 @@ import { addPkgNodeToGraph, getTopLevelDeps, PkgNode } from '../util';
 import type { DepGraphBuildOptions } from '../types';
 import type { NormalisedPkgs, PackageJsonBase } from '../types';
 import { getYarnLockV2ChildNode } from './utils';
+import { eventLoopSpinner } from 'event-loop-spinner';
 
-export const buildDepGraphYarnLockV2Simple = (
+export const buildDepGraphYarnLockV2Simple = async (
   extractedYarnLockV2Pkgs: NormalisedPkgs,
   pkgJson: PackageJsonBase,
   options: DepGraphBuildOptions,
@@ -30,7 +31,7 @@ export const buildDepGraphYarnLockV2Simple = (
     isDev: false,
   };
 
-  dfsVisit(
+  await dfsVisit(
     depGraphBuilder,
     rootNode,
     visitedMap,
@@ -49,7 +50,7 @@ export const buildDepGraphYarnLockV2Simple = (
  *  - If a node doesn't exist in the map, it means it hasn't been visited.
  *  - If a node is already visited, simply connect the new node with this node.
  */
-const dfsVisit = (
+const dfsVisit = async (
   depGraphBuilder: DepGraphBuilder,
   node: PkgNode,
   visitedMap: Set<string>,
@@ -57,10 +58,14 @@ const dfsVisit = (
   strictOutOfSync: boolean,
   includeOptionalDeps: boolean,
   resolutions: Record<string, string>,
-): void => {
+): Promise<void> => {
   visitedMap.add(node.id);
 
   for (const [name, depInfo] of Object.entries(node.dependencies || {})) {
+    if (eventLoopSpinner.isStarving()) {
+      await eventLoopSpinner.spin();
+    }
+
     const childNode = getYarnLockV2ChildNode(
       name,
       depInfo,
@@ -73,7 +78,7 @@ const dfsVisit = (
 
     if (!visitedMap.has(childNode.id)) {
       addPkgNodeToGraph(depGraphBuilder, childNode, {});
-      dfsVisit(
+      await dfsVisit(
         depGraphBuilder,
         childNode,
         visitedMap,

--- a/lib/dep-graph-builders/yarn-lock-v2/simple.ts
+++ b/lib/dep-graph-builders/yarn-lock-v2/simple.ts
@@ -2,19 +2,20 @@ import { extractPkgsFromYarnLockV2 } from './extract-yarnlock-v2-pkgs';
 import { parsePkgJson } from '../util';
 import { PackageJsonBase, ProjectParseOptions } from '../types';
 import { buildDepGraphYarnLockV2Simple } from './build-depgraph-simple';
+import { DepGraph } from '@snyk/dep-graph';
 
-export const parseYarnLockV2Project = (
+export const parseYarnLockV2Project = async (
   pkgJsonContent: string,
   yarnLockContent: string,
   options: ProjectParseOptions,
-) => {
+): Promise<DepGraph> => {
   const { includeDevDeps, includeOptionalDeps, strictOutOfSync } = options;
 
   const pkgs = extractPkgsFromYarnLockV2(yarnLockContent);
 
   const pkgJson: PackageJsonBase = parsePkgJson(pkgJsonContent);
 
-  const depgraph = buildDepGraphYarnLockV2Simple(pkgs, pkgJson, {
+  const depgraph = await buildDepGraphYarnLockV2Simple(pkgs, pkgJson, {
     includeDevDeps,
     strictOutOfSync,
     includeOptionalDeps,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "event-loop-spinner": "^2.0.0",
     "js-yaml": "^4.1.0",
     "lodash.clonedeep": "^4.5.0",
+    "p-map": "^4.0.0",
     "lodash.flatmap": "^4.5.0",
     "lodash.isempty": "^4.4.0",
     "lodash.topairs": "^4.3.0",

--- a/test/jest/dep-graph-builders/npm-lock-v2.test.ts
+++ b/test/jest/dep-graph-builders/npm-lock-v2.test.ts
@@ -29,7 +29,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
             'utf8',
           );
 
-          const newDepGraph = parseNpmLockV2Project(
+          const newDepGraph = await parseNpmLockV2Project(
             pkgJsonContent,
             pkgLockContent,
             {
@@ -71,7 +71,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
             'utf8',
           );
 
-          const newDepGraph = parseNpmLockV2Project(
+          const newDepGraph = await parseNpmLockV2Project(
             pkgJsonContent,
             pkgLockContent,
             {
@@ -111,7 +111,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
             'utf8',
           );
 
-          const newDepGraph = parseNpmLockV2Project(
+          const newDepGraph = await parseNpmLockV2Project(
             pkgJsonContent,
             pkgLockContent,
             {
@@ -151,7 +151,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
             'utf8',
           );
 
-          const newDepGraph = parseNpmLockV2Project(
+          const newDepGraph = await parseNpmLockV2Project(
             pkgJsonContent,
             pkgLockContent,
             {
@@ -196,7 +196,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
               'utf8',
             );
 
-            const newDepGraphDevDepsIncluded = parseNpmLockV2Project(
+            const newDepGraphDevDepsIncluded = await parseNpmLockV2Project(
               pkgJsonContent,
               npmLockContent,
               {
@@ -207,7 +207,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
               },
             );
 
-            const newDepGraphDevDepsExcluded = parseNpmLockV2Project(
+            const newDepGraphDevDepsExcluded = await parseNpmLockV2Project(
               pkgJsonContent,
               npmLockContent,
               {
@@ -267,7 +267,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
       );
       const npmLockContent = '';
       try {
-        parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
+        await parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
           includeDevDeps: false,
           includeOptionalDeps: true,
           pruneCycles: true,
@@ -278,34 +278,6 @@ describe('dep-graph-builder npm-lock-v2', () => {
           'package.json parsing failed with error Unexpected token } in JSON at position 100',
         );
         expect((err as Error).name).toBe('InvalidUserInputError');
-      }
-    });
-
-    it('project: simple-top-level-out-of-sync -> throws OutOfSyncError', async () => {
-      const fixtureName = 'missing-top-level-deps';
-      const pkgJsonContent = readFileSync(
-        join(__dirname, `./fixtures/npm-lock-v2/${fixtureName}/package.json`),
-        'utf8',
-      );
-      const npmLockContent = readFileSync(
-        join(
-          __dirname,
-          `./fixtures/npm-lock-v2/${fixtureName}/package-lock.json`,
-        ),
-        'utf8',
-      );
-      try {
-        parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
-          includeDevDeps: false,
-          includeOptionalDeps: true,
-          pruneCycles: true,
-          strictOutOfSync: true,
-        });
-      } catch (err) {
-        expect((err as Error).message).toBe(
-          'Dependency lodash@4.17.11 was not found in package-lock.json. Your package.json and package-lock.json are probably out of sync. Please run "npm install" and try again.',
-        );
-        expect((err as Error).name).toBe('OutOfSyncError');
       }
     });
 
@@ -323,7 +295,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
         'utf8',
       );
       try {
-        parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
+        await parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
           includeDevDeps: false,
           includeOptionalDeps: true,
           pruneCycles: true,
@@ -332,6 +304,34 @@ describe('dep-graph-builder npm-lock-v2', () => {
       } catch (err) {
         expect((err as Error).message).toBe(
           'Dependency ms@0.6.2 was not found in package-lock.json. Your package.json and package-lock.json are probably out of sync. Please run "npm install" and try again.',
+        );
+        expect((err as Error).name).toBe('OutOfSyncError');
+      }
+    });
+
+    it('project: simple-top-level-out-of-sync -> throws OutOfSyncError', async () => {
+      const fixtureName = 'missing-top-level-deps';
+      const pkgJsonContent = readFileSync(
+        join(__dirname, `./fixtures/npm-lock-v2/${fixtureName}/package.json`),
+        'utf8',
+      );
+      const npmLockContent = readFileSync(
+        join(
+          __dirname,
+          `./fixtures/npm-lock-v2/${fixtureName}/package-lock.json`,
+        ),
+        'utf8',
+      );
+      try {
+        await parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
+          includeDevDeps: false,
+          includeOptionalDeps: true,
+          pruneCycles: true,
+          strictOutOfSync: true,
+        });
+      } catch (err) {
+        expect((err as Error).message).toBe(
+          'Dependency lodash@4.17.11 was not found in package-lock.json. Your package.json and package-lock.json are probably out of sync. Please run "npm install" and try again.',
         );
         expect((err as Error).name).toBe('OutOfSyncError');
       }

--- a/test/jest/dep-graph-builders/yarn-lock-v2.test.ts
+++ b/test/jest/dep-graph-builders/yarn-lock-v2.test.ts
@@ -31,7 +31,7 @@ describe('dep-graph-builder yarn-lock-v1', () => {
             strictOutOfSync: false,
           };
 
-          const dg = parseYarnLockV2Project(
+          const dg = await parseYarnLockV2Project(
             pkgJsonContent,
             yarnLockContent,
             opts,


### PR DESCRIPTION
This adds the [event-loop-spinner](https://github.com/snyk/event-loop-spinner) to the dep graph builders to help prevent any event-loop-blocking by the synchronous loops within recursion currently in the newer pattern. 

This obviously changes the function apis slightly. 