### PR TITLE
feat: add pruning to dep graph generation of yarn projects by default

### DIFF
--- a/lib/dep-graph-builders/types.ts
+++ b/lib/dep-graph-builders/types.ts
@@ -34,5 +34,5 @@ export type LockFileParseOptions = {
 
 export type ProjectParseOptions = DepGraphBuildOptions &
   LockFileParseOptions & {
-    pruneCycles: boolean;
+    pruneCycles?: boolean;
   };

--- a/lib/dep-graph-builders/util.ts
+++ b/lib/dep-graph-builders/util.ts
@@ -22,6 +22,7 @@ export const addPkgNodeToGraph = (
   depGraphBuilder: DepGraphBuilder,
   node: PkgNode,
   options: {
+    prune?: boolean;
     isCyclic?: boolean;
     isWorkspacePkg?: boolean;
   },
@@ -33,6 +34,7 @@ export const addPkgNodeToGraph = (
       labels: {
         scope: node.isDev ? 'dev' : 'prod',
         ...(options.isCyclic && { pruned: 'cyclic' }),
+        ...(options.prune && { pruned: 'true' }),
         ...(options.isWorkspacePkg && { pruned: 'true' }),
         ...(node.missingLockFileEntry && { missingLockFileEntry: 'true' }),
       },

--- a/lib/dep-graph-builders/yarn-lock-v1/simple.ts
+++ b/lib/dep-graph-builders/yarn-lock-v1/simple.ts
@@ -1,7 +1,6 @@
 import { buildDepGraphYarnLockV1Simple } from '.';
 import { PackageJsonBase } from '../types';
 import { parsePkgJson } from '../util';
-import { buildDepGraphYarnLockV1SimpleCyclesPruned } from './build-depgraph-simple-pruned';
 import { extractPkgsFromYarnLockV1 } from './extract-yarnlock-v1-pkgs';
 import { ProjectParseOptions } from '../types';
 
@@ -10,24 +9,17 @@ export const parseYarnLockV1Project = async (
   yarnLockContent: string,
   options: ProjectParseOptions,
 ) => {
-  const { includeDevDeps, includeOptionalDeps, pruneCycles, strictOutOfSync } =
-    options;
+  const { includeDevDeps, includeOptionalDeps, strictOutOfSync } = options;
 
   const pkgs = extractPkgsFromYarnLockV1(yarnLockContent);
 
   const pkgJson: PackageJsonBase = parsePkgJson(pkgJsonContent);
 
-  const depGraph = pruneCycles
-    ? await buildDepGraphYarnLockV1SimpleCyclesPruned(pkgs, pkgJson, {
-        includeDevDeps,
-        strictOutOfSync,
-        includeOptionalDeps,
-      })
-    : await buildDepGraphYarnLockV1Simple(pkgs, pkgJson, {
-        includeDevDeps,
-        strictOutOfSync,
-        includeOptionalDeps,
-      });
+  const depGraph = await buildDepGraphYarnLockV1Simple(pkgs, pkgJson, {
+    includeDevDeps,
+    strictOutOfSync,
+    includeOptionalDeps,
+  });
 
   return depGraph;
 };


### PR DESCRIPTION
### What this does

This adds pruning to all dep graphs generated by Yarn projects with no opt out.

#### Notes
* This makes the pruned versions of yarn lock v1 depgraph generators redundant
* Pruning occurs only in the sub graph of a particular direct dep