### PR TITLE
fix: throw 'not implemented' error in buildDepTree for npm v2/v3 lockfiles

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -78,6 +78,7 @@ export enum Scope {
 export enum LockfileType {
   npm = 'npm',
   npm7 = 'npm7',
+  npm7v3 = 'npm7v3',
   yarn = 'yarn',
   yarn2 = 'yarn2',
 }

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -14,8 +14,8 @@ export interface PackageLock {
   name: string;
   version: string;
   dependencies?: PackageLockDeps;
-  lockfileVersion: 1 | 2;
-  type: LockfileType.npm | LockfileType.npm7;
+  lockfileVersion: 1 | 2 | 3;
+  type: LockfileType.npm | LockfileType.npm7 | LockfileType.npm7v3;
 }
 
 export interface PackageLockDeps {
@@ -78,6 +78,15 @@ export class PackageLockParser extends LockParserBase {
 
   protected getDepMap(lockfile: Lockfile): DepMap {
     const packageLock = lockfile as PackageLock;
+
+    if (packageLock.lockfileVersion == 2) {
+      throw new Error('not implemented: npm lockfile version 2');
+    }
+
+    if (packageLock.lockfileVersion == 3) {
+      throw new Error('not implemented: npm lockfile version 3');
+    }
+
     const depMap: DepMap = {};
 
     const flattenLockfileRec = (


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [ ] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [ ] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

throw `not implemented` error in `buildDepTree` for npm v2/v3 lockfiles

better than `OutOfSyncError` from `getDependencyTree`

```
OutOfSyncError: Dependency @cycle/http was not found in package-lock.json. Your package.json and package-lock.json are probably out of sync. Please run "npm install" and try again.
    at PackageLockParser.getDependencyTree (node_modules/snyk-nodejs-lockfile-parser/dist/parsers/lock-parser-base.js:124:27)
    at async PackageLockParser.getDependencyTree (node_modules/snyk-nodejs-lockfile-parser/dist/parsers/package-lock-parser.js:28:32)
  code: 422,
  dependencyName: '@cycle/http',
  lockFileType: 'npm7'
```

problem in `PackageLockParser.getDepMap`:
[packageLock.dependencies](https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json#dependencies) is undefined, it should use [packageLock.packages](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#packages)

https://github.com/snyk/nodejs-lockfile-parser/blob/103bb2de2e8391fab2b35c57e8c64b14e8205e3e/lib/parsers/package-lock-parser.ts#L110

so the `not implemented` error is thrown in `getDepMap` before calling `flattenLockfileRec`

to implement support for v2/v3 npm lockfiles, a good place would be `getDepMap`

```ts
  protected getDepMapV2(packageLock: PackageLock): DepMap {
    // TODO implement
  }

  protected getDepMap(lockfile: Lockfile): DepMap {
    const packageLock = lockfile as PackageLock;

    if (packageLock.lockfileVersion == 2) {
      return this.getDepMapV2(packageLock);
    }
```

### Notes for the reviewer

low priority
