### PR TITLE
fix: run all tests for npm lock v2

### DIFF
--- a/test/jest/dep-graph-builders/npm-lock-v2.test.ts
+++ b/test/jest/dep-graph-builders/npm-lock-v2.test.ts
@@ -340,7 +340,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
 });
 
 describe('bundledDependencies', () => {
-  fit('project: bundled-deps resolves dep-graph', async () => {
+  it('project: bundled-deps resolves dep-graph', async () => {
     const fixtureName = 'bundled-deps';
     const pkgJsonContent = readFileSync(
       join(__dirname, `./fixtures/npm-lock-v2/${fixtureName}/package.json`),


### PR DESCRIPTION
### What this does
Not all tests were being ran, this fixes it