### PR TITLE
fix: correctly pick npm-lock-v2 pkg version parsing lockfile

### DIFF
--- a/lib/dep-graph-builders/npm-lock-v2/index.ts
+++ b/lib/dep-graph-builders/npm-lock-v2/index.ts
@@ -331,16 +331,14 @@ export const getChildNodeKey = (
     return filteredCandidates[0];
   }
 
-  const ancestry_names = ancestry.map((el) => el.name).concat(name);
-  while (ancestry_names.length > 0) {
-    const possible_key = `node_modules/${ancestry_names.join(
-      '/node_modules/',
-    )}`;
+  const ancestryNames = ancestry.map((el) => el.name).concat(name);
+  while (ancestryNames.length > 0) {
+    const possibleKey = `node_modules/${ancestryNames.join('/node_modules/')}`;
 
-    if (pkgs[possible_key]) {
-      return possible_key;
+    if (filteredCandidates.includes(possibleKey)) {
+      return possibleKey;
     }
-    ancestry_names.shift();
+    ancestryNames.shift();
   }
 
   // Here we go through th eancestry backwards to find the nearest

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/bundled-deps/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/bundled-deps/expected.json
@@ -102,10 +102,10 @@
       }
     },
     {
-      "id": "tslib@2.6.0",
+      "id": "tslib@1.14.1",
       "info": {
         "name": "tslib",
-        "version": "2.6.0"
+        "version": "1.14.1"
       }
     },
     {
@@ -148,13 +148,6 @@
       "info": {
         "name": "lru_map",
         "version": "0.3.3"
-      }
-    },
-    {
-      "id": "tslib@1.14.1",
-      "info": {
-        "name": "tslib",
-        "version": "1.14.1"
       }
     },
     {
@@ -3868,6 +3861,13 @@
       }
     },
     {
+      "id": "tslib@2.6.0",
+      "info": {
+        "name": "tslib",
+        "version": "2.6.0"
+      }
+    },
+    {
       "id": "capital-case@1.0.4",
       "info": {
         "name": "capital-case",
@@ -4319,7 +4319,7 @@
             "nodeId": "@sentry/utils@7.17.4"
           },
           {
-            "nodeId": "tslib@2.6.0"
+            "nodeId": "tslib@1.14.1"
           }
         ],
         "info": {
@@ -4346,7 +4346,7 @@
             "nodeId": "@sentry/types@7.17.4"
           },
           {
-            "nodeId": "tslib@2.6.0"
+            "nodeId": "tslib@1.14.1"
           }
         ],
         "info": {
@@ -4356,8 +4356,8 @@
         }
       },
       {
-        "nodeId": "tslib@2.6.0",
-        "pkgId": "tslib@2.6.0",
+        "nodeId": "tslib@1.14.1",
+        "pkgId": "tslib@1.14.1",
         "deps": [],
         "info": {
           "labels": {
@@ -4433,16 +4433,6 @@
       {
         "nodeId": "lru_map@0.3.3",
         "pkgId": "lru_map@0.3.3",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "tslib@1.14.1",
-        "pkgId": "tslib@1.14.1",
         "deps": [],
         "info": {
           "labels": {
@@ -9918,7 +9908,7 @@
         "pkgId": "widest-line@4.0.1",
         "deps": [
           {
-            "nodeId": "string-width@4.2.3"
+            "nodeId": "string-width@5.1.2"
           }
         ],
         "info": {
@@ -12830,6 +12820,16 @@
             "nodeId": "tslib@2.6.0"
           }
         ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "tslib@2.6.0",
+        "pkgId": "tslib@2.6.0",
+        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/deeply-scoped/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/deeply-scoped/expected.json
@@ -355,10 +355,10 @@
       }
     },
     {
-      "id": "ms@2.1.3",
+      "id": "ms@2.1.2",
       "info": {
         "name": "ms",
-        "version": "2.1.3"
+        "version": "2.1.2"
       }
     },
     {
@@ -4548,6 +4548,13 @@
       }
     },
     {
+      "id": "ms@2.1.3",
+      "info": {
+        "name": "ms",
+        "version": "2.1.3"
+      }
+    },
+    {
       "id": "deepmerge@4.3.1",
       "info": {
         "name": "deepmerge",
@@ -6809,6 +6816,13 @@
       }
     },
     {
+      "id": "lowercase-keys@1.0.1",
+      "info": {
+        "name": "lowercase-keys",
+        "version": "1.0.1"
+      }
+    },
+    {
       "id": "decompress-response@3.3.0",
       "info": {
         "name": "decompress-response",
@@ -6820,13 +6834,6 @@
       "info": {
         "name": "duplexer3",
         "version": "0.1.5"
-      }
-    },
-    {
-      "id": "lowercase-keys@1.0.1",
-      "info": {
-        "name": "lowercase-keys",
-        "version": "1.0.1"
       }
     },
     {
@@ -11457,6 +11464,20 @@
       }
     },
     {
+      "id": "tr46@2.1.0",
+      "info": {
+        "name": "tr46",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "webidl-conversions@6.1.0",
+      "info": {
+        "name": "webidl-conversions",
+        "version": "6.1.0"
+      }
+    },
+    {
       "id": "decimal.js@10.4.3",
       "info": {
         "name": "decimal.js",
@@ -11667,13 +11688,6 @@
       }
     },
     {
-      "id": "webidl-conversions@6.1.0",
-      "info": {
-        "name": "webidl-conversions",
-        "version": "6.1.0"
-      }
-    },
-    {
       "id": "ws@7.5.9",
       "info": {
         "name": "ws",
@@ -11828,6 +11842,27 @@
       }
     },
     {
+      "id": "@nrwl/tao@13.2.3",
+      "info": {
+        "name": "@nrwl/tao",
+        "version": "13.2.3"
+      }
+    },
+    {
+      "id": "nx@13.2.3",
+      "info": {
+        "name": "nx",
+        "version": "13.2.3"
+      }
+    },
+    {
+      "id": "yargs-parser@20.0.0",
+      "info": {
+        "name": "yargs-parser",
+        "version": "20.0.0"
+      }
+    },
+    {
       "id": "@nrwl/linter@13.2.3",
       "info": {
         "name": "@nrwl/linter",
@@ -11835,10 +11870,108 @@
       }
     },
     {
+      "id": "@nrwl/jest@13.2.3",
+      "info": {
+        "name": "@nrwl/jest",
+        "version": "13.2.3"
+      }
+    },
+    {
+      "id": "@jest/reporters@27.2.2",
+      "info": {
+        "name": "@jest/reporters",
+        "version": "27.2.2"
+      }
+    },
+    {
+      "id": "istanbul-lib-instrument@4.0.3",
+      "info": {
+        "name": "istanbul-lib-instrument",
+        "version": "4.0.3"
+      }
+    },
+    {
+      "id": "@jest/test-result@27.2.2",
+      "info": {
+        "name": "@jest/test-result",
+        "version": "27.2.2"
+      }
+    },
+    {
+      "id": "jest-config@27.2.2",
+      "info": {
+        "name": "jest-config",
+        "version": "27.2.2"
+      }
+    },
+    {
+      "id": "is-ci@3.0.1",
+      "info": {
+        "name": "is-ci",
+        "version": "3.0.1"
+      }
+    },
+    {
+      "id": "jest-resolve@27.2.2",
+      "info": {
+        "name": "jest-resolve",
+        "version": "27.2.2"
+      }
+    },
+    {
+      "id": "jest-util@27.2.0",
+      "info": {
+        "name": "jest-util",
+        "version": "27.2.0"
+      }
+    },
+    {
       "id": "@nrwl/workspace@13.2.3",
       "info": {
         "name": "@nrwl/workspace",
         "version": "13.2.3"
+      }
+    },
+    {
+      "id": "@nrwl/cli@13.2.3",
+      "info": {
+        "name": "@nrwl/cli",
+        "version": "13.2.3"
+      }
+    },
+    {
+      "id": "@parcel/watcher@2.0.0-alpha.11",
+      "info": {
+        "name": "@parcel/watcher",
+        "version": "2.0.0-alpha.11"
+      }
+    },
+    {
+      "id": "cosmiconfig@4.0.0",
+      "info": {
+        "name": "cosmiconfig",
+        "version": "4.0.0"
+      }
+    },
+    {
+      "id": "is-directory@0.3.1",
+      "info": {
+        "name": "is-directory",
+        "version": "0.3.1"
+      }
+    },
+    {
+      "id": "parse-json@4.0.0",
+      "info": {
+        "name": "parse-json",
+        "version": "4.0.0"
+      }
+    },
+    {
+      "id": "json-parse-better-errors@1.0.2",
+      "info": {
+        "name": "json-parse-better-errors",
+        "version": "1.0.2"
       }
     },
     {
@@ -11874,20 +12007,6 @@
       "info": {
         "name": "load-json-file",
         "version": "4.0.0"
-      }
-    },
-    {
-      "id": "parse-json@4.0.0",
-      "info": {
-        "name": "parse-json",
-        "version": "4.0.0"
-      }
-    },
-    {
-      "id": "json-parse-better-errors@1.0.2",
-      "info": {
-        "name": "json-parse-better-errors",
-        "version": "1.0.2"
       }
     },
     {
@@ -11961,6 +12080,13 @@
       }
     },
     {
+      "id": "strip-ansi@6.0.0",
+      "info": {
+        "name": "strip-ansi",
+        "version": "6.0.0"
+      }
+    },
+    {
       "id": "fork-ts-checker-webpack-plugin@6.2.10",
       "info": {
         "name": "fork-ts-checker-webpack-plugin",
@@ -11986,69 +12112,6 @@
       "info": {
         "name": "webpack-node-externals",
         "version": "3.0.0"
-      }
-    },
-    {
-      "id": "yargs-parser@20.0.0",
-      "info": {
-        "name": "yargs-parser",
-        "version": "20.0.0"
-      }
-    },
-    {
-      "id": "@nrwl/jest@13.2.3",
-      "info": {
-        "name": "@nrwl/jest",
-        "version": "13.2.3"
-      }
-    },
-    {
-      "id": "@jest/reporters@27.2.2",
-      "info": {
-        "name": "@jest/reporters",
-        "version": "27.2.2"
-      }
-    },
-    {
-      "id": "istanbul-lib-instrument@4.0.3",
-      "info": {
-        "name": "istanbul-lib-instrument",
-        "version": "4.0.3"
-      }
-    },
-    {
-      "id": "@jest/test-result@27.2.2",
-      "info": {
-        "name": "@jest/test-result",
-        "version": "27.2.2"
-      }
-    },
-    {
-      "id": "jest-config@27.2.2",
-      "info": {
-        "name": "jest-config",
-        "version": "27.2.2"
-      }
-    },
-    {
-      "id": "is-ci@3.0.1",
-      "info": {
-        "name": "is-ci",
-        "version": "3.0.1"
-      }
-    },
-    {
-      "id": "jest-resolve@27.2.2",
-      "info": {
-        "name": "jest-resolve",
-        "version": "27.2.2"
-      }
-    },
-    {
-      "id": "jest-util@27.2.0",
-      "info": {
-        "name": "jest-util",
-        "version": "27.2.0"
       }
     },
     {
@@ -12262,6 +12325,27 @@
       }
     },
     {
+      "id": "schema-utils@4.0.0",
+      "info": {
+        "name": "schema-utils",
+        "version": "4.0.0"
+      }
+    },
+    {
+      "id": "ajv-formats@2.1.1",
+      "info": {
+        "name": "ajv-formats",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "ajv-keywords@5.1.0",
+      "info": {
+        "name": "ajv-keywords",
+        "version": "5.1.0"
+      }
+    },
+    {
       "id": "http-server@0.12.3",
       "info": {
         "name": "http-server",
@@ -12427,6 +12511,13 @@
       "info": {
         "name": "loader-utils",
         "version": "1.2.3"
+      }
+    },
+    {
+      "id": "emojis-list@2.1.0",
+      "info": {
+        "name": "emojis-list",
+        "version": "2.1.0"
       }
     },
     {
@@ -13050,20 +13141,6 @@
       "info": {
         "name": "retry",
         "version": "0.13.1"
-      }
-    },
-    {
-      "id": "schema-utils@4.0.0",
-      "info": {
-        "name": "schema-utils",
-        "version": "4.0.0"
-      }
-    },
-    {
-      "id": "ajv-formats@2.1.1",
-      "info": {
-        "name": "ajv-formats",
-        "version": "2.1.1"
       }
     },
     {
@@ -13823,6 +13900,13 @@
       }
     },
     {
+      "id": "is-extendable@1.0.1",
+      "info": {
+        "name": "is-extendable",
+        "version": "1.0.1"
+      }
+    },
+    {
       "id": "to-object-path@0.3.0",
       "info": {
         "name": "to-object-path",
@@ -13886,24 +13970,31 @@
       }
     },
     {
-      "id": "is-descriptor@1.0.2",
+      "id": "is-descriptor@0.1.6",
       "info": {
         "name": "is-descriptor",
-        "version": "1.0.2"
+        "version": "0.1.6"
       }
     },
     {
-      "id": "is-accessor-descriptor@1.0.0",
+      "id": "is-accessor-descriptor@0.1.6",
       "info": {
         "name": "is-accessor-descriptor",
-        "version": "1.0.0"
+        "version": "0.1.6"
       }
     },
     {
-      "id": "is-data-descriptor@1.0.0",
+      "id": "is-data-descriptor@0.1.4",
       "info": {
         "name": "is-data-descriptor",
-        "version": "1.0.0"
+        "version": "0.1.4"
+      }
+    },
+    {
+      "id": "kind-of@5.1.0",
+      "info": {
+        "name": "kind-of",
+        "version": "5.1.0"
       }
     },
     {
@@ -13935,6 +14026,27 @@
       }
     },
     {
+      "id": "is-descriptor@1.0.2",
+      "info": {
+        "name": "is-descriptor",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "is-accessor-descriptor@1.0.0",
+      "info": {
+        "name": "is-accessor-descriptor",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "is-data-descriptor@1.0.0",
+      "info": {
+        "name": "is-data-descriptor",
+        "version": "1.0.0"
+      }
+    },
+    {
       "id": "mixin-deep@1.3.2",
       "info": {
         "name": "mixin-deep",
@@ -13946,13 +14058,6 @@
       "info": {
         "name": "for-in",
         "version": "1.0.2"
-      }
-    },
-    {
-      "id": "is-extendable@1.0.1",
-      "info": {
-        "name": "is-extendable",
-        "version": "1.0.1"
       }
     },
     {
@@ -14397,20 +14502,6 @@
       }
     },
     {
-      "id": "jest-snapshot@28.1.3",
-      "info": {
-        "name": "jest-snapshot",
-        "version": "28.1.3"
-      }
-    },
-    {
-      "id": "jest-each@28.1.3",
-      "info": {
-        "name": "jest-each",
-        "version": "28.1.3"
-      }
-    },
-    {
       "id": "jest-matcher-utils@28.1.3",
       "info": {
         "name": "jest-matcher-utils",
@@ -14429,6 +14520,20 @@
       "info": {
         "name": "diff-sequences",
         "version": "28.1.1"
+      }
+    },
+    {
+      "id": "jest-snapshot@28.1.3",
+      "info": {
+        "name": "jest-snapshot",
+        "version": "28.1.3"
+      }
+    },
+    {
+      "id": "jest-each@28.1.3",
+      "info": {
+        "name": "jest-each",
+        "version": "28.1.3"
       }
     },
     {
@@ -16254,7 +16359,7 @@
         "pkgId": "debug@4.3.4",
         "deps": [
           {
-            "nodeId": "ms@2.1.3"
+            "nodeId": "ms@2.1.2"
           }
         ],
         "info": {
@@ -16264,8 +16369,8 @@
         }
       },
       {
-        "nodeId": "ms@2.1.3",
-        "pkgId": "ms@2.1.3",
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
         "deps": [],
         "info": {
           "labels": {
@@ -25868,6 +25973,16 @@
         }
       },
       {
+        "nodeId": "ms@2.1.3",
+        "pkgId": "ms@2.1.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
         "nodeId": "deepmerge@4.3.1",
         "pkgId": "deepmerge@4.3.1",
         "deps": [],
@@ -31346,9 +31461,19 @@
         "pkgId": "responselike@1.0.2",
         "deps": [
           {
-            "nodeId": "lowercase-keys@2.0.0"
+            "nodeId": "lowercase-keys@1.0.1"
           }
         ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lowercase-keys@1.0.1",
+        "pkgId": "lowercase-keys@1.0.1",
+        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"
@@ -31372,16 +31497,6 @@
       {
         "nodeId": "duplexer3@0.1.5",
         "pkgId": "duplexer3@0.1.5",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "lowercase-keys@1.0.1",
-        "pkgId": "lowercase-keys@1.0.1",
         "deps": [],
         "info": {
           "labels": {
@@ -42983,12 +43098,36 @@
             "nodeId": "lodash@4.17.21"
           },
           {
-            "nodeId": "tr46@0.0.3"
+            "nodeId": "tr46@2.1.0"
           },
           {
-            "nodeId": "webidl-conversions@3.0.1"
+            "nodeId": "webidl-conversions@6.1.0"
           }
         ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "tr46@2.1.0",
+        "pkgId": "tr46@2.1.0",
+        "deps": [
+          {
+            "nodeId": "punycode@2.3.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "webidl-conversions@6.1.0",
+        "pkgId": "webidl-conversions@6.1.0",
+        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"
@@ -43399,16 +43538,6 @@
       {
         "nodeId": "xml-name-validator@3.0.0",
         "pkgId": "xml-name-validator@3.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "webidl-conversions@6.1.0",
-        "pkgId": "webidl-conversions@6.1.0",
         "deps": [],
         "info": {
           "labels": {
@@ -43934,7 +44063,7 @@
         "pkgId": "@nrwl/devkit@13.2.3",
         "deps": [
           {
-            "nodeId": "@nrwl/tao@14.0.5"
+            "nodeId": "@nrwl/tao@13.2.3"
           },
           {
             "nodeId": "ejs@3.1.9"
@@ -43959,103 +44088,32 @@
         }
       },
       {
-        "nodeId": "@nrwl/linter@13.2.3",
-        "pkgId": "@nrwl/linter@13.2.3",
+        "nodeId": "@nrwl/tao@13.2.3",
+        "pkgId": "@nrwl/tao@13.2.3",
         "deps": [
-          {
-            "nodeId": "@nrwl/devkit@14.0.5"
-          },
-          {
-            "nodeId": "@nrwl/jest@14.0.5"
-          },
-          {
-            "nodeId": "eslint@7.32.0"
-          },
-          {
-            "nodeId": "glob@7.1.4"
-          },
-          {
-            "nodeId": "minimatch@3.1.2"
-          },
-          {
-            "nodeId": "tmp@0.2.1"
-          },
-          {
-            "nodeId": "tslib@2.4.1"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "@nrwl/workspace@13.2.3",
-        "pkgId": "@nrwl/workspace@13.2.3",
-        "deps": [
-          {
-            "nodeId": "@nrwl/cli@14.0.5"
-          },
-          {
-            "nodeId": "@nrwl/devkit@14.0.5"
-          },
-          {
-            "nodeId": "@nrwl/jest@14.0.5"
-          },
-          {
-            "nodeId": "@nrwl/linter@14.0.5"
-          },
-          {
-            "nodeId": "@parcel/watcher@2.0.4"
-          },
           {
             "nodeId": "chalk@4.1.0"
-          },
-          {
-            "nodeId": "chokidar@3.5.3"
-          },
-          {
-            "nodeId": "cosmiconfig@7.1.0"
-          },
-          {
-            "nodeId": "dotenv@10.0.0"
           },
           {
             "nodeId": "enquirer@2.3.6"
           },
           {
-            "nodeId": "flat@5.0.2"
-          },
-          {
             "nodeId": "fs-extra@9.1.0"
           },
           {
-            "nodeId": "glob@7.1.4"
+            "nodeId": "jsonc-parser@3.0.0"
           },
           {
-            "nodeId": "ignore@5.2.4"
-          },
-          {
-            "nodeId": "minimatch@3.0.4"
-          },
-          {
-            "nodeId": "npm-run-all@4.1.5"
-          },
-          {
-            "nodeId": "npm-run-path@4.0.1"
-          },
-          {
-            "nodeId": "open@7.4.2"
+            "nodeId": "nx@13.2.3"
           },
           {
             "nodeId": "rxjs@6.6.7"
           },
           {
-            "nodeId": "semver@7.3.4"
+            "nodeId": "rxjs-for-await@0.0.2"
           },
           {
-            "nodeId": "strip-ansi@6.0.1"
+            "nodeId": "semver@7.3.4"
           },
           {
             "nodeId": "tmp@0.2.1"
@@ -44064,10 +44122,7 @@
             "nodeId": "tslib@2.4.1"
           },
           {
-            "nodeId": "yargs@15.4.1"
-          },
-          {
-            "nodeId": "yargs-parser@21.0.1"
+            "nodeId": "yargs-parser@20.0.0"
           }
         ],
         "info": {
@@ -44077,378 +44132,13 @@
         }
       },
       {
-        "nodeId": "npm-run-all@4.1.5",
-        "pkgId": "npm-run-all@4.1.5",
+        "nodeId": "nx@13.2.3",
+        "pkgId": "nx@13.2.3",
         "deps": [
           {
-            "nodeId": "ansi-styles@3.2.1"
-          },
-          {
-            "nodeId": "chalk@2.4.2"
-          },
-          {
-            "nodeId": "cross-spawn@6.0.5"
-          },
-          {
-            "nodeId": "memorystream@0.3.1"
-          },
-          {
-            "nodeId": "minimatch@3.1.2"
-          },
-          {
-            "nodeId": "pidtree@0.3.1"
-          },
-          {
-            "nodeId": "read-pkg@3.0.0"
-          },
-          {
-            "nodeId": "shell-quote@1.8.0"
-          },
-          {
-            "nodeId": "string.prototype.padend@3.1.4"
+            "nodeId": "@nrwl/cli@14.0.5"
           }
         ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "memorystream@0.3.1",
-        "pkgId": "memorystream@0.3.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "pidtree@0.3.1",
-        "pkgId": "pidtree@0.3.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "read-pkg@3.0.0",
-        "pkgId": "read-pkg@3.0.0",
-        "deps": [
-          {
-            "nodeId": "load-json-file@4.0.0"
-          },
-          {
-            "nodeId": "normalize-package-data@2.5.0"
-          },
-          {
-            "nodeId": "path-type@3.0.0"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "load-json-file@4.0.0",
-        "pkgId": "load-json-file@4.0.0",
-        "deps": [
-          {
-            "nodeId": "graceful-fs@4.2.11"
-          },
-          {
-            "nodeId": "parse-json@4.0.0"
-          },
-          {
-            "nodeId": "pify@3.0.0"
-          },
-          {
-            "nodeId": "strip-bom@3.0.0"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "parse-json@4.0.0",
-        "pkgId": "parse-json@4.0.0",
-        "deps": [
-          {
-            "nodeId": "error-ex@1.3.2"
-          },
-          {
-            "nodeId": "json-parse-better-errors@1.0.2"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "json-parse-better-errors@1.0.2",
-        "pkgId": "json-parse-better-errors@1.0.2",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "pify@3.0.0",
-        "pkgId": "pify@3.0.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "normalize-package-data@2.5.0",
-        "pkgId": "normalize-package-data@2.5.0",
-        "deps": [
-          {
-            "nodeId": "hosted-git-info@2.8.9"
-          },
-          {
-            "nodeId": "resolve@1.22.1"
-          },
-          {
-            "nodeId": "semver@5.7.1"
-          },
-          {
-            "nodeId": "validate-npm-package-license@3.0.4"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "hosted-git-info@2.8.9",
-        "pkgId": "hosted-git-info@2.8.9",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "validate-npm-package-license@3.0.4",
-        "pkgId": "validate-npm-package-license@3.0.4",
-        "deps": [
-          {
-            "nodeId": "spdx-correct@3.2.0"
-          },
-          {
-            "nodeId": "spdx-expression-parse@3.0.1"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "spdx-correct@3.2.0",
-        "pkgId": "spdx-correct@3.2.0",
-        "deps": [
-          {
-            "nodeId": "spdx-expression-parse@3.0.1"
-          },
-          {
-            "nodeId": "spdx-license-ids@3.0.13"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "spdx-expression-parse@3.0.1",
-        "pkgId": "spdx-expression-parse@3.0.1",
-        "deps": [
-          {
-            "nodeId": "spdx-exceptions@2.3.0"
-          },
-          {
-            "nodeId": "spdx-license-ids@3.0.13"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "spdx-exceptions@2.3.0",
-        "pkgId": "spdx-exceptions@2.3.0",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "spdx-license-ids@3.0.13",
-        "pkgId": "spdx-license-ids@3.0.13",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "path-type@3.0.0",
-        "pkgId": "path-type@3.0.0",
-        "deps": [
-          {
-            "nodeId": "pify@3.0.0"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "string.prototype.padend@3.1.4",
-        "pkgId": "string.prototype.padend@3.1.4",
-        "deps": [
-          {
-            "nodeId": "call-bind@1.0.2"
-          },
-          {
-            "nodeId": "define-properties@1.2.0"
-          },
-          {
-            "nodeId": "es-abstract@1.21.2"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "fork-ts-checker-webpack-plugin@6.2.10",
-        "pkgId": "fork-ts-checker-webpack-plugin@6.2.10",
-        "deps": [
-          {
-            "nodeId": "@babel/code-frame@7.18.6"
-          },
-          {
-            "nodeId": "@types/json-schema@7.0.11"
-          },
-          {
-            "nodeId": "chalk@4.1.2"
-          },
-          {
-            "nodeId": "chokidar@3.5.3"
-          },
-          {
-            "nodeId": "cosmiconfig@6.0.0"
-          },
-          {
-            "nodeId": "deepmerge@4.3.1"
-          },
-          {
-            "nodeId": "fs-extra@9.1.0"
-          },
-          {
-            "nodeId": "glob@7.2.3"
-          },
-          {
-            "nodeId": "memfs@3.4.13"
-          },
-          {
-            "nodeId": "minimatch@3.1.2"
-          },
-          {
-            "nodeId": "schema-utils@2.7.0"
-          },
-          {
-            "nodeId": "semver@7.3.8"
-          },
-          {
-            "nodeId": "tapable@1.1.3"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "ts-loader@9.4.2",
-        "pkgId": "ts-loader@9.4.2",
-        "deps": [
-          {
-            "nodeId": "chalk@4.1.2"
-          },
-          {
-            "nodeId": "enhanced-resolve@5.12.0"
-          },
-          {
-            "nodeId": "micromatch@4.0.5"
-          },
-          {
-            "nodeId": "semver@7.3.8"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "tsconfig-paths-webpack-plugin@3.4.1",
-        "pkgId": "tsconfig-paths-webpack-plugin@3.4.1",
-        "deps": [
-          {
-            "nodeId": "chalk@4.1.2"
-          },
-          {
-            "nodeId": "enhanced-resolve@5.12.0"
-          },
-          {
-            "nodeId": "tsconfig-paths@3.14.2"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "webpack-node-externals@3.0.0",
-        "pkgId": "webpack-node-externals@3.0.0",
-        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"
@@ -44459,6 +44149,38 @@
         "nodeId": "yargs-parser@20.0.0",
         "pkgId": "yargs-parser@20.0.0",
         "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@nrwl/linter@13.2.3",
+        "pkgId": "@nrwl/linter@13.2.3",
+        "deps": [
+          {
+            "nodeId": "@nrwl/devkit@13.2.3"
+          },
+          {
+            "nodeId": "@nrwl/jest@13.2.3"
+          },
+          {
+            "nodeId": "eslint@7.32.0"
+          },
+          {
+            "nodeId": "glob@7.1.4"
+          },
+          {
+            "nodeId": "minimatch@3.0.4"
+          },
+          {
+            "nodeId": "tmp@0.2.1"
+          },
+          {
+            "nodeId": "tslib@2.4.1"
+          }
+        ],
         "info": {
           "labels": {
             "scope": "prod"
@@ -44717,7 +44439,7 @@
         "pkgId": "is-ci@3.0.1",
         "deps": [
           {
-            "nodeId": "ci-info@2.0.0"
+            "nodeId": "ci-info@3.8.0"
           }
         ],
         "info": {
@@ -44790,6 +44512,564 @@
             "nodeId": "picomatch@2.3.1"
           }
         ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@nrwl/workspace@13.2.3",
+        "pkgId": "@nrwl/workspace@13.2.3",
+        "deps": [
+          {
+            "nodeId": "@nrwl/cli@13.2.3"
+          },
+          {
+            "nodeId": "@nrwl/devkit@13.2.3"
+          },
+          {
+            "nodeId": "@nrwl/jest@13.2.3"
+          },
+          {
+            "nodeId": "@nrwl/linter@13.2.3"
+          },
+          {
+            "nodeId": "@parcel/watcher@2.0.0-alpha.11"
+          },
+          {
+            "nodeId": "chalk@4.1.0"
+          },
+          {
+            "nodeId": "chokidar@3.5.3"
+          },
+          {
+            "nodeId": "cosmiconfig@4.0.0"
+          },
+          {
+            "nodeId": "dotenv@10.0.0"
+          },
+          {
+            "nodeId": "enquirer@2.3.6"
+          },
+          {
+            "nodeId": "flat@5.0.2"
+          },
+          {
+            "nodeId": "fs-extra@9.1.0"
+          },
+          {
+            "nodeId": "glob@7.1.4"
+          },
+          {
+            "nodeId": "ignore@5.2.4"
+          },
+          {
+            "nodeId": "minimatch@3.0.4"
+          },
+          {
+            "nodeId": "npm-run-all@4.1.5"
+          },
+          {
+            "nodeId": "npm-run-path@4.0.1"
+          },
+          {
+            "nodeId": "open@7.4.2"
+          },
+          {
+            "nodeId": "rxjs@6.6.7"
+          },
+          {
+            "nodeId": "semver@7.3.4"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.0"
+          },
+          {
+            "nodeId": "tmp@0.2.1"
+          },
+          {
+            "nodeId": "tslib@2.4.1"
+          },
+          {
+            "nodeId": "yargs@15.4.1"
+          },
+          {
+            "nodeId": "yargs-parser@20.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@nrwl/cli@13.2.3",
+        "pkgId": "@nrwl/cli@13.2.3",
+        "deps": [
+          {
+            "nodeId": "@nrwl/tao@13.2.3"
+          },
+          {
+            "nodeId": "chalk@4.1.0"
+          },
+          {
+            "nodeId": "enquirer@2.3.6"
+          },
+          {
+            "nodeId": "v8-compile-cache@2.3.0"
+          },
+          {
+            "nodeId": "yargs@15.4.1"
+          },
+          {
+            "nodeId": "yargs-parser@20.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@parcel/watcher@2.0.0-alpha.11",
+        "pkgId": "@parcel/watcher@2.0.0-alpha.11",
+        "deps": [
+          {
+            "nodeId": "node-addon-api@3.2.1"
+          },
+          {
+            "nodeId": "node-gyp-build@4.6.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "cosmiconfig@4.0.0",
+        "pkgId": "cosmiconfig@4.0.0",
+        "deps": [
+          {
+            "nodeId": "is-directory@0.3.1"
+          },
+          {
+            "nodeId": "js-yaml@3.14.1"
+          },
+          {
+            "nodeId": "parse-json@4.0.0"
+          },
+          {
+            "nodeId": "require-from-string@2.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-directory@0.3.1",
+        "pkgId": "is-directory@0.3.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "parse-json@4.0.0",
+        "pkgId": "parse-json@4.0.0",
+        "deps": [
+          {
+            "nodeId": "error-ex@1.3.2"
+          },
+          {
+            "nodeId": "json-parse-better-errors@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "json-parse-better-errors@1.0.2",
+        "pkgId": "json-parse-better-errors@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "npm-run-all@4.1.5",
+        "pkgId": "npm-run-all@4.1.5",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@3.2.1"
+          },
+          {
+            "nodeId": "chalk@2.4.2"
+          },
+          {
+            "nodeId": "cross-spawn@6.0.5"
+          },
+          {
+            "nodeId": "memorystream@0.3.1"
+          },
+          {
+            "nodeId": "minimatch@3.1.2"
+          },
+          {
+            "nodeId": "pidtree@0.3.1"
+          },
+          {
+            "nodeId": "read-pkg@3.0.0"
+          },
+          {
+            "nodeId": "shell-quote@1.8.0"
+          },
+          {
+            "nodeId": "string.prototype.padend@3.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "memorystream@0.3.1",
+        "pkgId": "memorystream@0.3.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pidtree@0.3.1",
+        "pkgId": "pidtree@0.3.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "read-pkg@3.0.0",
+        "pkgId": "read-pkg@3.0.0",
+        "deps": [
+          {
+            "nodeId": "load-json-file@4.0.0"
+          },
+          {
+            "nodeId": "normalize-package-data@2.5.0"
+          },
+          {
+            "nodeId": "path-type@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "load-json-file@4.0.0",
+        "pkgId": "load-json-file@4.0.0",
+        "deps": [
+          {
+            "nodeId": "graceful-fs@4.2.11"
+          },
+          {
+            "nodeId": "parse-json@4.0.0"
+          },
+          {
+            "nodeId": "pify@3.0.0"
+          },
+          {
+            "nodeId": "strip-bom@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "pify@3.0.0",
+        "pkgId": "pify@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "normalize-package-data@2.5.0",
+        "pkgId": "normalize-package-data@2.5.0",
+        "deps": [
+          {
+            "nodeId": "hosted-git-info@2.8.9"
+          },
+          {
+            "nodeId": "resolve@1.22.1"
+          },
+          {
+            "nodeId": "semver@5.7.1"
+          },
+          {
+            "nodeId": "validate-npm-package-license@3.0.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "hosted-git-info@2.8.9",
+        "pkgId": "hosted-git-info@2.8.9",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "validate-npm-package-license@3.0.4",
+        "pkgId": "validate-npm-package-license@3.0.4",
+        "deps": [
+          {
+            "nodeId": "spdx-correct@3.2.0"
+          },
+          {
+            "nodeId": "spdx-expression-parse@3.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-correct@3.2.0",
+        "pkgId": "spdx-correct@3.2.0",
+        "deps": [
+          {
+            "nodeId": "spdx-expression-parse@3.0.1"
+          },
+          {
+            "nodeId": "spdx-license-ids@3.0.13"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-expression-parse@3.0.1",
+        "pkgId": "spdx-expression-parse@3.0.1",
+        "deps": [
+          {
+            "nodeId": "spdx-exceptions@2.3.0"
+          },
+          {
+            "nodeId": "spdx-license-ids@3.0.13"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-exceptions@2.3.0",
+        "pkgId": "spdx-exceptions@2.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "spdx-license-ids@3.0.13",
+        "pkgId": "spdx-license-ids@3.0.13",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "path-type@3.0.0",
+        "pkgId": "path-type@3.0.0",
+        "deps": [
+          {
+            "nodeId": "pify@3.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string.prototype.padend@3.1.4",
+        "pkgId": "string.prototype.padend@3.1.4",
+        "deps": [
+          {
+            "nodeId": "call-bind@1.0.2"
+          },
+          {
+            "nodeId": "define-properties@1.2.0"
+          },
+          {
+            "nodeId": "es-abstract@1.21.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@6.0.0",
+        "pkgId": "strip-ansi@6.0.0",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@5.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fork-ts-checker-webpack-plugin@6.2.10",
+        "pkgId": "fork-ts-checker-webpack-plugin@6.2.10",
+        "deps": [
+          {
+            "nodeId": "@babel/code-frame@7.18.6"
+          },
+          {
+            "nodeId": "@types/json-schema@7.0.11"
+          },
+          {
+            "nodeId": "chalk@4.1.2"
+          },
+          {
+            "nodeId": "chokidar@3.5.3"
+          },
+          {
+            "nodeId": "cosmiconfig@6.0.0"
+          },
+          {
+            "nodeId": "deepmerge@4.3.1"
+          },
+          {
+            "nodeId": "fs-extra@9.1.0"
+          },
+          {
+            "nodeId": "glob@7.2.3"
+          },
+          {
+            "nodeId": "memfs@3.4.13"
+          },
+          {
+            "nodeId": "minimatch@3.1.2"
+          },
+          {
+            "nodeId": "schema-utils@2.7.0"
+          },
+          {
+            "nodeId": "semver@7.3.8"
+          },
+          {
+            "nodeId": "tapable@1.1.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ts-loader@9.4.2",
+        "pkgId": "ts-loader@9.4.2",
+        "deps": [
+          {
+            "nodeId": "chalk@4.1.2"
+          },
+          {
+            "nodeId": "enhanced-resolve@5.12.0"
+          },
+          {
+            "nodeId": "micromatch@4.0.5"
+          },
+          {
+            "nodeId": "semver@7.3.8"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "tsconfig-paths-webpack-plugin@3.4.1",
+        "pkgId": "tsconfig-paths-webpack-plugin@3.4.1",
+        "deps": [
+          {
+            "nodeId": "chalk@4.1.2"
+          },
+          {
+            "nodeId": "enhanced-resolve@5.12.0"
+          },
+          {
+            "nodeId": "tsconfig-paths@3.14.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "webpack-node-externals@3.0.0",
+        "pkgId": "webpack-node-externals@3.0.0",
+        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"
@@ -45613,19 +45893,70 @@
             "nodeId": "cssnano@5.1.15"
           },
           {
-            "nodeId": "jest-worker@26.6.2"
+            "nodeId": "jest-worker@27.5.1"
           },
           {
             "nodeId": "postcss@8.4.21"
           },
           {
-            "nodeId": "schema-utils@3.1.1"
+            "nodeId": "schema-utils@4.0.0"
           },
           {
-            "nodeId": "serialize-javascript@5.0.1"
+            "nodeId": "serialize-javascript@6.0.1"
           },
           {
             "nodeId": "source-map@0.6.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "schema-utils@4.0.0",
+        "pkgId": "schema-utils@4.0.0",
+        "deps": [
+          {
+            "nodeId": "@types/json-schema@7.0.11"
+          },
+          {
+            "nodeId": "ajv@8.12.0"
+          },
+          {
+            "nodeId": "ajv-formats@2.1.1"
+          },
+          {
+            "nodeId": "ajv-keywords@5.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ajv-formats@2.1.1",
+        "pkgId": "ajv-formats@2.1.1",
+        "deps": [
+          {
+            "nodeId": "ajv@8.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ajv-keywords@5.1.0",
+        "pkgId": "ajv-keywords@5.1.0",
+        "deps": [
+          {
+            "nodeId": "fast-deep-equal@3.1.3"
           }
         ],
         "info": {
@@ -46001,7 +46332,7 @@
             "nodeId": "big.js@5.2.2"
           },
           {
-            "nodeId": "emojis-list@3.0.0"
+            "nodeId": "emojis-list@2.1.0"
           },
           {
             "nodeId": "json5@1.0.2"
@@ -46014,11 +46345,21 @@
         }
       },
       {
+        "nodeId": "emojis-list@2.1.0",
+        "pkgId": "emojis-list@2.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
         "nodeId": "mini-css-extract-plugin@2.4.7",
         "pkgId": "mini-css-extract-plugin@2.4.7",
         "deps": [
           {
-            "nodeId": "schema-utils@3.1.1"
+            "nodeId": "schema-utils@4.0.0"
           }
         ],
         "info": {
@@ -47470,43 +47811,6 @@
         }
       },
       {
-        "nodeId": "schema-utils@4.0.0",
-        "pkgId": "schema-utils@4.0.0",
-        "deps": [
-          {
-            "nodeId": "@types/json-schema@7.0.11"
-          },
-          {
-            "nodeId": "ajv@6.12.6"
-          },
-          {
-            "nodeId": "ajv-formats@2.1.1"
-          },
-          {
-            "nodeId": "ajv-keywords@3.5.2"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "ajv-formats@2.1.1",
-        "pkgId": "ajv-formats@2.1.1",
-        "deps": [
-          {
-            "nodeId": "ajv@8.12.0"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
         "nodeId": "selfsigned@2.1.1",
         "pkgId": "selfsigned@2.1.1",
         "deps": [
@@ -47858,7 +48162,7 @@
             "nodeId": "range-parser@1.2.1"
           },
           {
-            "nodeId": "schema-utils@3.1.1"
+            "nodeId": "schema-utils@4.0.0"
           }
         ],
         "info": {
@@ -48533,7 +48837,7 @@
             "nodeId": "domelementtype@2.3.0"
           },
           {
-            "nodeId": "entities@4.4.0"
+            "nodeId": "entities@2.2.0"
           }
         ],
         "info": {
@@ -49351,7 +49655,7 @@
         "pkgId": "kind-of@4.0.0",
         "deps": [
           {
-            "nodeId": "is-buffer@2.0.5"
+            "nodeId": "is-buffer@1.1.6"
           }
         ],
         "info": {
@@ -49405,7 +49709,7 @@
             "nodeId": "assign-symbols@1.0.0"
           },
           {
-            "nodeId": "is-extendable@0.1.1"
+            "nodeId": "is-extendable@1.0.1"
           }
         ],
         "info": {
@@ -49418,6 +49722,20 @@
         "nodeId": "assign-symbols@1.0.0",
         "pkgId": "assign-symbols@1.0.0",
         "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-extendable@1.0.1",
+        "pkgId": "is-extendable@1.0.1",
+        "deps": [
+          {
+            "nodeId": "is-plain-object@2.0.4"
+          }
+        ],
         "info": {
           "labels": {
             "scope": "prod"
@@ -49560,7 +49878,7 @@
         "pkgId": "define-property@0.2.5",
         "deps": [
           {
-            "nodeId": "is-descriptor@1.0.2"
+            "nodeId": "is-descriptor@0.1.6"
           }
         ],
         "info": {
@@ -49570,17 +49888,17 @@
         }
       },
       {
-        "nodeId": "is-descriptor@1.0.2",
-        "pkgId": "is-descriptor@1.0.2",
+        "nodeId": "is-descriptor@0.1.6",
+        "pkgId": "is-descriptor@0.1.6",
         "deps": [
           {
-            "nodeId": "is-accessor-descriptor@1.0.0"
+            "nodeId": "is-accessor-descriptor@0.1.6"
           },
           {
-            "nodeId": "is-data-descriptor@1.0.0"
+            "nodeId": "is-data-descriptor@0.1.4"
           },
           {
-            "nodeId": "kind-of@6.0.3"
+            "nodeId": "kind-of@5.1.0"
           }
         ],
         "info": {
@@ -49590,11 +49908,11 @@
         }
       },
       {
-        "nodeId": "is-accessor-descriptor@1.0.0",
-        "pkgId": "is-accessor-descriptor@1.0.0",
+        "nodeId": "is-accessor-descriptor@0.1.6",
+        "pkgId": "is-accessor-descriptor@0.1.6",
         "deps": [
           {
-            "nodeId": "kind-of@6.0.3"
+            "nodeId": "kind-of@3.2.2"
           }
         ],
         "info": {
@@ -49604,13 +49922,23 @@
         }
       },
       {
-        "nodeId": "is-data-descriptor@1.0.0",
-        "pkgId": "is-data-descriptor@1.0.0",
+        "nodeId": "is-data-descriptor@0.1.4",
+        "pkgId": "is-data-descriptor@0.1.4",
         "deps": [
           {
-            "nodeId": "kind-of@6.0.3"
+            "nodeId": "kind-of@3.2.2"
           }
         ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "kind-of@5.1.0",
+        "pkgId": "kind-of@5.1.0",
+        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"
@@ -49679,6 +50007,54 @@
         }
       },
       {
+        "nodeId": "is-descriptor@1.0.2",
+        "pkgId": "is-descriptor@1.0.2",
+        "deps": [
+          {
+            "nodeId": "is-accessor-descriptor@1.0.0"
+          },
+          {
+            "nodeId": "is-data-descriptor@1.0.0"
+          },
+          {
+            "nodeId": "kind-of@6.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-accessor-descriptor@1.0.0",
+        "pkgId": "is-accessor-descriptor@1.0.0",
+        "deps": [
+          {
+            "nodeId": "kind-of@6.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-data-descriptor@1.0.0",
+        "pkgId": "is-data-descriptor@1.0.0",
+        "deps": [
+          {
+            "nodeId": "kind-of@6.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
         "nodeId": "mixin-deep@1.3.2",
         "pkgId": "mixin-deep@1.3.2",
         "deps": [
@@ -49699,20 +50075,6 @@
         "nodeId": "for-in@1.0.2",
         "pkgId": "for-in@1.0.2",
         "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "is-extendable@1.0.1",
-        "pkgId": "is-extendable@1.0.1",
-        "deps": [
-          {
-            "nodeId": "is-plain-object@2.0.4"
-          }
-        ],
         "info": {
           "labels": {
             "scope": "prod"
@@ -50714,7 +51076,7 @@
             "nodeId": "jest-regex-util@28.0.2"
           },
           {
-            "nodeId": "jest-util@27.5.1"
+            "nodeId": "jest-util@28.1.3"
           },
           {
             "nodeId": "jest-worker@28.1.3"
@@ -50756,7 +51118,7 @@
             "nodeId": "merge-stream@2.0.0"
           },
           {
-            "nodeId": "supports-color@7.2.0"
+            "nodeId": "supports-color@8.1.1"
           }
         ],
         "info": {
@@ -51137,7 +51499,7 @@
             "nodeId": "jest-mock@28.1.3"
           },
           {
-            "nodeId": "jest-util@27.5.1"
+            "nodeId": "jest-util@28.1.3"
           }
         ],
         "info": {
@@ -51202,16 +51564,16 @@
             "nodeId": "@jest/expect-utils@28.1.3"
           },
           {
-            "nodeId": "jest-get-type@27.5.1"
+            "nodeId": "jest-get-type@28.0.2"
           },
           {
-            "nodeId": "jest-matcher-utils@27.5.1"
+            "nodeId": "jest-matcher-utils@28.1.3"
           },
           {
-            "nodeId": "jest-message-util@27.5.1"
+            "nodeId": "jest-message-util@28.1.3"
           },
           {
-            "nodeId": "jest-util@27.5.1"
+            "nodeId": "jest-util@28.1.3"
           }
         ],
         "info": {
@@ -51238,112 +51600,6 @@
         "nodeId": "jest-get-type@28.0.2",
         "pkgId": "jest-get-type@28.0.2",
         "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "jest-snapshot@28.1.3",
-        "pkgId": "jest-snapshot@28.1.3",
-        "deps": [
-          {
-            "nodeId": "@babel/core@7.12.13"
-          },
-          {
-            "nodeId": "@babel/generator@7.21.3"
-          },
-          {
-            "nodeId": "@babel/plugin-syntax-typescript@7.20.0"
-          },
-          {
-            "nodeId": "@babel/traverse@7.21.3"
-          },
-          {
-            "nodeId": "@babel/types@7.21.3"
-          },
-          {
-            "nodeId": "@jest/expect-utils@28.1.3"
-          },
-          {
-            "nodeId": "@jest/transform@27.5.1"
-          },
-          {
-            "nodeId": "@jest/types@27.5.1"
-          },
-          {
-            "nodeId": "@types/babel__traverse@7.18.3"
-          },
-          {
-            "nodeId": "@types/prettier@2.7.2"
-          },
-          {
-            "nodeId": "babel-preset-current-node-syntax@1.0.1"
-          },
-          {
-            "nodeId": "chalk@4.1.2"
-          },
-          {
-            "nodeId": "expect@27.5.1"
-          },
-          {
-            "nodeId": "graceful-fs@4.2.11"
-          },
-          {
-            "nodeId": "jest-diff@27.5.1"
-          },
-          {
-            "nodeId": "jest-get-type@27.5.1"
-          },
-          {
-            "nodeId": "jest-haste-map@27.5.1"
-          },
-          {
-            "nodeId": "jest-matcher-utils@27.5.1"
-          },
-          {
-            "nodeId": "jest-message-util@27.5.1"
-          },
-          {
-            "nodeId": "jest-util@27.5.1"
-          },
-          {
-            "nodeId": "natural-compare@1.4.0"
-          },
-          {
-            "nodeId": "pretty-format@27.5.1"
-          },
-          {
-            "nodeId": "semver@7.3.8"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "jest-each@28.1.3",
-        "pkgId": "jest-each@28.1.3",
-        "deps": [
-          {
-            "nodeId": "@jest/types@28.1.3"
-          },
-          {
-            "nodeId": "chalk@4.1.2"
-          },
-          {
-            "nodeId": "jest-get-type@28.0.2"
-          },
-          {
-            "nodeId": "jest-util@27.5.1"
-          },
-          {
-            "nodeId": "pretty-format@28.1.3"
-          }
-        ],
         "info": {
           "labels": {
             "scope": "prod"
@@ -51407,6 +51663,112 @@
         }
       },
       {
+        "nodeId": "jest-snapshot@28.1.3",
+        "pkgId": "jest-snapshot@28.1.3",
+        "deps": [
+          {
+            "nodeId": "@babel/core@7.12.13"
+          },
+          {
+            "nodeId": "@babel/generator@7.21.3"
+          },
+          {
+            "nodeId": "@babel/plugin-syntax-typescript@7.20.0"
+          },
+          {
+            "nodeId": "@babel/traverse@7.21.3"
+          },
+          {
+            "nodeId": "@babel/types@7.21.3"
+          },
+          {
+            "nodeId": "@jest/expect-utils@28.1.3"
+          },
+          {
+            "nodeId": "@jest/transform@28.1.3"
+          },
+          {
+            "nodeId": "@jest/types@28.1.3"
+          },
+          {
+            "nodeId": "@types/babel__traverse@7.18.3"
+          },
+          {
+            "nodeId": "@types/prettier@2.7.2"
+          },
+          {
+            "nodeId": "babel-preset-current-node-syntax@1.0.1"
+          },
+          {
+            "nodeId": "chalk@4.1.2"
+          },
+          {
+            "nodeId": "expect@28.1.3"
+          },
+          {
+            "nodeId": "graceful-fs@4.2.11"
+          },
+          {
+            "nodeId": "jest-diff@28.1.3"
+          },
+          {
+            "nodeId": "jest-get-type@28.0.2"
+          },
+          {
+            "nodeId": "jest-haste-map@28.1.3"
+          },
+          {
+            "nodeId": "jest-matcher-utils@28.1.3"
+          },
+          {
+            "nodeId": "jest-message-util@28.1.3"
+          },
+          {
+            "nodeId": "jest-util@28.1.3"
+          },
+          {
+            "nodeId": "natural-compare@1.4.0"
+          },
+          {
+            "nodeId": "pretty-format@28.1.3"
+          },
+          {
+            "nodeId": "semver@7.3.8"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "jest-each@28.1.3",
+        "pkgId": "jest-each@28.1.3",
+        "deps": [
+          {
+            "nodeId": "@jest/types@28.1.3"
+          },
+          {
+            "nodeId": "chalk@4.1.2"
+          },
+          {
+            "nodeId": "jest-get-type@28.0.2"
+          },
+          {
+            "nodeId": "jest-util@28.1.3"
+          },
+          {
+            "nodeId": "pretty-format@28.1.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
         "nodeId": "jest-runtime@28.1.3",
         "pkgId": "jest-runtime@28.1.3",
         "deps": [
@@ -51423,7 +51785,7 @@
             "nodeId": "@jest/source-map@28.1.2"
           },
           {
-            "nodeId": "@jest/test-result@27.5.1"
+            "nodeId": "@jest/test-result@28.1.3"
           },
           {
             "nodeId": "@jest/transform@28.1.3"
@@ -51468,7 +51830,7 @@
             "nodeId": "jest-snapshot@28.1.3"
           },
           {
-            "nodeId": "jest-util@27.5.1"
+            "nodeId": "jest-util@28.1.3"
           },
           {
             "nodeId": "slash@3.0.0"
@@ -51540,7 +51902,7 @@
             "nodeId": "jest-pnp-resolver@1.2.3"
           },
           {
-            "nodeId": "jest-util@27.5.1"
+            "nodeId": "jest-util@28.1.3"
           },
           {
             "nodeId": "jest-validate@28.1.3"

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/different-versions/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/different-versions/expected.json
@@ -1,0 +1,485 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "npm"
+  },
+  "pkgs": [
+    {
+      "id": "test-repo@1.0.0",
+      "info": {
+        "name": "test-repo",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "gauge@2.7.4",
+      "info": {
+        "name": "gauge",
+        "version": "2.7.4"
+      }
+    },
+    {
+      "id": "aproba@1.2.0",
+      "info": {
+        "name": "aproba",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "console-control-strings@1.1.0",
+      "info": {
+        "name": "console-control-strings",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "has-unicode@2.0.1",
+      "info": {
+        "name": "has-unicode",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "object-assign@4.1.1",
+      "info": {
+        "name": "object-assign",
+        "version": "4.1.1"
+      }
+    },
+    {
+      "id": "signal-exit@3.0.7",
+      "info": {
+        "name": "signal-exit",
+        "version": "3.0.7"
+      }
+    },
+    {
+      "id": "string-width@1.0.2",
+      "info": {
+        "name": "string-width",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "code-point-at@1.1.0",
+      "info": {
+        "name": "code-point-at",
+        "version": "1.1.0"
+      }
+    },
+    {
+      "id": "is-fullwidth-code-point@1.0.0",
+      "info": {
+        "name": "is-fullwidth-code-point",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "number-is-nan@1.0.1",
+      "info": {
+        "name": "number-is-nan",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "strip-ansi@3.0.1",
+      "info": {
+        "name": "strip-ansi",
+        "version": "3.0.1"
+      }
+    },
+    {
+      "id": "ansi-regex@2.1.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "wide-align@1.1.5",
+      "info": {
+        "name": "wide-align",
+        "version": "1.1.5"
+      }
+    },
+    {
+      "id": "wrap-ansi@6.2.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "6.2.0"
+      }
+    },
+    {
+      "id": "ansi-styles@4.3.0",
+      "info": {
+        "name": "ansi-styles",
+        "version": "4.3.0"
+      }
+    },
+    {
+      "id": "color-convert@2.0.1",
+      "info": {
+        "name": "color-convert",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "color-name@1.1.4",
+      "info": {
+        "name": "color-name",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "string-width@4.2.3",
+      "info": {
+        "name": "string-width",
+        "version": "4.2.3"
+      }
+    },
+    {
+      "id": "emoji-regex@8.0.0",
+      "info": {
+        "name": "emoji-regex",
+        "version": "8.0.0"
+      }
+    },
+    {
+      "id": "is-fullwidth-code-point@3.0.0",
+      "info": {
+        "name": "is-fullwidth-code-point",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "strip-ansi@6.0.1",
+      "info": {
+        "name": "strip-ansi",
+        "version": "6.0.1"
+      }
+    },
+    {
+      "id": "ansi-regex@5.0.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "5.0.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "test-repo@1.0.0",
+        "deps": [
+          {
+            "nodeId": "gauge@2.7.4"
+          },
+          {
+            "nodeId": "wrap-ansi@6.2.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "gauge@2.7.4",
+        "pkgId": "gauge@2.7.4",
+        "deps": [
+          {
+            "nodeId": "aproba@1.2.0"
+          },
+          {
+            "nodeId": "console-control-strings@1.1.0"
+          },
+          {
+            "nodeId": "has-unicode@2.0.1"
+          },
+          {
+            "nodeId": "object-assign@4.1.1"
+          },
+          {
+            "nodeId": "signal-exit@3.0.7"
+          },
+          {
+            "nodeId": "string-width@1.0.2"
+          },
+          {
+            "nodeId": "strip-ansi@3.0.1"
+          },
+          {
+            "nodeId": "wide-align@1.1.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "aproba@1.2.0",
+        "pkgId": "aproba@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "console-control-strings@1.1.0",
+        "pkgId": "console-control-strings@1.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-unicode@2.0.1",
+        "pkgId": "has-unicode@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object-assign@4.1.1",
+        "pkgId": "object-assign@4.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "signal-exit@3.0.7",
+        "pkgId": "signal-exit@3.0.7",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@1.0.2",
+        "pkgId": "string-width@1.0.2",
+        "deps": [
+          {
+            "nodeId": "code-point-at@1.1.0"
+          },
+          {
+            "nodeId": "is-fullwidth-code-point@1.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@3.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "code-point-at@1.1.0",
+        "pkgId": "code-point-at@1.1.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-fullwidth-code-point@1.0.0",
+        "pkgId": "is-fullwidth-code-point@1.0.0",
+        "deps": [
+          {
+            "nodeId": "number-is-nan@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "number-is-nan@1.0.1",
+        "pkgId": "number-is-nan@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@3.0.1",
+        "pkgId": "strip-ansi@3.0.1",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@2.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@2.1.1",
+        "pkgId": "ansi-regex@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wide-align@1.1.5",
+        "pkgId": "wide-align@1.1.5",
+        "deps": [
+          {
+            "nodeId": "string-width@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrap-ansi@6.2.0",
+        "pkgId": "wrap-ansi@6.2.0",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@4.3.0"
+          },
+          {
+            "nodeId": "string-width@4.2.3"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-styles@4.3.0",
+        "pkgId": "ansi-styles@4.3.0",
+        "deps": [
+          {
+            "nodeId": "color-convert@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-convert@2.0.1",
+        "pkgId": "color-convert@2.0.1",
+        "deps": [
+          {
+            "nodeId": "color-name@1.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-name@1.1.4",
+        "pkgId": "color-name@1.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@4.2.3",
+        "pkgId": "string-width@4.2.3",
+        "deps": [
+          {
+            "nodeId": "emoji-regex@8.0.0"
+          },
+          {
+            "nodeId": "is-fullwidth-code-point@3.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "emoji-regex@8.0.0",
+        "pkgId": "emoji-regex@8.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-fullwidth-code-point@3.0.0",
+        "pkgId": "is-fullwidth-code-point@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@6.0.1",
+        "pkgId": "strip-ansi@6.0.1",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@5.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@5.0.1",
+        "pkgId": "ansi-regex@5.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/different-versions/package-lock.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/different-versions/package-lock.json
@@ -1,0 +1,407 @@
+{
+  "name": "test-repo",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-repo",
+      "version": "1.0.0",
+      "dependencies": {
+        "gauge": "2.7.4",
+        "wrap-ansi": "6.2.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/different-versions/package.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/different-versions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-repo",
+  "version": "1.0.0",
+  "dependencies": {
+    "gauge": "2.7.4",
+    "wrap-ansi": "6.2.0"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/goof/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/goof/expected.json
@@ -327,6 +327,13 @@
       }
     },
     {
+      "id": "ee-first@1.1.0",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.0"
+      }
+    },
+    {
       "id": "fresh@0.2.4",
       "info": {
         "name": "fresh",
@@ -1335,6 +1342,20 @@
       }
     },
     {
+      "id": "argparse@1.0.10",
+      "info": {
+        "name": "argparse",
+        "version": "1.0.10"
+      }
+    },
+    {
+      "id": "sprintf-js@1.0.3",
+      "info": {
+        "name": "sprintf-js",
+        "version": "1.0.3"
+      }
+    },
+    {
       "id": "esprima@2.7.3",
       "info": {
         "name": "esprima",
@@ -1836,20 +1857,6 @@
       "info": {
         "name": "js-yaml",
         "version": "3.14.1"
-      }
-    },
-    {
-      "id": "argparse@1.0.10",
-      "info": {
-        "name": "argparse",
-        "version": "1.0.10"
-      }
-    },
-    {
-      "id": "sprintf-js@1.0.3",
-      "info": {
-        "name": "sprintf-js",
-        "version": "1.0.3"
       }
     },
     {
@@ -3830,9 +3837,19 @@
         "pkgId": "on-finished@2.2.1",
         "deps": [
           {
-            "nodeId": "ee-first@1.0.5"
+            "nodeId": "ee-first@1.1.0"
           }
         ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.0",
+        "pkgId": "ee-first@1.1.0",
+        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"
@@ -5852,12 +5869,36 @@
         "pkgId": "js-yaml@3.6.1",
         "deps": [
           {
-            "nodeId": "argparse@2.0.1"
+            "nodeId": "argparse@1.0.10"
           },
           {
             "nodeId": "esprima@2.7.3"
           }
         ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "argparse@1.0.10",
+        "pkgId": "argparse@1.0.10",
+        "deps": [
+          {
+            "nodeId": "sprintf-js@1.0.3"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "sprintf-js@1.0.3",
+        "pkgId": "sprintf-js@1.0.3",
+        "deps": [],
         "info": {
           "labels": {
             "scope": "prod"
@@ -6870,30 +6911,6 @@
         }
       },
       {
-        "nodeId": "argparse@1.0.10",
-        "pkgId": "argparse@1.0.10",
-        "deps": [
-          {
-            "nodeId": "sprintf-js@1.0.3"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "sprintf-js@1.0.3",
-        "pkgId": "sprintf-js@1.0.3",
-        "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
         "nodeId": "esprima@4.0.1",
         "pkgId": "esprima@4.0.1",
         "deps": [],
@@ -7729,10 +7746,10 @@
             "nodeId": "inherits@2.0.1"
           },
           {
-            "nodeId": "minimatch@3.1.2"
+            "nodeId": "minimatch@3.0.0"
           },
           {
-            "nodeId": "once@1.4.0"
+            "nodeId": "once@1.3.3"
           },
           {
             "nodeId": "path-is-absolute@1.0.0"

--- a/test/jest/dep-graph-builders/npm-lock-v2.test.ts
+++ b/test/jest/dep-graph-builders/npm-lock-v2.test.ts
@@ -12,6 +12,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
         'cyclic-dep',
         'deeply-nested-packages',
         'deeply-scoped',
+        'different-versions',
       ])('[simple tests] project: %s ', (fixtureName) => {
         test('matches expected', async () => {
           const pkgJsonContent = readFileSync(


### PR DESCRIPTION
### What this does

This fixes a bug discovered [in this PR](https://github.com/snyk/nodejs-lockfile-parser/pull/202/files/ca913ff58600c1894085ac11cbe8d98724b07196#diff-81f70fb04fd56113a23046eb84b767b2c22af26fb791de3e071b1ecce7170fce) and separates as to release it as it's own fix, as it provides value on it's own.