### PR TITLE
fix: stop assumption that local pkgs are in workspaces

### DIFF
--- a/lib/dep-graph-builders/npm-lock-v2/index.ts
+++ b/lib/dep-graph-builders/npm-lock-v2/index.ts
@@ -201,10 +201,14 @@ const getChildNode = (
 
   let depData = pkgs[childNodeKey];
 
-  const resolvedToWorkspace = () => {
+  const resolvedToWorkspace = (): boolean => {
     // Workspaces can be set as an array, or as an object
     // { packages: [] }, this can be checked in
     // https://github.com/npm/map-workspaces/blob/ff82968a3dbb78659fb7febfce4841bf58c514de/lib/index.js#L27-L41
+    if (pkgs['']['workspaces'] === undefined) {
+      return false;
+    }
+
     const workspacesDeclaration = Array.isArray(
       pkgs['']['workspaces']['packages'],
     )

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/local-pkg-without-workspaces/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/local-pkg-without-workspaces/expected.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "npm"
+  },
+  "pkgs": [
+    {
+      "id": "local-pkg-without-workspace@1.0.0",
+      "info": {
+        "name": "local-pkg-without-workspace",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@scope/my-local-pkg@",
+      "info": {
+        "name": "@scope/my-local-pkg"
+      }
+    },
+    {
+      "id": "react@18.0.0",
+      "info": {
+        "name": "react",
+        "version": "18.0.0"
+      }
+    },
+    {
+      "id": "loose-envify@1.4.0",
+      "info": {
+        "name": "loose-envify",
+        "version": "1.4.0"
+      }
+    },
+    {
+      "id": "js-tokens@4.0.0",
+      "info": {
+        "name": "js-tokens",
+        "version": "4.0.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "local-pkg-without-workspace@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@scope/my-local-pkg@undefined"
+          },
+          {
+            "nodeId": "react@18.0.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "@scope/my-local-pkg@undefined",
+        "pkgId": "@scope/my-local-pkg@",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "react@18.0.0",
+        "pkgId": "react@18.0.0",
+        "deps": [
+          {
+            "nodeId": "loose-envify@1.4.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "loose-envify@1.4.0",
+        "pkgId": "loose-envify@1.4.0",
+        "deps": [
+          {
+            "nodeId": "js-tokens@4.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "js-tokens@4.0.0",
+        "pkgId": "js-tokens@4.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/local-pkg-without-workspaces/local-pkg/package.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/local-pkg-without-workspaces/local-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@scope/my-local-pkg",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "5.0.0"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/local-pkg-without-workspaces/package-lock.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/local-pkg-without-workspaces/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "local-pkg-without-workspace",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "local-pkg-without-workspace",
+      "version": "1.0.0",
+      "dependencies": {
+        "@scope/my-local-pkg": "file:../local-pkg",
+        "react": "18.0.0"
+      }
+    },
+    "../local-pkg": {},
+    "node_modules/@scope/my-local-pkg": {
+      "resolved": "../local-pkg",
+      "link": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@scope/my-local-pkg": {
+      "version": "file:../local-pkg"
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "react": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    }
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/local-pkg-without-workspaces/package.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/local-pkg-without-workspaces/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "local-pkg-without-workspace",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@scope/my-local-pkg": "file:../local-pkg",
+    "react": "18.0.0"
+  }
+}

--- a/test/jest/dep-graph-builders/npm-lock-v2.test.ts
+++ b/test/jest/dep-graph-builders/npm-lock-v2.test.ts
@@ -13,6 +13,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
         'deeply-nested-packages',
         'deeply-scoped',
         'different-versions',
+        'local-pkg-without-workspaces',
       ])('[simple tests] project: %s ', (fixtureName) => {
         test('matches expected', async () => {
           const pkgJsonContent = readFileSync(


### PR DESCRIPTION
### What this does

This fixes a regression introduced by this change https://github.com/snyk/nodejs-lockfile-parser/compare/v1.52.2...v1.52.3 where an assumption was made that we would always have a workspace object in the lockfile when we have a `link` in dependency data.