### PR TITLE
fix: pnpm workspaces should return everything if config file empty

### DIFF
--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -202,7 +202,7 @@ export function getPnpmWorkspaces(workspacesYamlFile: string): string[] {
       schema: FAILSAFE_SCHEMA,
     });
 
-    if (rawPnpmWorkspacesYaml.packages) {
+    if (rawPnpmWorkspacesYaml && rawPnpmWorkspacesYaml.packages) {
       if (Array.isArray(rawPnpmWorkspacesYaml.packages)) {
         return rawPnpmWorkspacesYaml.packages;
       }


### PR DESCRIPTION
### What this does

If the pnpm-workspace.yaml  file is empty, all packages of all subdirectories are returned, instead of throwing an error - https://pnpm.io/pnpm-workspace_yaml

