### PR TITLE
fix: avoid redos by replacing regex with string split

### DIFF
--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v6.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v6.ts
@@ -71,8 +71,7 @@ export class LockfileV6Parser extends PnpmLockfileParser {
   // Dependency path and versions include transitive peer dependencies encapsulated in dependencies
   // e.g. '/cdktf-cli@0.20.3(ink@3.2.0)(react@17.0.2)' -> cdktf-cli@0.20.3
   public excludeTransPeerDepsVersions(fullVersionStr: string): string {
-    const match = fullVersionStr.match(/([^)]*)\(/);
-    return match?.[1] ?? fullVersionStr;
+    return fullVersionStr.split('(')[0];
   }
 
   public static isAbsoluteDepenencyPath(dependencyPath: string): boolean {


### PR DESCRIPTION
### What this does

Instead of matching (..) groups, which has a redos vulnerability, split string by "(". This gets the string till the first occurence of "(".
This works just fine because a package name cannot have "(" in its name (it shows up just as a separator).
