### PR TITLE
feat: normalize pnpm importers on parse

### DIFF
--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-parser.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-parser.ts
@@ -5,6 +5,7 @@ import {
   ParsedDepPath,
   PnpmDepPath,
   PnpmDeps,
+  PnpmImporters,
   PnpmLockPkg,
 } from '../types';
 import { valid } from 'semver';
@@ -19,6 +20,7 @@ export abstract class PnpmLockfileParser {
   public optionalDependencies: Record<string, any>;
   public peerDependencies: Record<string, any>;
   public extractedPackages: NormalisedPnpmPkgs;
+  public importers: PnpmImporters;
   public workspaceArgs?: PnpmWorkspaceArgs;
 
   public constructor(rawPnpmLock: any, workspaceArgs?: PnpmWorkspaceArgs) {
@@ -32,6 +34,7 @@ export abstract class PnpmLockfileParser {
     this.optionalDependencies = depsRoot.optionalDependencies || {};
     this.peerDependencies = depsRoot.peerDependencies || {};
     this.extractedPackages = this.extractPackages();
+    this.importers = this.normaliseImporters(rawPnpmLock);
   }
 
   public isWorkspaceLockfile() {
@@ -204,4 +207,7 @@ export abstract class PnpmLockfileParser {
   // v5 example: '/@babel/preset-typescript/7.12.13_@babel+core@7.12.13'
   // v6 example: '/cdktf-cli@0.20.3(ink@3.2.0)(react@17.0.2)'
   abstract excludeTransPeerDepsVersions(fullVersionStr: string): string;
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  abstract normaliseImporters(rawPnpmLock: any): PnpmImporters;
 }

--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v6.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v6.ts
@@ -1,5 +1,5 @@
 import { PnpmWorkspaceArgs } from '../../types';
-import { ParsedDepPath, PnpmDeps } from '../types';
+import { ParsedDepPath, PnpmDeps, PnpmImporters } from '../types';
 import { PnpmLockfileParser } from './lockfile-parser';
 
 export class LockfileV6Parser extends PnpmLockfileParser {
@@ -76,5 +76,36 @@ export class LockfileV6Parser extends PnpmLockfileParser {
 
   public static isAbsoluteDepenencyPath(dependencyPath: string): boolean {
     return dependencyPath[0] !== '/';
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public normaliseImporters(rawPnpmLock: any): PnpmImporters {
+    if (!('importers' in rawPnpmLock)) {
+      return {};
+    }
+
+    const rawImporters = rawPnpmLock.importers as Record<
+      string,
+      { dependencies?: Record<string, { version: string }> }
+    >;
+    return Object.entries(rawImporters).reduce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (acc, [key, val]) => {
+        // No deps case
+        if (!('dependencies' in val)) {
+          return { ...acc, [key]: {} };
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const deps = val.dependencies!;
+        const depsNormalized = Object.fromEntries(
+          Object.entries(deps).map(([depName, depInfo]) => {
+            return [depName, depInfo.version];
+          }),
+        );
+        return { ...acc, [key]: depsNormalized };
+      },
+      {},
+    );
   }
 }

--- a/lib/dep-graph-builders/pnpm/types.ts
+++ b/lib/dep-graph-builders/pnpm/types.ts
@@ -57,3 +57,12 @@ export type ParsedDepPath = {
   name?: string;
   version?: string;
 };
+
+export type PnpmWorkspacePath = string;
+export type DepName = string;
+export type DepVersion = string;
+export type PnpmImporter = Record<DepName, DepVersion>;
+export type PnpmImporters = Record<
+  PnpmWorkspacePath,
+  Record<DepName, DepVersion>
+>;


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [ ] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [ ] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

The parser for pnpm lockfiles now normalises the importers object on construction/parse. This is useful for inspecting information around packages in a workspace without multiple parsers.

If not a workspace lockfile then the importers will be empty and the `importers` field on the parser will be an empty object.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [SC-XXXX]()
- [Link to documentation]()

### Screenshots

_Visuals that may help the reviewer_
