### PR TITLE
fix: replacing micromatch with minimatch due to CVEs

### DIFF
--- a/lib/dep-graph-builders/npm-lock-v2/index.ts
+++ b/lib/dep-graph-builders/npm-lock-v2/index.ts
@@ -4,8 +4,8 @@ import {
   PackageJsonBase,
   ProjectParseOptions,
 } from '../types';
-import { extractPkgsFromNpmLockV2 } from './extract-npm-lock-v2-pkgs';
 import type { NpmLockPkg } from './extract-npm-lock-v2-pkgs';
+import { extractPkgsFromNpmLockV2 } from './extract-npm-lock-v2-pkgs';
 import { DepGraph, DepGraphBuilder } from '@snyk/dep-graph';
 import {
   addPkgNodeToGraph,
@@ -18,9 +18,9 @@ import { OutOfSyncError } from '../../errors';
 import { LockfileType } from '../../parsers';
 
 import * as semver from 'semver';
-import * as micromatch from 'micromatch';
 import * as pathUtil from 'path';
 import { eventLoopSpinner } from 'event-loop-spinner';
+import * as multimatch from 'multimatch';
 
 export { extractPkgsFromNpmLockV2 };
 
@@ -249,7 +249,7 @@ const getChildNode = (
     const normalizedWorkspacesDefn = workspacesDeclaration.map((p) => {
       return pathUtil.normalize(p).replace(/\\/g, '/');
     });
-    return micromatch.isMatch(fixedResolvedPath, normalizedWorkspacesDefn);
+    return multimatch([fixedResolvedPath], normalizedWorkspacesDefn).length > 0;
   };
 
   // Check for workspaces

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   ],
   "homepage": "https://github.com/snyk/nodejs-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/error-catalog-nodejs-public": "^5.16.0",
     "@snyk/dep-graph": "^2.3.0",
+    "@snyk/error-catalog-nodejs-public": "^5.16.0",
     "@snyk/graphlib": "2.1.9-patch.3",
     "@yarnpkg/core": "^2.4.0",
     "@yarnpkg/lockfile": "^1.1.0",
@@ -43,7 +43,7 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.isempty": "^4.4.0",
     "lodash.topairs": "^4.3.0",
-    "micromatch": "^4.0.5",
+    "multimatch": "5.0.0",
     "p-map": "^4.0.0",
     "semver": "^7.6.0",
     "snyk-config": "^5.0.0",


### PR DESCRIPTION
There's a bunfight going on over at Micromatch, to which I won't link, as it will show up in their conversation, but the link is https://github.com/micromatch/micromatch and the issue is `243` in case you're interested.

In any event that looks like it will never be sorted any time soon, so let's just fix the paperwork the easy way.