### PR TITLE
fix: [OSM-1122] handle projects cycles in workspace

### DIFF
--- a/lib/dep-graph-builders/pnpm/parse-project.ts
+++ b/lib/dep-graph-builders/pnpm/parse-project.ts
@@ -29,6 +29,12 @@ export const parsePnpmProject = async (
   // Lockfile V9 simple project has the root importer
   if (lockFileParser.lockFileVersion.startsWith('9')) {
     importer = '.';
+    lockFileParser.workspaceArgs = {
+      projectsVersionMap: {
+        '.': { name: pkgJson.name, version: pkgJson.version },
+      },
+      isWorkspace: true,
+    };
   }
 
   const depgraph = await buildDepGraphPnpm(

--- a/lib/dep-graph-builders/pnpm/parse-workspace.ts
+++ b/lib/dep-graph-builders/pnpm/parse-workspace.ts
@@ -28,8 +28,10 @@ function computeProjectVersionMaps(root: string, targets: string[]) {
 
     try {
       const parsedPkgJson = parsePkgJson(packageJson.content);
-      const projectVersion = parsedPkgJson.version;
-      projectsVersionMap[target] = projectVersion;
+      projectsVersionMap[target] = {
+        version: parsedPkgJson.version,
+        name: parsedPkgJson.name,
+      };
     } catch (err: any) {
       debug(
         `Error getting version for project: ${packageJsonFileName}. ERROR: ${err}`,

--- a/lib/dep-graph-builders/types.ts
+++ b/lib/dep-graph-builders/types.ts
@@ -84,11 +84,17 @@ export type Yarn1DepGraphBuildOptions = {
 
 export type PnpmWorkspaceArgs = {
   isWorkspace: boolean;
-  projectsVersionMap: Record<string, string>;
+  projectsVersionMap: Record<string, PnpmProject>;
+};
+
+export type PnpmProject = {
+  name: string;
+  version: string;
 };
 
 export type PnpmProjectParseOptions = {
   includeDevDeps: boolean;
+  includePeerDeps?: boolean;
   includeOptionalDeps: boolean;
   strictOutOfSync: boolean;
   pruneWithinTopLevelDeps: boolean;

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/expected.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/root@0.0.0:pruned",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/root",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "send": "0.17.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/pnpm-lock.yaml
@@ -1,0 +1,156 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers:
+      '@test/react': workspace:*
+      send: 0.17.1
+    dependencies:
+      '@test/react': link:shared/react
+      send: 0.17.1
+
+  shared/react:
+    specifiers:
+      '@test/root': workspace:*
+      debug: 4.3.1
+    dependencies:
+      '@test/root': link:../..
+      debug: 4.3.1
+
+packages:
+
+  /debug/2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
+  /debug/4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
+  /depd/1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /destroy/1.0.4:
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
+    dev: false
+
+  /ee-first/1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
+
+  /encodeurl/1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /escape-html/1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
+  /etag/1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh/0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /http-errors/1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+    dev: false
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /mime/1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
+  /ms/2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
+
+  /ms/2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+    dev: false
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: false
+
+  /on-finished/2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
+  /range-parser/1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /send/0.17.1:
+    resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.7.3
+      mime: 1.6.0
+      ms: 2.1.1
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /setprototypeof/1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+    dev: false
+
+  /statuses/1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /toidentifier/1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+    dev: false

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/pnpm-workspace.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "shared/**"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/shared/react/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/shared/react/expected.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/root@0.0.0",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/shared/react/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/shared/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/react",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/root": "workspace:*",
+    "debug": "4.3.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/expected.json
@@ -1,0 +1,822 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/root",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "send": "0.17.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/pnpm-lock.yaml
@@ -1,0 +1,241 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers:
+      '@test/react': workspace:*
+      send: 0.17.1
+    dependencies:
+      '@test/react': link:shared/react
+      send: 0.17.1
+
+  shared/backend:
+    specifiers:
+      '@test/react': workspace:*
+      body-parser: https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz
+    dependencies:
+      '@test/react': link:../react
+      body-parser: '@github.com/expressjs/body-parser/archive/1.9.0.tar.gz'
+
+  shared/react:
+    specifiers:
+      '@test/backend': workspace:*
+      debug: 4.3.1
+    dependencies:
+      '@test/backend': link:../backend
+      debug: 4.3.1
+
+packages:
+
+  /bytes/1.0.0:
+    resolution: {integrity: sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==}
+    dev: false
+
+  /debug/2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
+  /debug/4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
+  /depd/1.0.1:
+    resolution: {integrity: sha512-OEWAMbCkK9IWQ8pfTvHBhCSqHgR+sk5pbiYqq0FqfARG4Cy+cRsCbITx6wh5pcsmfBPiJAcbd98tfdz5fnBbag==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /depd/1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /destroy/1.0.4:
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
+    dev: false
+
+  /ee-first/1.0.5:
+    resolution: {integrity: sha512-+FCut34oNiJD2jD+YL/onRxOHF5ut3xOGgTIyEIOdYfun8AexYhEyurzv9izwhTft1Z7pdy4VlTq51K/sIsQRA==}
+    dev: false
+
+  /ee-first/1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
+
+  /encodeurl/1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /escape-html/1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
+  /etag/1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh/0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /http-errors/1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+    dev: false
+
+  /iconv-lite/0.4.4:
+    resolution: {integrity: sha512-BnjNp13aZpK4WBGbmjaNHN2MCp3P850n8zd/JLinQJ8Lsnq2Br4o2467C2waMsY5kr7Z41SL1gEqh8Vbfzg15A==}
+    engines: {node: '>=0.8.0'}
+    dev: false
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /media-typer/0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-db/1.12.0:
+    resolution: {integrity: sha512-5aMAW7I4jZoZB27fXRuekqc4DVvJ7+hM8UcWrNj2mqibE54gXgPSonBYBdQW5hyaVNGmiYjY0ZMqn9fBefWYvA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types/2.0.14:
+    resolution: {integrity: sha512-2ZHUEstNkIf2oTWgtODr6X0Cc4Ns/RN/hktdozndiEhhAC2wxXejF1FH0XLHTEImE9h6gr/tcnr3YOnSGsxc7Q==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.12.0
+    dev: false
+
+  /mime/1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
+  /ms/2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
+
+  /ms/2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+    dev: false
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: false
+
+  /on-finished/2.1.0:
+    resolution: {integrity: sha512-33+g6TZkplndl+2k2VNO1YphX5hm79DGhBP6TJcDI9o1sCFbUvO2bgxPdGanIFqZK4su6OVLwPHY9GkLQrojgA==}
+    dependencies:
+      ee-first: 1.0.5
+    dev: false
+
+  /on-finished/2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
+  /qs/2.2.4:
+    resolution: {integrity: sha512-ptau9CngYR/IimcThDkAs7LzlZhxo92RiMHtLbOq3R6u9iDkixdSysaAVaZpYByrXWWantEJ4fVPl0xR2McSCQ==}
+    dev: false
+
+  /range-parser/1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /raw-body/1.3.0:
+    resolution: {integrity: sha512-iuI1bOSi9tEmVCrXq02ZysXatTrhAu+fSo7XOQHhMo4g87dSy9YB2W/9Udwhz0bPpFk4UcoLhjrHgpPbRD3ktA==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      bytes: 1.0.0
+      iconv-lite: 0.4.4
+    dev: false
+
+  /send/0.17.1:
+    resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.7.3
+      mime: 1.6.0
+      ms: 2.1.1
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /setprototypeof/1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+    dev: false
+
+  /statuses/1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /toidentifier/1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+    dev: false
+
+  /type-is/1.5.7:
+    resolution: {integrity: sha512-of68V0oUmVH4thGc1cLR3sKdICPsaL7kzpYc7FX1pcagY4eIllhyMqQcoOq289f+xj2orm8oPWwsCwxiCgVJbQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.0.14
+    dev: false
+
+  '@github.com/expressjs/body-parser/archive/1.9.0.tar.gz':
+    resolution: {tarball: https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz}
+    name: body-parser
+    version: 1.9.0
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 1.0.0
+      depd: 1.0.1
+      iconv-lite: 0.4.4
+      media-typer: 0.3.0
+      on-finished: 2.1.0
+      qs: 2.2.4
+      raw-body: 1.3.0
+      type-is: 1.5.7
+    dev: false

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/pnpm-workspace.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "shared/**"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/backend/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/backend/expected.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0:pruned",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/backend/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/backend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/backend",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "body-parser": "https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/react/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/react/expected.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/backend@1.0.0",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/react/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/react",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/backend": "workspace:*",
+    "debug": "4.3.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/expected.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/root@0.0.0:pruned",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/root",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "send": "0.17.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/pnpm-lock.yaml
@@ -1,0 +1,162 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@test/react':
+        specifier: workspace:*
+        version: link:shared/react
+      send:
+        specifier: 0.17.1
+        version: 0.17.1
+
+  shared/react:
+    dependencies:
+      '@test/root':
+        specifier: workspace:*
+        version: link:../..
+      debug:
+        specifier: 4.3.1
+        version: 4.3.1
+
+packages:
+
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
+  /debug@4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
+  /depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /destroy@1.0.4:
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
+    dev: false
+
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
+
+  /encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /http-errors@1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+    dev: false
+
+  /inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
+
+  /ms@2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+    dev: false
+
+  /ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: false
+
+  /on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
+  /range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /send@0.17.1:
+    resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.7.3
+      mime: 1.6.0
+      ms: 2.1.1
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /setprototypeof@1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+    dev: false
+
+  /statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /toidentifier@1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+    dev: false

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/pnpm-workspace.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "shared/**"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/shared/react/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/shared/react/expected.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/root@0.0.0",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/shared/react/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/shared/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/react",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/root": "workspace:*",
+    "debug": "4.3.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/expected.json
@@ -1,0 +1,822 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/root",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "send": "0.17.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/pnpm-lock.yaml
@@ -1,0 +1,248 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@test/react':
+        specifier: workspace:*
+        version: link:shared/react
+      send:
+        specifier: 0.17.1
+        version: 0.17.1
+
+  shared/backend:
+    dependencies:
+      '@test/react':
+        specifier: workspace:*
+        version: link:../react
+      body-parser:
+        specifier: https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz
+        version: '@github.com/expressjs/body-parser/archive/1.9.0.tar.gz'
+
+  shared/react:
+    dependencies:
+      '@test/backend':
+        specifier: workspace:*
+        version: link:../backend
+      debug:
+        specifier: 4.3.1
+        version: 4.3.1
+
+packages:
+
+  /bytes@1.0.0:
+    resolution: {integrity: sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==}
+    dev: false
+
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
+  /debug@4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
+  /depd@1.0.1:
+    resolution: {integrity: sha512-OEWAMbCkK9IWQ8pfTvHBhCSqHgR+sk5pbiYqq0FqfARG4Cy+cRsCbITx6wh5pcsmfBPiJAcbd98tfdz5fnBbag==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /destroy@1.0.4:
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
+    dev: false
+
+  /ee-first@1.0.5:
+    resolution: {integrity: sha512-+FCut34oNiJD2jD+YL/onRxOHF5ut3xOGgTIyEIOdYfun8AexYhEyurzv9izwhTft1Z7pdy4VlTq51K/sIsQRA==}
+    dev: false
+
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
+
+  /encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /http-errors@1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+    dev: false
+
+  /iconv-lite@0.4.4:
+    resolution: {integrity: sha512-BnjNp13aZpK4WBGbmjaNHN2MCp3P850n8zd/JLinQJ8Lsnq2Br4o2467C2waMsY5kr7Z41SL1gEqh8Vbfzg15A==}
+    engines: {node: '>=0.8.0'}
+    dev: false
+
+  /inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-db@1.12.0:
+    resolution: {integrity: sha512-5aMAW7I4jZoZB27fXRuekqc4DVvJ7+hM8UcWrNj2mqibE54gXgPSonBYBdQW5hyaVNGmiYjY0ZMqn9fBefWYvA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@2.0.14:
+    resolution: {integrity: sha512-2ZHUEstNkIf2oTWgtODr6X0Cc4Ns/RN/hktdozndiEhhAC2wxXejF1FH0XLHTEImE9h6gr/tcnr3YOnSGsxc7Q==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.12.0
+    dev: false
+
+  /mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
+
+  /ms@2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+    dev: false
+
+  /ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: false
+
+  /on-finished@2.1.0:
+    resolution: {integrity: sha512-33+g6TZkplndl+2k2VNO1YphX5hm79DGhBP6TJcDI9o1sCFbUvO2bgxPdGanIFqZK4su6OVLwPHY9GkLQrojgA==}
+    dependencies:
+      ee-first: 1.0.5
+    dev: false
+
+  /on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
+  /qs@2.2.4:
+    resolution: {integrity: sha512-ptau9CngYR/IimcThDkAs7LzlZhxo92RiMHtLbOq3R6u9iDkixdSysaAVaZpYByrXWWantEJ4fVPl0xR2McSCQ==}
+    dev: false
+
+  /range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /raw-body@1.3.0:
+    resolution: {integrity: sha512-iuI1bOSi9tEmVCrXq02ZysXatTrhAu+fSo7XOQHhMo4g87dSy9YB2W/9Udwhz0bPpFk4UcoLhjrHgpPbRD3ktA==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      bytes: 1.0.0
+      iconv-lite: 0.4.4
+    dev: false
+
+  /send@0.17.1:
+    resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.7.3
+      mime: 1.6.0
+      ms: 2.1.1
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /setprototypeof@1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+    dev: false
+
+  /statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /toidentifier@1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+    dev: false
+
+  /type-is@1.5.7:
+    resolution: {integrity: sha512-of68V0oUmVH4thGc1cLR3sKdICPsaL7kzpYc7FX1pcagY4eIllhyMqQcoOq289f+xj2orm8oPWwsCwxiCgVJbQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.0.14
+    dev: false
+
+  '@github.com/expressjs/body-parser/archive/1.9.0.tar.gz':
+    resolution: {tarball: https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz}
+    name: body-parser
+    version: 1.9.0
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 1.0.0
+      depd: 1.0.1
+      iconv-lite: 0.4.4
+      media-typer: 0.3.0
+      on-finished: 2.1.0
+      qs: 2.2.4
+      raw-body: 1.3.0
+      type-is: 1.5.7
+    dev: false

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/pnpm-workspace.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "shared/**"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/backend/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/backend/expected.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0:pruned",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/backend/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/backend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/backend",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "body-parser": "https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/react/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/react/expected.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/backend@1.0.0",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/react/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/react",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/backend": "workspace:*",
+    "debug": "4.3.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/expected.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/root@0.0.0:pruned",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/root",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "send": "0.17.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/pnpm-lock.yaml
@@ -1,0 +1,185 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@test/react':
+        specifier: workspace:*
+        version: link:shared/react
+      send:
+        specifier: 0.17.1
+        version: 0.17.1
+
+  shared/react:
+    dependencies:
+      '@test/root':
+        specifier: workspace:*
+        version: link:../..
+      debug:
+        specifier: 4.3.1
+        version: 4.3.1
+
+packages:
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+
+  destroy@1.0.4:
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  http-errors@1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  send@0.17.1:
+    resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
+  toidentifier@1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+
+snapshots:
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  debug@4.3.1:
+    dependencies:
+      ms: 2.1.2
+
+  depd@1.1.2: {}
+
+  destroy@1.0.4: {}
+
+  ee-first@1.1.1: {}
+
+  encodeurl@1.0.2: {}
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  fresh@0.5.2: {}
+
+  http-errors@1.7.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+
+  inherits@2.0.4: {}
+
+  mime@1.6.0: {}
+
+  ms@2.0.0: {}
+
+  ms@2.1.1: {}
+
+  ms@2.1.2: {}
+
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
+  range-parser@1.2.1: {}
+
+  send@0.17.1:
+    dependencies:
+      debug: 2.6.9
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.7.3
+      mime: 1.6.0
+      ms: 2.1.1
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.1.1: {}
+
+  statuses@1.5.0: {}
+
+  toidentifier@1.0.0: {}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/pnpm-workspace.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "shared/**"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/shared/react/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/shared/react/expected.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/root@0.0.0",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/shared/react/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/shared/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/react",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/root": "workspace:*",
+    "debug": "4.3.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/expected.json
@@ -1,0 +1,822 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/root",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "send": "0.17.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/pnpm-lock.yaml
@@ -1,0 +1,282 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@test/react':
+        specifier: workspace:*
+        version: link:shared/react
+      send:
+        specifier: 0.17.1
+        version: 0.17.1
+
+  shared/backend:
+    dependencies:
+      '@test/react':
+        specifier: workspace:*
+        version: link:../react
+      body-parser:
+        specifier: https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz
+        version: https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz
+
+  shared/react:
+    dependencies:
+      '@test/backend':
+        specifier: workspace:*
+        version: link:../backend
+      debug:
+        specifier: 4.3.1
+        version: 4.3.1
+
+packages:
+
+  body-parser@https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz:
+    resolution: {tarball: https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz}
+    version: 1.9.0
+    engines: {node: '>= 0.8'}
+
+  bytes@1.0.0:
+    resolution: {integrity: sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@1.0.1:
+    resolution: {integrity: sha512-OEWAMbCkK9IWQ8pfTvHBhCSqHgR+sk5pbiYqq0FqfARG4Cy+cRsCbITx6wh5pcsmfBPiJAcbd98tfdz5fnBbag==}
+    engines: {node: '>= 0.6'}
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+
+  destroy@1.0.4:
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
+
+  ee-first@1.0.5:
+    resolution: {integrity: sha512-+FCut34oNiJD2jD+YL/onRxOHF5ut3xOGgTIyEIOdYfun8AexYhEyurzv9izwhTft1Z7pdy4VlTq51K/sIsQRA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  http-errors@1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+
+  iconv-lite@0.4.4:
+    resolution: {integrity: sha512-BnjNp13aZpK4WBGbmjaNHN2MCp3P850n8zd/JLinQJ8Lsnq2Br4o2467C2waMsY5kr7Z41SL1gEqh8Vbfzg15A==}
+    engines: {node: '>=0.8.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.12.0:
+    resolution: {integrity: sha512-5aMAW7I4jZoZB27fXRuekqc4DVvJ7+hM8UcWrNj2mqibE54gXgPSonBYBdQW5hyaVNGmiYjY0ZMqn9fBefWYvA==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.0.14:
+    resolution: {integrity: sha512-2ZHUEstNkIf2oTWgtODr6X0Cc4Ns/RN/hktdozndiEhhAC2wxXejF1FH0XLHTEImE9h6gr/tcnr3YOnSGsxc7Q==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  on-finished@2.1.0:
+    resolution: {integrity: sha512-33+g6TZkplndl+2k2VNO1YphX5hm79DGhBP6TJcDI9o1sCFbUvO2bgxPdGanIFqZK4su6OVLwPHY9GkLQrojgA==}
+
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+
+  qs@2.2.4:
+    resolution: {integrity: sha512-ptau9CngYR/IimcThDkAs7LzlZhxo92RiMHtLbOq3R6u9iDkixdSysaAVaZpYByrXWWantEJ4fVPl0xR2McSCQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@1.3.0:
+    resolution: {integrity: sha512-iuI1bOSi9tEmVCrXq02ZysXatTrhAu+fSo7XOQHhMo4g87dSy9YB2W/9Udwhz0bPpFk4UcoLhjrHgpPbRD3ktA==}
+    engines: {node: '>= 0.8.0'}
+
+  send@0.17.1:
+    resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
+  toidentifier@1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+
+  type-is@1.5.7:
+    resolution: {integrity: sha512-of68V0oUmVH4thGc1cLR3sKdICPsaL7kzpYc7FX1pcagY4eIllhyMqQcoOq289f+xj2orm8oPWwsCwxiCgVJbQ==}
+    engines: {node: '>= 0.6'}
+
+snapshots:
+
+  body-parser@https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz:
+    dependencies:
+      bytes: 1.0.0
+      depd: 1.0.1
+      iconv-lite: 0.4.4
+      media-typer: 0.3.0
+      on-finished: 2.1.0
+      qs: 2.2.4
+      raw-body: 1.3.0
+      type-is: 1.5.7
+
+  bytes@1.0.0: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  debug@4.3.1:
+    dependencies:
+      ms: 2.1.2
+
+  depd@1.0.1: {}
+
+  depd@1.1.2: {}
+
+  destroy@1.0.4: {}
+
+  ee-first@1.0.5: {}
+
+  ee-first@1.1.1: {}
+
+  encodeurl@1.0.2: {}
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  fresh@0.5.2: {}
+
+  http-errors@1.7.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+
+  iconv-lite@0.4.4: {}
+
+  inherits@2.0.4: {}
+
+  media-typer@0.3.0: {}
+
+  mime-db@1.12.0: {}
+
+  mime-types@2.0.14:
+    dependencies:
+      mime-db: 1.12.0
+
+  mime@1.6.0: {}
+
+  ms@2.0.0: {}
+
+  ms@2.1.1: {}
+
+  ms@2.1.2: {}
+
+  on-finished@2.1.0:
+    dependencies:
+      ee-first: 1.0.5
+
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
+  qs@2.2.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@1.3.0:
+    dependencies:
+      bytes: 1.0.0
+      iconv-lite: 0.4.4
+
+  send@0.17.1:
+    dependencies:
+      debug: 2.6.9
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.7.3
+      mime: 1.6.0
+      ms: 2.1.1
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.1.1: {}
+
+  statuses@1.5.0: {}
+
+  toidentifier@1.0.0: {}
+
+  type-is@1.5.7:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.0.14

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/pnpm-workspace.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "shared/**"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/backend/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/backend/expected.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@1.0.0",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0:pruned",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/backend/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/backend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/backend",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/react": "workspace:*",
+    "body-parser": "https://github.com/expressjs/body-parser/archive/1.9.0.tar.gz"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/react/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/react/expected.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/backend@1.0.0",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/react/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@test/react",
+  "version": "1.0.0",
+  "dependencies": {
+    "@test/backend": "workspace:*",
+    "debug": "4.3.1"
+  }
+}

--- a/test/jest/dep-graph-builders/pnpm-workspaces.test.ts
+++ b/test/jest/dep-graph-builders/pnpm-workspaces.test.ts
@@ -124,6 +124,135 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
           Buffer.from(JSON.stringify(expectedDepGraphJson)).toString('base64'),
         );
       });
+
+      it('cyclic workspace projects including root', async () => {
+        const fixtureName = 'workspace-cyclic-root';
+        const result = await parsePnpmWorkspace(
+          __dirname,
+          join(__dirname, `./fixtures/${lockFileVersionPath}/${fixtureName}`),
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: false,
+          },
+        );
+
+        const expectedDepGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/expected.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        const expectedSecondDepGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/react/expected.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(result[0].targetFile.replace(/\\/g, '/')).toEqual(
+          `fixtures/${lockFileVersionPath}/${fixtureName}/package.json`,
+        );
+        expect(
+          Buffer.from(JSON.stringify(result[0].depGraph)).toString('base64'),
+        ).toBe(
+          Buffer.from(JSON.stringify(expectedDepGraphJson)).toString('base64'),
+        );
+
+        expect(result[1].targetFile.replace(/\\/g, '/')).toEqual(
+          `fixtures/${lockFileVersionPath}/${fixtureName}/shared/react/package.json`,
+        );
+        expect(
+          Buffer.from(JSON.stringify(result[1].depGraph)).toString('base64'),
+        ).toBe(
+          Buffer.from(JSON.stringify(expectedSecondDepGraphJson)).toString(
+            'base64',
+          ),
+        );
+      });
+      it('cycle in workspace projects starting from the second level projects', async () => {
+        const fixtureName = 'workspace-cyclic';
+        const result = await parsePnpmWorkspace(
+          __dirname,
+          join(__dirname, `./fixtures/${lockFileVersionPath}/${fixtureName}`),
+          {
+            includeDevDeps: true,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: false,
+          },
+        );
+
+        const expectedRootGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/expected.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        const expectedBackendGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/backend/expected.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        const expectedReactGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/react/expected.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(result[0].targetFile.replace(/\\/g, '/')).toEqual(
+          `fixtures/${lockFileVersionPath}/${fixtureName}/package.json`,
+        );
+        expect(
+          Buffer.from(JSON.stringify(result[0].depGraph)).toString('base64'),
+        ).toBe(
+          Buffer.from(JSON.stringify(expectedRootGraphJson)).toString('base64'),
+        );
+
+        expect(result[1].targetFile.replace(/\\/g, '/')).toEqual(
+          `fixtures/${lockFileVersionPath}/${fixtureName}/shared/backend/package.json`,
+        );
+        expect(
+          Buffer.from(JSON.stringify(result[1].depGraph)).toString('base64'),
+        ).toBe(
+          Buffer.from(JSON.stringify(expectedBackendGraphJson)).toString(
+            'base64',
+          ),
+        );
+
+        expect(result[2].targetFile.replace(/\\/g, '/')).toEqual(
+          `fixtures/${lockFileVersionPath}/${fixtureName}/shared/react/package.json`,
+        );
+        expect(
+          Buffer.from(JSON.stringify(result[2].depGraph)).toString('base64'),
+        ).toBe(
+          Buffer.from(JSON.stringify(expectedReactGraphJson)).toString(
+            'base64',
+          ),
+        );
+      });
     });
   },
 );


### PR DESCRIPTION
### What this does

Problem 1 solved
Cyclic dependencies corresponding to projects inside a workspace were not handled correctly because resolving a local workspace project as a dependency of another enters a recursive normalisation function. 
Example of scneario
package.json - Project A
pnpm-lock.yaml
pnpm-workspace-yaml
packages/b/package.json - Project B
packages/c/package.json - Project C

,all being part of a workspace. A has B as a dependency. B has C as a dependency and C has B as a dependency.
See test workspace-cyclic.

Problem 2 solved
When building the dependency graph, if there is a cyclic dependency to the root package, this is now handled.
See test workspace-cyclic-root.

Some improvement: Projects of a workspace are not 'normalized' multiple times. For example, if a project B is a dependency of the root project, it is 'normalized' (dependencies are retrieved, along with name, version, etc.) once when the root is processed (as part of its dependencies) and stored. When B is handled as a project, it is not normalized anymore and just retrieved.

### Notes for the reviewer

See tests.

