### PR TITLE
fix: [OSM-1996] support pnpm packages aliases

### DIFF
--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-parser.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-parser.ts
@@ -22,6 +22,7 @@ export abstract class PnpmLockfileParser {
   public extractedPackages: NormalisedPnpmPkgs;
   public importers: PnpmImporters;
   public workspaceArgs?: PnpmWorkspaceArgs;
+  public resolvedPackages: Record<string, PnpmDepPath>;
 
   public constructor(rawPnpmLock: any, workspaceArgs?: PnpmWorkspaceArgs) {
     this.rawPnpmLock = rawPnpmLock;
@@ -29,6 +30,7 @@ export abstract class PnpmLockfileParser {
     this.workspaceArgs = workspaceArgs;
     this.packages = rawPnpmLock.packages || {};
     this.extractedPackages = {};
+    this.resolvedPackages = {};
     this.importers = this.normaliseImporters(rawPnpmLock);
   }
 
@@ -61,6 +63,7 @@ export abstract class PnpmLockfileParser {
           optionalDependencies: versionData.optionalDependencies || {},
         };
         packages[`${pkg.name}@${pkg.version}`] = pkg;
+        this.resolvedPackages[depPath] = `${pkg.name}@${pkg.version}`;
       },
     );
     return packages;

--- a/lib/dep-graph-builders/pnpm/utils.ts
+++ b/lib/dep-graph-builders/pnpm/utils.ts
@@ -20,11 +20,19 @@ export const getPnpmChildNode = (
   includeDevDeps: boolean,
   lockfileParser: PnpmLockfileParser,
 ): PnpmNode => {
-  const resolvedVersion =
+  let resolvedVersion =
     valid(depInfo.version) || depInfo.version === undefined
       ? depInfo.version
       : lockfileParser.excludeTransPeerDepsVersions(depInfo.version);
-  const childNodeKey = `${name}@${resolvedVersion}`;
+  let childNodeKey = `${name}@${resolvedVersion}`;
+  // For aliases, the version is the dependency path that
+  // shows up in the packages section of lockfiles
+  if (lockfileParser.resolvedPackages[depInfo.version]) {
+    childNodeKey = lockfileParser.resolvedPackages[depInfo.version];
+    const pkgData = pkgs[childNodeKey];
+    name = pkgData.name;
+    resolvedVersion = pkgData.version;
+  }
   if (!pkgs[childNodeKey]) {
     if (lockfileParser.isWorkspaceLockfile()) {
       return {

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/alias-sub-dependency/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/alias-sub-dependency/expected.json
@@ -1,0 +1,432 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "pnpm-alias@",
+      "info": {
+        "name": "pnpm-alias"
+      }
+    },
+    {
+      "id": "@isaacs/cliui@8.0.2",
+      "info": {
+        "name": "@isaacs/cliui",
+        "version": "8.0.2"
+      }
+    },
+    {
+      "id": "string-width@5.1.2",
+      "info": {
+        "name": "string-width",
+        "version": "5.1.2"
+      }
+    },
+    {
+      "id": "eastasianwidth@0.2.0",
+      "info": {
+        "name": "eastasianwidth",
+        "version": "0.2.0"
+      }
+    },
+    {
+      "id": "emoji-regex@9.2.2",
+      "info": {
+        "name": "emoji-regex",
+        "version": "9.2.2"
+      }
+    },
+    {
+      "id": "strip-ansi@7.1.0",
+      "info": {
+        "name": "strip-ansi",
+        "version": "7.1.0"
+      }
+    },
+    {
+      "id": "ansi-regex@6.0.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "6.0.1"
+      }
+    },
+    {
+      "id": "string-width@4.2.3",
+      "info": {
+        "name": "string-width",
+        "version": "4.2.3"
+      }
+    },
+    {
+      "id": "emoji-regex@8.0.0",
+      "info": {
+        "name": "emoji-regex",
+        "version": "8.0.0"
+      }
+    },
+    {
+      "id": "is-fullwidth-code-point@3.0.0",
+      "info": {
+        "name": "is-fullwidth-code-point",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "strip-ansi@6.0.1",
+      "info": {
+        "name": "strip-ansi",
+        "version": "6.0.1"
+      }
+    },
+    {
+      "id": "ansi-regex@5.0.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "5.0.1"
+      }
+    },
+    {
+      "id": "wrap-ansi@8.1.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "8.1.0"
+      }
+    },
+    {
+      "id": "ansi-styles@6.2.1",
+      "info": {
+        "name": "ansi-styles",
+        "version": "6.2.1"
+      }
+    },
+    {
+      "id": "wrap-ansi@7.0.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "7.0.0"
+      }
+    },
+    {
+      "id": "ansi-styles@4.3.0",
+      "info": {
+        "name": "ansi-styles",
+        "version": "4.3.0"
+      }
+    },
+    {
+      "id": "color-convert@2.0.1",
+      "info": {
+        "name": "color-convert",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "color-name@1.1.4",
+      "info": {
+        "name": "color-name",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "lodash@1.3.1",
+      "info": {
+        "name": "lodash",
+        "version": "1.3.1"
+      }
+    },
+    {
+      "id": "lodash@2.4.2",
+      "info": {
+        "name": "lodash",
+        "version": "2.4.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "pnpm-alias@",
+        "deps": [
+          {
+            "nodeId": "@isaacs/cliui@8.0.2"
+          },
+          {
+            "nodeId": "lodash@1.3.1"
+          },
+          {
+            "nodeId": "lodash@2.4.2"
+          }
+        ]
+      },
+      {
+        "nodeId": "@isaacs/cliui@8.0.2",
+        "pkgId": "@isaacs/cliui@8.0.2",
+        "deps": [
+          {
+            "nodeId": "string-width@5.1.2"
+          },
+          {
+            "nodeId": "string-width@4.2.3"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          },
+          {
+            "nodeId": "wrap-ansi@8.1.0"
+          },
+          {
+            "nodeId": "wrap-ansi@7.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@5.1.2",
+        "pkgId": "string-width@5.1.2",
+        "deps": [
+          {
+            "nodeId": "eastasianwidth@0.2.0"
+          },
+          {
+            "nodeId": "emoji-regex@9.2.2"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "eastasianwidth@0.2.0",
+        "pkgId": "eastasianwidth@0.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "emoji-regex@9.2.2",
+        "pkgId": "emoji-regex@9.2.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@7.1.0",
+        "pkgId": "strip-ansi@7.1.0",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@6.0.1",
+        "pkgId": "ansi-regex@6.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@4.2.3",
+        "pkgId": "string-width@4.2.3",
+        "deps": [
+          {
+            "nodeId": "emoji-regex@8.0.0"
+          },
+          {
+            "nodeId": "is-fullwidth-code-point@3.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "emoji-regex@8.0.0",
+        "pkgId": "emoji-regex@8.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-fullwidth-code-point@3.0.0",
+        "pkgId": "is-fullwidth-code-point@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@6.0.1",
+        "pkgId": "strip-ansi@6.0.1",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@5.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@5.0.1",
+        "pkgId": "ansi-regex@5.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrap-ansi@8.1.0",
+        "pkgId": "wrap-ansi@8.1.0",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@6.2.1"
+          },
+          {
+            "nodeId": "string-width@5.1.2"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-styles@6.2.1",
+        "pkgId": "ansi-styles@6.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrap-ansi@7.0.0",
+        "pkgId": "wrap-ansi@7.0.0",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@4.3.0"
+          },
+          {
+            "nodeId": "string-width@4.2.3"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-styles@4.3.0",
+        "pkgId": "ansi-styles@4.3.0",
+        "deps": [
+          {
+            "nodeId": "color-convert@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-convert@2.0.1",
+        "pkgId": "color-convert@2.0.1",
+        "deps": [
+          {
+            "nodeId": "color-name@1.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-name@1.1.4",
+        "pkgId": "color-name@1.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash@1.3.1",
+        "pkgId": "lodash@1.3.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash@2.4.2",
+        "pkgId": "lodash@2.4.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/alias-sub-dependency/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/alias-sub-dependency/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-alias",
+  "dependencies": {
+    "@isaacs/cliui": "8.0.2",
+    "lodash1": "npm:lodash@1",
+    "lodash2": "npm:lodash@2"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/alias-sub-dependency/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/alias-sub-dependency/pnpm-lock.yaml
@@ -1,0 +1,135 @@
+lockfileVersion: 5.4
+
+specifiers:
+  '@isaacs/cliui': 8.0.2
+  lodash1: npm:lodash@1
+  lodash2: npm:lodash@2
+
+dependencies:
+  '@isaacs/cliui': 8.0.2
+  lodash1: /lodash/1.3.1
+  lodash2: /lodash/2.4.2
+
+packages:
+
+  /@isaacs/cliui/8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width/4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: /strip-ansi/6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi/7.0.0
+    dev: false
+
+  /ansi-regex/5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /ansi-regex/6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /ansi-styles/4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: false
+
+  /ansi-styles/6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /color-convert/2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: false
+
+  /color-name/1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: false
+
+  /eastasianwidth/0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: false
+
+  /emoji-regex/8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: false
+
+  /emoji-regex/9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: false
+
+  /is-fullwidth-code-point/3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /lodash/1.3.1:
+    resolution: {integrity: sha512-F7AB8u+6d00CCgnbjWzq9fFLpzOMCgq6mPjOW4+8+dYbrnc0obRrC+IHctzfZ1KKTQxX0xo/punrlpOWcf4gpw==}
+    engines: {'0': node, '1': rhino}
+    dev: false
+
+  /lodash/2.4.2:
+    resolution: {integrity: sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==}
+    engines: {'0': node, '1': rhino}
+    dev: false
+
+  /string-width/4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: false
+
+  /string-width/5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+    dev: false
+
+  /strip-ansi/6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: false
+
+  /strip-ansi/7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.0.1
+    dev: false
+
+  /wrap-ansi/7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: false
+
+  /wrap-ansi/8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+    dev: false

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/deeply-scoped/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/deeply-scoped/expected.json
@@ -8076,10 +8076,10 @@
       }
     },
     {
-      "id": "legacy-swc-helpers@/@swc/helpers/0.4.14",
+      "id": "@swc/helpers@0.4.14",
       "info": {
-        "name": "legacy-swc-helpers",
-        "version": "/@swc/helpers/0.4.14"
+        "name": "@swc/helpers",
+        "version": "0.4.14"
       }
     },
     {
@@ -35476,7 +35476,7 @@
         "pkgId": "@swc/helpers@0.4.36",
         "deps": [
           {
-            "nodeId": "legacy-swc-helpers@/@swc/helpers/0.4.14"
+            "nodeId": "@swc/helpers@0.4.14"
           },
           {
             "nodeId": "tslib@2.6.2"
@@ -35489,9 +35489,13 @@
         }
       },
       {
-        "nodeId": "legacy-swc-helpers@/@swc/helpers/0.4.14",
-        "pkgId": "legacy-swc-helpers@/@swc/helpers/0.4.14",
-        "deps": [],
+        "nodeId": "@swc/helpers@0.4.14",
+        "pkgId": "@swc/helpers@0.4.14",
+        "deps": [
+          {
+            "nodeId": "tslib@2.6.2"
+          }
+        ],
         "info": {
           "labels": {
             "scope": "prod"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/alias-sub-dependency/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/alias-sub-dependency/expected.json
@@ -1,0 +1,432 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "pnpm-alias@",
+      "info": {
+        "name": "pnpm-alias"
+      }
+    },
+    {
+      "id": "@isaacs/cliui@8.0.2",
+      "info": {
+        "name": "@isaacs/cliui",
+        "version": "8.0.2"
+      }
+    },
+    {
+      "id": "string-width@5.1.2",
+      "info": {
+        "name": "string-width",
+        "version": "5.1.2"
+      }
+    },
+    {
+      "id": "eastasianwidth@0.2.0",
+      "info": {
+        "name": "eastasianwidth",
+        "version": "0.2.0"
+      }
+    },
+    {
+      "id": "emoji-regex@9.2.2",
+      "info": {
+        "name": "emoji-regex",
+        "version": "9.2.2"
+      }
+    },
+    {
+      "id": "strip-ansi@7.1.0",
+      "info": {
+        "name": "strip-ansi",
+        "version": "7.1.0"
+      }
+    },
+    {
+      "id": "ansi-regex@6.0.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "6.0.1"
+      }
+    },
+    {
+      "id": "string-width@4.2.3",
+      "info": {
+        "name": "string-width",
+        "version": "4.2.3"
+      }
+    },
+    {
+      "id": "emoji-regex@8.0.0",
+      "info": {
+        "name": "emoji-regex",
+        "version": "8.0.0"
+      }
+    },
+    {
+      "id": "is-fullwidth-code-point@3.0.0",
+      "info": {
+        "name": "is-fullwidth-code-point",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "strip-ansi@6.0.1",
+      "info": {
+        "name": "strip-ansi",
+        "version": "6.0.1"
+      }
+    },
+    {
+      "id": "ansi-regex@5.0.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "5.0.1"
+      }
+    },
+    {
+      "id": "wrap-ansi@8.1.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "8.1.0"
+      }
+    },
+    {
+      "id": "ansi-styles@6.2.1",
+      "info": {
+        "name": "ansi-styles",
+        "version": "6.2.1"
+      }
+    },
+    {
+      "id": "wrap-ansi@7.0.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "7.0.0"
+      }
+    },
+    {
+      "id": "ansi-styles@4.3.0",
+      "info": {
+        "name": "ansi-styles",
+        "version": "4.3.0"
+      }
+    },
+    {
+      "id": "color-convert@2.0.1",
+      "info": {
+        "name": "color-convert",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "color-name@1.1.4",
+      "info": {
+        "name": "color-name",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "lodash@1.3.1",
+      "info": {
+        "name": "lodash",
+        "version": "1.3.1"
+      }
+    },
+    {
+      "id": "lodash@2.4.2",
+      "info": {
+        "name": "lodash",
+        "version": "2.4.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "pnpm-alias@",
+        "deps": [
+          {
+            "nodeId": "@isaacs/cliui@8.0.2"
+          },
+          {
+            "nodeId": "lodash@1.3.1"
+          },
+          {
+            "nodeId": "lodash@2.4.2"
+          }
+        ]
+      },
+      {
+        "nodeId": "@isaacs/cliui@8.0.2",
+        "pkgId": "@isaacs/cliui@8.0.2",
+        "deps": [
+          {
+            "nodeId": "string-width@5.1.2"
+          },
+          {
+            "nodeId": "string-width@4.2.3"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          },
+          {
+            "nodeId": "wrap-ansi@8.1.0"
+          },
+          {
+            "nodeId": "wrap-ansi@7.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@5.1.2",
+        "pkgId": "string-width@5.1.2",
+        "deps": [
+          {
+            "nodeId": "eastasianwidth@0.2.0"
+          },
+          {
+            "nodeId": "emoji-regex@9.2.2"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "eastasianwidth@0.2.0",
+        "pkgId": "eastasianwidth@0.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "emoji-regex@9.2.2",
+        "pkgId": "emoji-regex@9.2.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@7.1.0",
+        "pkgId": "strip-ansi@7.1.0",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@6.0.1",
+        "pkgId": "ansi-regex@6.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@4.2.3",
+        "pkgId": "string-width@4.2.3",
+        "deps": [
+          {
+            "nodeId": "emoji-regex@8.0.0"
+          },
+          {
+            "nodeId": "is-fullwidth-code-point@3.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "emoji-regex@8.0.0",
+        "pkgId": "emoji-regex@8.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-fullwidth-code-point@3.0.0",
+        "pkgId": "is-fullwidth-code-point@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@6.0.1",
+        "pkgId": "strip-ansi@6.0.1",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@5.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@5.0.1",
+        "pkgId": "ansi-regex@5.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrap-ansi@8.1.0",
+        "pkgId": "wrap-ansi@8.1.0",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@6.2.1"
+          },
+          {
+            "nodeId": "string-width@5.1.2"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-styles@6.2.1",
+        "pkgId": "ansi-styles@6.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrap-ansi@7.0.0",
+        "pkgId": "wrap-ansi@7.0.0",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@4.3.0"
+          },
+          {
+            "nodeId": "string-width@4.2.3"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-styles@4.3.0",
+        "pkgId": "ansi-styles@4.3.0",
+        "deps": [
+          {
+            "nodeId": "color-convert@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-convert@2.0.1",
+        "pkgId": "color-convert@2.0.1",
+        "deps": [
+          {
+            "nodeId": "color-name@1.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-name@1.1.4",
+        "pkgId": "color-name@1.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash@1.3.1",
+        "pkgId": "lodash@1.3.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash@2.4.2",
+        "pkgId": "lodash@2.4.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/alias-sub-dependency/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/alias-sub-dependency/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-alias",
+  "dependencies": {
+    "@isaacs/cliui": "8.0.2",
+    "lodash1": "npm:lodash@1",
+    "lodash2": "npm:lodash@2"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/alias-sub-dependency/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/alias-sub-dependency/pnpm-lock.yaml
@@ -1,0 +1,140 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  '@isaacs/cliui':
+    specifier: 8.0.2
+    version: 8.0.2
+  lodash1:
+    specifier: npm:lodash@1
+    version: /lodash@1.3.1
+  lodash2:
+    specifier: npm:lodash@2
+    version: /lodash@2.4.2
+
+packages:
+
+  /@isaacs/cliui@8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: /strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: false
+
+  /ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /ansi-regex@6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: false
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: false
+
+  /color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: false
+
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: false
+
+  /emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: false
+
+  /emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: false
+
+  /is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /lodash@1.3.1:
+    resolution: {integrity: sha512-F7AB8u+6d00CCgnbjWzq9fFLpzOMCgq6mPjOW4+8+dYbrnc0obRrC+IHctzfZ1KKTQxX0xo/punrlpOWcf4gpw==}
+    engines: {'0': node, '1': rhino}
+    dev: false
+
+  /lodash@2.4.2:
+    resolution: {integrity: sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==}
+    engines: {'0': node, '1': rhino}
+    dev: false
+
+  /string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: false
+
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+    dev: false
+
+  /strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: false
+
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.0.1
+    dev: false
+
+  /wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: false
+
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+    dev: false

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/deeply-scoped/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/deeply-scoped/expected.json
@@ -7733,10 +7733,10 @@
       }
     },
     {
-      "id": "legacy-swc-helpers@/@swc/helpers@0.4.14",
+      "id": "@swc/helpers@0.4.14",
       "info": {
-        "name": "legacy-swc-helpers",
-        "version": "/@swc/helpers@0.4.14"
+        "name": "@swc/helpers",
+        "version": "0.4.14"
       }
     },
     {
@@ -36634,7 +36634,7 @@
         "pkgId": "@swc/helpers@0.4.36",
         "deps": [
           {
-            "nodeId": "legacy-swc-helpers@/@swc/helpers@0.4.14"
+            "nodeId": "@swc/helpers@0.4.14"
           },
           {
             "nodeId": "tslib@2.6.2"
@@ -36647,9 +36647,13 @@
         }
       },
       {
-        "nodeId": "legacy-swc-helpers@/@swc/helpers@0.4.14",
-        "pkgId": "legacy-swc-helpers@/@swc/helpers@0.4.14",
-        "deps": [],
+        "nodeId": "@swc/helpers@0.4.14",
+        "pkgId": "@swc/helpers@0.4.14",
+        "deps": [
+          {
+            "nodeId": "tslib@2.6.2"
+          }
+        ],
         "info": {
           "labels": {
             "scope": "prod"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/alias-sub-dependency/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/alias-sub-dependency/expected.json
@@ -1,0 +1,432 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "pnpm-alias@",
+      "info": {
+        "name": "pnpm-alias"
+      }
+    },
+    {
+      "id": "@isaacs/cliui@8.0.2",
+      "info": {
+        "name": "@isaacs/cliui",
+        "version": "8.0.2"
+      }
+    },
+    {
+      "id": "string-width@5.1.2",
+      "info": {
+        "name": "string-width",
+        "version": "5.1.2"
+      }
+    },
+    {
+      "id": "eastasianwidth@0.2.0",
+      "info": {
+        "name": "eastasianwidth",
+        "version": "0.2.0"
+      }
+    },
+    {
+      "id": "emoji-regex@9.2.2",
+      "info": {
+        "name": "emoji-regex",
+        "version": "9.2.2"
+      }
+    },
+    {
+      "id": "strip-ansi@7.1.0",
+      "info": {
+        "name": "strip-ansi",
+        "version": "7.1.0"
+      }
+    },
+    {
+      "id": "ansi-regex@6.0.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "6.0.1"
+      }
+    },
+    {
+      "id": "string-width@4.2.3",
+      "info": {
+        "name": "string-width",
+        "version": "4.2.3"
+      }
+    },
+    {
+      "id": "emoji-regex@8.0.0",
+      "info": {
+        "name": "emoji-regex",
+        "version": "8.0.0"
+      }
+    },
+    {
+      "id": "is-fullwidth-code-point@3.0.0",
+      "info": {
+        "name": "is-fullwidth-code-point",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "strip-ansi@6.0.1",
+      "info": {
+        "name": "strip-ansi",
+        "version": "6.0.1"
+      }
+    },
+    {
+      "id": "ansi-regex@5.0.1",
+      "info": {
+        "name": "ansi-regex",
+        "version": "5.0.1"
+      }
+    },
+    {
+      "id": "wrap-ansi@8.1.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "8.1.0"
+      }
+    },
+    {
+      "id": "ansi-styles@6.2.1",
+      "info": {
+        "name": "ansi-styles",
+        "version": "6.2.1"
+      }
+    },
+    {
+      "id": "wrap-ansi@7.0.0",
+      "info": {
+        "name": "wrap-ansi",
+        "version": "7.0.0"
+      }
+    },
+    {
+      "id": "ansi-styles@4.3.0",
+      "info": {
+        "name": "ansi-styles",
+        "version": "4.3.0"
+      }
+    },
+    {
+      "id": "color-convert@2.0.1",
+      "info": {
+        "name": "color-convert",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "color-name@1.1.4",
+      "info": {
+        "name": "color-name",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "lodash@1.3.1",
+      "info": {
+        "name": "lodash",
+        "version": "1.3.1"
+      }
+    },
+    {
+      "id": "lodash@2.4.2",
+      "info": {
+        "name": "lodash",
+        "version": "2.4.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "pnpm-alias@",
+        "deps": [
+          {
+            "nodeId": "@isaacs/cliui@8.0.2"
+          },
+          {
+            "nodeId": "lodash@1.3.1"
+          },
+          {
+            "nodeId": "lodash@2.4.2"
+          }
+        ]
+      },
+      {
+        "nodeId": "@isaacs/cliui@8.0.2",
+        "pkgId": "@isaacs/cliui@8.0.2",
+        "deps": [
+          {
+            "nodeId": "string-width@5.1.2"
+          },
+          {
+            "nodeId": "string-width@4.2.3"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          },
+          {
+            "nodeId": "wrap-ansi@8.1.0"
+          },
+          {
+            "nodeId": "wrap-ansi@7.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@5.1.2",
+        "pkgId": "string-width@5.1.2",
+        "deps": [
+          {
+            "nodeId": "eastasianwidth@0.2.0"
+          },
+          {
+            "nodeId": "emoji-regex@9.2.2"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "eastasianwidth@0.2.0",
+        "pkgId": "eastasianwidth@0.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "emoji-regex@9.2.2",
+        "pkgId": "emoji-regex@9.2.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@7.1.0",
+        "pkgId": "strip-ansi@7.1.0",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@6.0.1",
+        "pkgId": "ansi-regex@6.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "string-width@4.2.3",
+        "pkgId": "string-width@4.2.3",
+        "deps": [
+          {
+            "nodeId": "emoji-regex@8.0.0"
+          },
+          {
+            "nodeId": "is-fullwidth-code-point@3.0.0"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "emoji-regex@8.0.0",
+        "pkgId": "emoji-regex@8.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "is-fullwidth-code-point@3.0.0",
+        "pkgId": "is-fullwidth-code-point@3.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "strip-ansi@6.0.1",
+        "pkgId": "strip-ansi@6.0.1",
+        "deps": [
+          {
+            "nodeId": "ansi-regex@5.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-regex@5.0.1",
+        "pkgId": "ansi-regex@5.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrap-ansi@8.1.0",
+        "pkgId": "wrap-ansi@8.1.0",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@6.2.1"
+          },
+          {
+            "nodeId": "string-width@5.1.2"
+          },
+          {
+            "nodeId": "strip-ansi@7.1.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-styles@6.2.1",
+        "pkgId": "ansi-styles@6.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "wrap-ansi@7.0.0",
+        "pkgId": "wrap-ansi@7.0.0",
+        "deps": [
+          {
+            "nodeId": "ansi-styles@4.3.0"
+          },
+          {
+            "nodeId": "string-width@4.2.3"
+          },
+          {
+            "nodeId": "strip-ansi@6.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ansi-styles@4.3.0",
+        "pkgId": "ansi-styles@4.3.0",
+        "deps": [
+          {
+            "nodeId": "color-convert@2.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-convert@2.0.1",
+        "pkgId": "color-convert@2.0.1",
+        "deps": [
+          {
+            "nodeId": "color-name@1.1.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "color-name@1.1.4",
+        "pkgId": "color-name@1.1.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash@1.3.1",
+        "pkgId": "lodash@1.3.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "lodash@2.4.2",
+        "pkgId": "lodash@2.4.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/alias-sub-dependency/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/alias-sub-dependency/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-alias",
+  "dependencies": {
+    "@isaacs/cliui": "8.0.2",
+    "lodash1": "npm:lodash@1",
+    "lodash2": "npm:lodash@2"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/alias-sub-dependency/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/alias-sub-dependency/pnpm-lock.yaml
@@ -1,0 +1,164 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@isaacs/cliui':
+        specifier: 8.0.2
+        version: 8.0.2
+      lodash1:
+        specifier: npm:lodash@1
+        version: lodash@1.3.1
+      lodash2:
+        specifier: npm:lodash@2
+        version: lodash@2.4.2
+
+packages:
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  lodash@1.3.1:
+    resolution: {integrity: sha512-F7AB8u+6d00CCgnbjWzq9fFLpzOMCgq6mPjOW4+8+dYbrnc0obRrC+IHctzfZ1KKTQxX0xo/punrlpOWcf4gpw==}
+    engines: {'0': node, '1': rhino}
+
+  lodash@2.4.2:
+    resolution: {integrity: sha512-Kak1hi6/hYHGVPmdyiZijoQyz5x2iGVzs6w9GYB/HiXEtylY7tIoYEROMjvM1d9nXJqPOrG2MNPMn01bJ+S0Rw==}
+    engines: {'0': node, '1': rhino}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  lodash@1.3.1: {}
+
+  lodash@2.4.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/deeply-scoped/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/deeply-scoped/expected.json
@@ -7544,10 +7544,10 @@
       }
     },
     {
-      "id": "legacy-swc-helpers@@swc/helpers@0.4.14",
+      "id": "@swc/helpers@0.4.14",
       "info": {
-        "name": "legacy-swc-helpers",
-        "version": "@swc/helpers@0.4.14"
+        "name": "@swc/helpers",
+        "version": "0.4.14"
       }
     },
     {
@@ -35748,7 +35748,7 @@
         "pkgId": "@swc/helpers@0.4.36",
         "deps": [
           {
-            "nodeId": "legacy-swc-helpers@@swc/helpers@0.4.14"
+            "nodeId": "@swc/helpers@0.4.14"
           },
           {
             "nodeId": "tslib@2.6.2"
@@ -35761,9 +35761,13 @@
         }
       },
       {
-        "nodeId": "legacy-swc-helpers@@swc/helpers@0.4.14",
-        "pkgId": "legacy-swc-helpers@@swc/helpers@0.4.14",
-        "deps": [],
+        "nodeId": "@swc/helpers@0.4.14",
+        "pkgId": "@swc/helpers@0.4.14",
+        "deps": [
+          {
+            "nodeId": "tslib@2.6.2"
+          }
+        ],
         "info": {
           "labels": {
             "scope": "prod"

--- a/test/jest/dep-graph-builders/pnpm-lock.test.ts
+++ b/test/jest/dep-graph-builders/pnpm-lock.test.ts
@@ -21,6 +21,7 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
           'simple-override',
           'npm-protocol',
           'scoped-override',
+          'alias-sub-dependency',
         ])('[simple tests] project: %s ', (fixtureName) => {
           jest.setTimeout(50 * 1000);
           it('matches expected', async () => {
@@ -45,7 +46,7 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
               {
                 includeDevDeps: false,
                 includeOptionalDeps: false,
-                strictOutOfSync: false,
+                strictOutOfSync: true,
                 pruneWithinTopLevelDeps: false,
               },
             );


### PR DESCRIPTION
### What this does

https://pnpm.io/aliases

pnpm aliases were not handled correctly.
In subdependencies, their version shows up as the dependency path from the packages section in the lockfile.

### Notes for the reviewer

A package can be installed with multiple different versions for the same package.

### More information

- [OSM-1996](https://snyksec.atlassian.net/browse/OSM-1996)


[OSM-1996]: https://snyksec.atlassian.net/browse/OSM-1996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ