### PR TITLE
fix: fail early for top level deps out of sync pnpm and updated tests

### DIFF
--- a/lib/dep-graph-builders/pnpm/build-dep-graph-pnpm.ts
+++ b/lib/dep-graph-builders/pnpm/build-dep-graph-pnpm.ts
@@ -6,6 +6,12 @@ import { getPnpmChildNode } from './utils';
 import { eventLoopSpinner } from 'event-loop-spinner';
 import { PnpmLockfileParser } from './lockfile-parser/lockfile-parser';
 import { NormalisedPnpmPkgs, PnpmNode } from './types';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
+import {
+  INSTALL_COMMAND,
+  LOCK_FILE_NAME,
+} from '../../errors/out-of-sync-error';
+import { LockfileType } from '../..';
 
 export const buildDepGraphPnpm = async (
   lockFileParser: PnpmLockfileParser,
@@ -41,6 +47,16 @@ export const buildDepGraphPnpm = async (
     ) || {};
 
   for (const name of Object.keys(topLevelDeps)) {
+    if (!extractedTopLevelDeps[name]) {
+      throw new OpenSourceEcosystems.PnpmOutOfSyncError(
+        `Dependency ${name} was not found in ` +
+          `${LOCK_FILE_NAME[LockfileType.pnpm]}. Your package.json and ` +
+          `${
+            LOCK_FILE_NAME[LockfileType.pnpm]
+          } are probably out of sync. Please run ` +
+          `"${INSTALL_COMMAND[LockfileType.pnpm]}" and try again.`,
+      );
+    }
     topLevelDeps[name].version = extractedTopLevelDeps[name].version;
   }
 

--- a/lib/dep-graph-builders/pnpm/utils.ts
+++ b/lib/dep-graph-builders/pnpm/utils.ts
@@ -34,15 +34,6 @@ export const getPnpmChildNode = (
     resolvedVersion = pkgData.version;
   }
   if (!pkgs[childNodeKey]) {
-    if (lockfileParser.isWorkspaceLockfile()) {
-      return {
-        id: childNodeKey,
-        name: name,
-        version: resolvedVersion,
-        dependencies: {},
-        isDev: depInfo.isDev,
-      };
-    }
     if (strictOutOfSync && !/^file:/.test(depInfo.version)) {
       const errMessage =
         `Dependency ${childNodeKey} was not found in ` +

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/missing-non-top-level-deps/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/missing-non-top-level-deps/pnpm-lock.yaml
@@ -25,6 +25,3 @@ packages:
     resolution: {integrity: sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==}
     dev: false
 
-  /ms/0.6.2:
-    resolution: {integrity: sha512-/pc3eh7TWorTtbvXg8je4GvrvEqCfH7PA3P7iW01yL2E53FKixzgMBaQi0NOPbMJqY34cBSvR0tZtmlTkdUG4A==}
-    dev: false

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/missing-top-level-deps/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/missing-top-level-deps/pnpm-lock.yaml
@@ -3,12 +3,10 @@ lockfileVersion: 5.4
 specifiers:
   body-parser: ^1.18.2
   debug: 2.0.x
-  lodash: 4.17.11
 
 dependencies:
   body-parser: 1.20.2
   debug: 2.0.0
-  lodash: 4.17.11
 
 packages:
 

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/missing-non-top-level-deps/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/missing-non-top-level-deps/pnpm-lock.yaml
@@ -28,7 +28,3 @@ packages:
   /lodash@4.17.11:
     resolution: {integrity: sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==}
     dev: false
-
-  /ms@0.6.2:
-    resolution: {integrity: sha512-/pc3eh7TWorTtbvXg8je4GvrvEqCfH7PA3P7iW01yL2E53FKixzgMBaQi0NOPbMJqY34cBSvR0tZtmlTkdUG4A==}
-    dev: false

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/missing-top-level-deps/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/missing-top-level-deps/pnpm-lock.yaml
@@ -11,9 +11,6 @@ dependencies:
   debug:
     specifier: 2.0.x
     version: 2.0.0
-  lodash:
-    specifier: 4.17.11
-    version: 4.17.11
 
 packages:
 

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/missing-non-top-level-deps/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/missing-non-top-level-deps/pnpm-lock.yaml
@@ -28,9 +28,6 @@ packages:
   lodash@4.17.11:
     resolution: {integrity: sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==}
 
-  ms@0.6.2:
-    resolution: {integrity: sha512-/pc3eh7TWorTtbvXg8je4GvrvEqCfH7PA3P7iW01yL2E53FKixzgMBaQi0NOPbMJqY34cBSvR0tZtmlTkdUG4A==}
-
 snapshots:
 
   debug@2.0.0:
@@ -38,5 +35,3 @@ snapshots:
       ms: 0.6.2
 
   lodash@4.17.11: {}
-
-  ms@0.6.2: {}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/missing-top-level-deps/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/missing-top-level-deps/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       debug:
         specifier: 2.0.x
         version: 2.0.0
-      lodash:
-        specifier: 4.17.11
-        version: 4.17.11
 
 packages:
 

--- a/test/jest/dep-graph-builders/npm-lock-v2.test.ts
+++ b/test/jest/dep-graph-builders/npm-lock-v2.test.ts
@@ -1,6 +1,11 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
-import { parseNpmLockV2Project } from '../../../lib/';
+import {
+  InvalidUserInputError,
+  LockfileType,
+  OutOfSyncError,
+  parseNpmLockV2Project,
+} from '../../../lib/';
 
 describe('dep-graph-builder npm-lock-v2', () => {
   describe('Happy path tests', () => {
@@ -397,19 +402,18 @@ describe('dep-graph-builder npm-lock-v2', () => {
         'utf8',
       );
       const npmLockContent = '';
-      try {
-        await parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
+      await expect(
+        parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
           includeDevDeps: false,
           includeOptionalDeps: true,
           pruneCycles: true,
           strictOutOfSync: false,
-        });
-      } catch (err) {
-        expect((err as Error).message).toBe(
+        }),
+      ).rejects.toThrow(
+        new InvalidUserInputError(
           'package.json parsing failed with error Unexpected token } in JSON at position 100',
-        );
-        expect((err as Error).name).toBe('InvalidUserInputError');
-      }
+        ),
+      );
     });
 
     it('project: simple-non-top-level-out-of-sync -> throws OutOfSyncError', async () => {
@@ -425,19 +429,14 @@ describe('dep-graph-builder npm-lock-v2', () => {
         ),
         'utf8',
       );
-      try {
-        await parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
+      await expect(
+        parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
           includeDevDeps: false,
           includeOptionalDeps: true,
           pruneCycles: true,
           strictOutOfSync: true,
-        });
-      } catch (err) {
-        expect((err as Error).message).toBe(
-          'Dependency ms@0.6.2 was not found in package-lock.json. Your package.json and package-lock.json are probably out of sync. Please run "npm install" and try again.',
-        );
-        expect((err as Error).name).toBe('OutOfSyncError');
-      }
+        }),
+      ).rejects.toThrow(new OutOfSyncError('ms@0.6.2', LockfileType.npm));
     });
 
     it('project: simple-top-level-out-of-sync -> throws OutOfSyncError', async () => {
@@ -453,19 +452,14 @@ describe('dep-graph-builder npm-lock-v2', () => {
         ),
         'utf8',
       );
-      try {
-        await parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
+      await expect(
+        parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
           includeDevDeps: false,
           includeOptionalDeps: true,
           pruneCycles: true,
           strictOutOfSync: true,
-        });
-      } catch (err) {
-        expect((err as Error).message).toBe(
-          'Dependency lodash@4.17.11 was not found in package-lock.json. Your package.json and package-lock.json are probably out of sync. Please run "npm install" and try again.',
-        );
-        expect((err as Error).name).toBe('OutOfSyncError');
-      }
+        }),
+      ).rejects.toThrow(new OutOfSyncError('lodash@4.17.11', LockfileType.npm));
     });
   });
 });

--- a/test/jest/dep-graph-builders/pnpm-lock.test.ts
+++ b/test/jest/dep-graph-builders/pnpm-lock.test.ts
@@ -1,6 +1,8 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
 import { parsePnpmProject } from '../../../lib/dep-graph-builders';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
+import { InvalidUserInputError } from '../../../lib';
 
 describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
   'pnpm dep-graph-builder %s',
@@ -130,19 +132,18 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
           'utf8',
         );
         const pnpmLockContent = '';
-        try {
-          await parsePnpmProject(pkgJsonContent, pnpmLockContent, {
+        await expect(
+          parsePnpmProject(pkgJsonContent, pnpmLockContent, {
             includeDevDeps: false,
             includeOptionalDeps: true,
             pruneWithinTopLevelDeps: true,
             strictOutOfSync: false,
-          });
-        } catch (err) {
-          expect((err as Error).message).toBe(
+          }),
+        ).rejects.toThrow(
+          new InvalidUserInputError(
             'package.json parsing failed with error Unexpected token } in JSON at position 100',
-          );
-          expect((err as Error).name).toBe('InvalidUserInputError');
-        }
+          ),
+        );
       });
       it('project: simple-non-top-level-out-of-sync -> throws OutOfSyncError', async () => {
         const fixtureName = 'missing-non-top-level-deps';
@@ -160,19 +161,18 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
           ),
           'utf8',
         );
-        try {
-          await parsePnpmProject(pkgJsonContent, pnpmLockContent, {
+        await expect(
+          parsePnpmProject(pkgJsonContent, pnpmLockContent, {
             includeDevDeps: false,
             includeOptionalDeps: true,
             pruneWithinTopLevelDeps: true,
             strictOutOfSync: true,
-          });
-        } catch (err) {
-          expect((err as Error).message).toBe(
+          }),
+        ).rejects.toThrow(
+          new OpenSourceEcosystems.PnpmOutOfSyncError(
             'Dependency ms@0.6.2 was not found in pnpm-lock.yaml. Your package.json and pnpm-lock.yaml are probably out of sync. Please run "pnpm install" and try again.',
-          );
-          expect((err as Error).name).toBe('OutOfSyncError');
-        }
+          ),
+        );
       });
       it('project: simple-top-level-out-of-sync -> throws OutOfSyncError', async () => {
         const fixtureName = 'missing-top-level-deps';
@@ -190,19 +190,18 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
           ),
           'utf8',
         );
-        try {
-          await parsePnpmProject(pkgJsonContent, pnpmLockContent, {
+        await expect(
+          parsePnpmProject(pkgJsonContent, pnpmLockContent, {
             includeDevDeps: false,
             includeOptionalDeps: true,
             pruneWithinTopLevelDeps: true,
             strictOutOfSync: true,
-          });
-        } catch (err) {
-          expect((err as Error).message).toBe(
-            'Dependency lodash@4.17.11 was not found in pnpm-lock.yaml. Your package.json and pnpm-lock.yaml are probably out of sync. Please run "pnpm install" and try again.',
-          );
-          expect((err as Error).name).toBe('OutOfSyncError');
-        }
+          }),
+        ).rejects.toThrow(
+          new OpenSourceEcosystems.PnpmOutOfSyncError(
+            'Dependency lodash was not found in pnpm-lock.yaml. Your package.json and pnpm-lock.yaml are probably out of sync. Please run "pnpm install" and try again.',
+          ),
+        );
       });
     });
   },


### PR DESCRIPTION
### What this does

We should throw OutOfSync early if top level deps were not found in extracted lockfile packages.

Updated tests for pnpm/npm/yarn: we shouldn't use try-catch to test a failing scenario because if if the function doesn't fail as expected the test still passes
