### PR TITLE
fix: extract packages in pnpm parser constructor

### DIFF
--- a/lib/dep-graph-builders/pnpm/build-dep-graph-pnpm.ts
+++ b/lib/dep-graph-builders/pnpm/build-dep-graph-pnpm.ts
@@ -34,8 +34,6 @@ export const buildDepGraphPnpm = async (
     { name: pkgJson.name, version: pkgJson.version },
   );
 
-  lockFileParser.extractedPackages = lockFileParser.extractPackages();
-
   const extractedPnpmPkgs: NormalisedPnpmPkgs =
     lockFileParser.extractedPackages;
 

--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-parser.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-parser.ts
@@ -38,12 +38,11 @@ export abstract class PnpmLockfileParser {
     return this.workspaceArgs?.isWorkspace;
   }
 
-  public extractPackages() {
+  public extractPackages(): void {
     // Packages should be parsed only one time for a parser
     if (Object.keys(this.extractedPackages).length > 0) {
-      return this.extractedPackages;
+      return;
     }
-    const packages: NormalisedPnpmPkgs = {};
     Object.entries(this.packages).forEach(
       ([depPath, versionData]: [string, any]) => {
         // name and version are optional in version data - if they don't show up in version data, they can be deducted from the dependency path
@@ -62,11 +61,10 @@ export abstract class PnpmLockfileParser {
           devDependencies: versionData.devDependencies || {},
           optionalDependencies: versionData.optionalDependencies || {},
         };
-        packages[`${pkg.name}@${pkg.version}`] = pkg;
+        this.extractedPackages[`${pkg.name}@${pkg.version}`] = pkg;
         this.resolvedPackages[depPath] = `${pkg.name}@${pkg.version}`;
       },
     );
-    return packages;
   }
 
   public extractTopLevelDependencies(

--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v5.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v5.ts
@@ -13,6 +13,7 @@ export class LockfileV5Parser extends PnpmLockfileParser {
       };
     }
     super(rawPnpmLock, workspaceArgs);
+    this.extractPackages();
   }
 
   public parseDepPath(depPath: string): ParsedDepPath {

--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v6.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v6.ts
@@ -8,6 +8,7 @@ export class LockfileV6Parser extends PnpmLockfileParser {
   public constructor(rawPnpmLock: any, workspaceArgs?: PnpmWorkspaceArgs) {
     super(rawPnpmLock, workspaceArgs);
     this.settings = rawPnpmLock.settings;
+    this.extractPackages();
   }
 
   public parseDepPath(depPath: string): ParsedDepPath {

--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v9.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v9.ts
@@ -26,5 +26,6 @@ export class LockfileV9Parser extends LockfileV6Parser {
         };
       },
     );
+    this.extractPackages();
   }
 }


### PR DESCRIPTION
Call extractPackages in pnpm parser constructor because the extracted packages are bound to the class, they need to be extracted before calling getTopLevelDependencies.