### PR TITLE
fix: return same format for undefined versions pnpm

### DIFF
--- a/lib/dep-graph-builders/pnpm/build-dep-graph-pnpm.ts
+++ b/lib/dep-graph-builders/pnpm/build-dep-graph-pnpm.ts
@@ -13,6 +13,7 @@ import {
 } from '../../errors/out-of-sync-error';
 import { LockfileType } from '../..';
 import * as debugModule from 'debug';
+import { UNDEFINED_VERSION } from './constants';
 
 const debug = debugModule('snyk-pnpm-workspaces');
 
@@ -31,7 +32,7 @@ export const buildDepGraphPnpm = async (
 
   const depGraphBuilder = new DepGraphBuilder(
     { name: 'pnpm' },
-    { name: pkgJson.name, version: pkgJson.version },
+    { name: pkgJson.name, version: pkgJson.version || UNDEFINED_VERSION },
   );
 
   lockFileParser.extractedPackages = lockFileParser.extractPackages();

--- a/lib/dep-graph-builders/pnpm/constants.ts
+++ b/lib/dep-graph-builders/pnpm/constants.ts
@@ -1,0 +1,1 @@
+export const UNDEFINED_VERSION = 'undefined';

--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-parser.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-parser.ts
@@ -12,6 +12,7 @@ import { valid } from 'semver';
 import * as pathUtil from 'path';
 import { isEmpty } from 'lodash';
 import * as debugModule from 'debug';
+import { UNDEFINED_VERSION } from '../constants';
 
 const debug = debugModule('snyk-pnpm-workspaces');
 
@@ -218,12 +219,12 @@ export abstract class PnpmLockfileParser {
         debug(
           `Importer ${resolvedPathDep} discovered as a dependency of ${importerName} was not found in the lockfile`,
         );
-        version = 'undefined';
+        version = UNDEFINED_VERSION;
       } else {
         version = mappedProjInfo.version;
       }
       if (!version) {
-        version = 'undefined';
+        version = UNDEFINED_VERSION;
       }
 
       // Stop recursion here if this package was already normalized and stored in extractedPackages

--- a/lib/dep-graph-builders/pnpm/parse-workspace.ts
+++ b/lib/dep-graph-builders/pnpm/parse-workspace.ts
@@ -12,6 +12,7 @@ import { getPnpmLockfileParser } from './lockfile-parser/index';
 import { PnpmLockfileParser } from './lockfile-parser/lockfile-parser';
 import { getPnpmLockfileVersion } from '../../utils';
 import { getFileContents } from './utils';
+import { UNDEFINED_VERSION } from './constants';
 
 const debug = debugModule('snyk-pnpm-workspaces');
 
@@ -29,7 +30,7 @@ function computeProjectVersionMaps(root: string, targets: string[]) {
     try {
       const parsedPkgJson = parsePkgJson(packageJson.content);
       projectsVersionMap[target] = {
-        version: parsedPkgJson.version,
+        version: parsedPkgJson.version || UNDEFINED_VERSION,
         name: parsedPkgJson.name,
       };
     } catch (err: any) {

--- a/lib/dep-graph-builders/pnpm/utils.ts
+++ b/lib/dep-graph-builders/pnpm/utils.ts
@@ -11,6 +11,7 @@ import {
   LOCK_FILE_NAME,
 } from '../../errors/out-of-sync-error';
 import * as debugModule from 'debug';
+import { UNDEFINED_VERSION } from './constants';
 
 const debug = debugModule('snyk-pnpm-workspaces');
 export const getPnpmChildNode = (
@@ -50,7 +51,7 @@ export const getPnpmChildNode = (
       return {
         id: childNodeKey,
         name: name,
-        version: resolvedVersion,
+        version: resolvedVersion || UNDEFINED_VERSION,
         dependencies: {},
         isDev: depInfo.isDev,
         missingLockFileEntry: true,
@@ -71,7 +72,7 @@ export const getPnpmChildNode = (
     return {
       id: `${name}@${depData.version}`,
       name: name,
-      version: resolvedVersion,
+      version: depData.version || UNDEFINED_VERSION,
       dependencies: {
         ...dependencies,
         ...optionalDependencies,

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/alias-sub-dependency/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/alias-sub-dependency/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "pnpm-alias@",
+      "id": "pnpm-alias@undefined",
       "info": {
-        "name": "pnpm-alias"
+        "name": "pnpm-alias",
+        "version": "undefined"
       }
     },
     {
@@ -149,7 +150,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "pnpm-alias@",
+        "pkgId": "pnpm-alias@undefined",
         "deps": [
           {
             "nodeId": "@isaacs/cliui@8.0.2"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/cyclic-dep/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/cyclic-dep/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "cyclic@",
+      "id": "cyclic@undefined",
       "info": {
-        "name": "cyclic"
+        "name": "cyclic",
+        "version": "undefined"
       }
     },
     {
@@ -254,7 +255,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "cyclic@",
+        "pkgId": "cyclic@undefined",
         "deps": [
           {
             "nodeId": "@blitzjs/display@0.43.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/external-tarball/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/external-tarball/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "external-tarball@",
+      "id": "external-tarball@undefined",
       "info": {
-        "name": "external-tarball"
+        "name": "external-tarball",
+        "version": "undefined"
       }
     },
     {
@@ -100,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "external-tarball@",
+        "pkgId": "external-tarball@undefined",
         "deps": [
           {
             "nodeId": "body-parser@1.9.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/git-ssh-url-deps/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/git-ssh-url-deps/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "git-ssh-url-deps@",
+      "id": "git-ssh-url-deps@undefined",
       "info": {
-        "name": "git-ssh-url-deps"
+        "name": "git-ssh-url-deps",
+        "version": "undefined"
       }
     },
     {
@@ -100,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "git-ssh-url-deps@",
+        "pkgId": "git-ssh-url-deps@undefined",
         "deps": [
           {
             "nodeId": "body-parser@1.9.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/npm-protocol/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/npm-protocol/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "test3@",
+      "id": "test3@undefined",
       "info": {
-        "name": "test3"
+        "name": "test3",
+        "version": "undefined"
       }
     },
     {
@@ -23,7 +24,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "test3@",
+        "pkgId": "test3@undefined",
         "deps": [
           {
             "nodeId": "lodash@4.17.21"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-undefined-versions/packages/pkgs/pkg-a/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-undefined-versions/packages/pkgs/pkg-a/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "pkg-a@",
+      "id": "pkg-a@undefined",
       "info": {
-        "name": "pkg-a"
+        "name": "pkg-a",
+        "version": "undefined"
       }
     },
     {
@@ -310,7 +311,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "pkg-a@",
+        "pkgId": "pkg-a@undefined",
         "deps": [
           {
             "nodeId": "ms@2.1.2"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/alias-sub-dependency/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/alias-sub-dependency/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "pnpm-alias@",
+      "id": "pnpm-alias@undefined",
       "info": {
-        "name": "pnpm-alias"
+        "name": "pnpm-alias",
+        "version": "undefined"
       }
     },
     {
@@ -149,7 +150,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "pnpm-alias@",
+        "pkgId": "pnpm-alias@undefined",
         "deps": [
           {
             "nodeId": "@isaacs/cliui@8.0.2"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/cyclic-dep/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/cyclic-dep/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "cyclic@",
+      "id": "cyclic@undefined",
       "info": {
-        "name": "cyclic"
+        "name": "cyclic",
+        "version": "undefined"
       }
     },
     {
@@ -254,7 +255,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "cyclic@",
+        "pkgId": "cyclic@undefined",
         "deps": [
           {
             "nodeId": "@blitzjs/display@0.43.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/external-tarball/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/external-tarball/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "external-tarball@",
+      "id": "external-tarball@undefined",
       "info": {
-        "name": "external-tarball"
+        "name": "external-tarball",
+        "version": "undefined"
       }
     },
     {
@@ -100,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "external-tarball@",
+        "pkgId": "external-tarball@undefined",
         "deps": [
           {
             "nodeId": "body-parser@1.9.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/git-ssh-url-deps/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/git-ssh-url-deps/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "git-ssh-url-deps@",
+      "id": "git-ssh-url-deps@undefined",
       "info": {
-        "name": "git-ssh-url-deps"
+        "name": "git-ssh-url-deps",
+        "version": "undefined"
       }
     },
     {
@@ -100,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "git-ssh-url-deps@",
+        "pkgId": "git-ssh-url-deps@undefined",
         "deps": [
           {
             "nodeId": "body-parser@1.9.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/npm-protocol/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/npm-protocol/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "test3@",
+      "id": "test3@undefined",
       "info": {
-        "name": "test3"
+        "name": "test3",
+        "version": "undefined"
       }
     },
     {
@@ -23,7 +24,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "test3@",
+        "pkgId": "test3@undefined",
         "deps": [
           {
             "nodeId": "lodash@4.17.21"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-undefined-versions/packages/pkgs/pkg-a/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-undefined-versions/packages/pkgs/pkg-a/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "pkg-a@",
+      "id": "pkg-a@undefined",
       "info": {
-        "name": "pkg-a"
+        "name": "pkg-a",
+        "version": "undefined"
       }
     },
     {
@@ -310,7 +311,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "pkg-a@",
+        "pkgId": "pkg-a@undefined",
         "deps": [
           {
             "nodeId": "ms@2.1.2"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/alias-sub-dependency/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/alias-sub-dependency/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "pnpm-alias@",
+      "id": "pnpm-alias@undefined",
       "info": {
-        "name": "pnpm-alias"
+        "name": "pnpm-alias",
+        "version": "undefined"
       }
     },
     {
@@ -149,7 +150,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "pnpm-alias@",
+        "pkgId": "pnpm-alias@undefined",
         "deps": [
           {
             "nodeId": "@isaacs/cliui@8.0.2"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/cyclic-dep/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/cyclic-dep/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "cyclic@",
+      "id": "cyclic@undefined",
       "info": {
-        "name": "cyclic"
+        "name": "cyclic",
+        "version": "undefined"
       }
     },
     {
@@ -254,7 +255,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "cyclic@",
+        "pkgId": "cyclic@undefined",
         "deps": [
           {
             "nodeId": "@blitzjs/display@0.43.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/external-tarball/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/external-tarball/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "external-tarball@",
+      "id": "external-tarball@undefined",
       "info": {
-        "name": "external-tarball"
+        "name": "external-tarball",
+        "version": "undefined"
       }
     },
     {
@@ -100,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "external-tarball@",
+        "pkgId": "external-tarball@undefined",
         "deps": [
           {
             "nodeId": "body-parser@1.9.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/git-ssh-url-deps/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/git-ssh-url-deps/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "git-ssh-url-deps@",
+      "id": "git-ssh-url-deps@undefined",
       "info": {
-        "name": "git-ssh-url-deps"
+        "name": "git-ssh-url-deps",
+        "version": "undefined"
       }
     },
     {
@@ -100,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "git-ssh-url-deps@",
+        "pkgId": "git-ssh-url-deps@undefined",
         "deps": [
           {
             "nodeId": "body-parser@1.9.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/npm-protocol/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/npm-protocol/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "test3@",
+      "id": "test3@undefined",
       "info": {
-        "name": "test3"
+        "name": "test3",
+        "version": "undefined"
       }
     },
     {
@@ -23,7 +24,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "test3@",
+        "pkgId": "test3@undefined",
         "deps": [
           {
             "nodeId": "lodash@4.17.21"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-catalogs/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-catalogs/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "@example/root@",
+      "id": "@example/root@undefined",
       "info": {
-        "name": "@example/root"
+        "name": "@example/root",
+        "version": "undefined"
       }
     },
     {
@@ -114,7 +115,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "@example/root@",
+        "pkgId": "@example/root@undefined",
         "deps": [
           {
             "nodeId": "react-dom@16.14.0"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-catalogs/packages/example-components/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-catalogs/packages/example-components/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "@example/components@",
+      "id": "@example/components@undefined",
       "info": {
-        "name": "@example/components"
+        "name": "@example/components",
+        "version": "undefined"
       }
     },
     {
@@ -44,7 +45,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "@example/components@",
+        "pkgId": "@example/components@undefined",
         "deps": [
           {
             "nodeId": "react@18.3.1"

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-undefined-versions/packages/pkgs/pkg-a/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-undefined-versions/packages/pkgs/pkg-a/expected.json
@@ -5,9 +5,10 @@
   },
   "pkgs": [
     {
-      "id": "pkg-a@",
+      "id": "pkg-a@undefined",
       "info": {
-        "name": "pkg-a"
+        "name": "pkg-a",
+        "version": "undefined"
       }
     },
     {
@@ -310,7 +311,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "pkg-a@",
+        "pkgId": "pkg-a@undefined",
         "deps": [
           {
             "nodeId": "ms@2.1.2"


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [ ] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [ ] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

For undefined versions of top level packages or undefined versions in general, keep the same 'undefined' string as the version.
