### PR TITLE
fix: [OSM-2329] pnpm check out of sync option for missing top level deps

### DIFF
--- a/lib/dep-graph-builders/pnpm/build-dep-graph-pnpm.ts
+++ b/lib/dep-graph-builders/pnpm/build-dep-graph-pnpm.ts
@@ -47,6 +47,9 @@ export const buildDepGraphPnpm = async (
 
   for (const name of Object.keys(topLevelDeps)) {
     if (!extractedTopLevelDeps[name]) {
+      if (!strictOutOfSync) {
+        continue;
+      }
       const errMessage =
         `Dependency ${name} was not found in ` +
         `${LOCK_FILE_NAME[LockfileType.pnpm]}. Your package.json and ` +

--- a/test/jest/dep-graph-builders/pnpm-lock.test.ts
+++ b/test/jest/dep-graph-builders/pnpm-lock.test.ts
@@ -207,6 +207,56 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
           ),
         );
       });
+
+      it('project: simple-non-top-level-out-of-sync does not throws OutOfSyncError for strictOutOfSync=false', async () => {
+        const fixtureName = 'missing-non-top-level-deps';
+        const pkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/package.json`,
+          ),
+          'utf8',
+        );
+        const pnpmLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+        const deGraph = parsePnpmProject(pkgJsonContent, pnpmLockContent, {
+          includeDevDeps: false,
+          includeOptionalDeps: true,
+          pruneWithinTopLevelDeps: true,
+          strictOutOfSync: false,
+        });
+        expect(deGraph).toBeDefined();
+      });
+
+      it('project: simple-top-level-out-of-sync does not throws OutOfSyncError for strictOutOfSync=false', async () => {
+        const fixtureName = 'missing-top-level-deps';
+        const pkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/package.json`,
+          ),
+          'utf8',
+        );
+        const pnpmLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+        const deGraph = parsePnpmProject(pkgJsonContent, pnpmLockContent, {
+          includeDevDeps: false,
+          includeOptionalDeps: true,
+          pruneWithinTopLevelDeps: true,
+          strictOutOfSync: false,
+        });
+        expect(deGraph).toBeDefined();
+      });
     });
   },
 );


### PR DESCRIPTION
### What this does

Check the strict out of sync option and don't throw error if set to false (for top level dependencies, this check was missing).

