### PR TITLE
feat: pnpm - function for parsing single project from a workspace

### DIFF
--- a/lib/dep-graph-builders/index.ts
+++ b/lib/dep-graph-builders/index.ts
@@ -13,7 +13,11 @@ import {
   extractPkgsFromYarnLockV2,
 } from './yarn-lock-v2';
 import { parseNpmLockV2Project } from './npm-lock-v2';
-import { parsePnpmProject, parsePnpmWorkspace } from './pnpm';
+import {
+  parsePnpmProject,
+  parsePnpmWorkspace,
+  parsePnpmWorkspaceProject,
+} from './pnpm';
 import { parsePkgJson } from './util';
 
 export {
@@ -30,5 +34,6 @@ export {
   extractPkgsFromYarnLockV2,
   parsePnpmProject,
   parsePnpmWorkspace,
+  parsePnpmWorkspaceProject,
   parsePkgJson,
 };

--- a/lib/dep-graph-builders/pnpm/index.ts
+++ b/lib/dep-graph-builders/pnpm/index.ts
@@ -1,4 +1,5 @@
 import { parsePnpmProject } from './parse-project';
 import { parsePnpmWorkspace } from './parse-workspace';
+import { parsePnpmWorkspaceProject } from './parse-workspace-project';
 
-export { parsePnpmProject, parsePnpmWorkspace };
+export { parsePnpmProject, parsePnpmWorkspace, parsePnpmWorkspaceProject };

--- a/lib/dep-graph-builders/pnpm/parse-workspace-project.ts
+++ b/lib/dep-graph-builders/pnpm/parse-workspace-project.ts
@@ -1,0 +1,55 @@
+import { parsePkgJson } from '../util';
+import { PackageJsonBase, PnpmProjectParseOptions } from '../types';
+import { buildDepGraphPnpm } from './build-dep-graph-pnpm';
+import { DepGraph } from '@snyk/dep-graph';
+import { getPnpmLockfileParser } from './lockfile-parser/index';
+import { PnpmLockfileParser } from './lockfile-parser/lockfile-parser';
+import { NodeLockfileVersion } from '../../utils';
+import { UNDEFINED_VERSION } from './constants';
+
+export const parsePnpmWorkspaceProject = async (
+  pkgJsonContent: string,
+  pnpmLockfileContents: string,
+  options: PnpmProjectParseOptions,
+  importer: string,
+  lockfileVersion?: NodeLockfileVersion,
+) => {
+  const {
+    includeDevDeps,
+    includePeerDeps,
+    includeOptionalDeps,
+    strictOutOfSync,
+    pruneWithinTopLevelDeps,
+  } = options;
+
+  const lockFileParser: PnpmLockfileParser = getPnpmLockfileParser(
+    pnpmLockfileContents,
+    lockfileVersion,
+  );
+
+  const pkgJson: PackageJsonBase = parsePkgJson(pkgJsonContent);
+
+  lockFileParser.workspaceArgs = {
+    isWorkspace: true,
+    projectsVersionMap: {
+      [importer]: {
+        name: pkgJson.name,
+        version: pkgJson.version || UNDEFINED_VERSION,
+      },
+    },
+  };
+  const depGraph: DepGraph = await buildDepGraphPnpm(
+    lockFileParser,
+    pkgJson,
+    {
+      includeDevDeps,
+      includePeerDeps,
+      strictOutOfSync,
+      includeOptionalDeps,
+      pruneWithinTopLevelDeps,
+    },
+    importer,
+  );
+
+  return depGraph;
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -53,6 +53,7 @@ import {
   buildDepGraphYarnLockV2Simple,
   parsePnpmProject,
   parsePnpmWorkspace,
+  parsePnpmWorkspaceProject,
   parsePkgJson,
 } from './dep-graph-builders';
 import { getPnpmLockfileParser } from './dep-graph-builders/pnpm/lockfile-parser';
@@ -84,6 +85,7 @@ export {
   getPnpmLockfileParser,
   parsePnpmProject,
   parsePnpmWorkspace,
+  parsePnpmWorkspaceProject,
   parsePkgJson,
   PackageJsonBase,
   ProjectParseOptions,

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/expected-workspace-projects-undefined.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/root@0.0.0:pruned",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/shared/react/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic-root/shared/react/expected-workspace-projects-undefined.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/root@undefined",
+      "info": {
+        "name": "@test/root",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/root@undefined",
+        "pkgId": "@test/root@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/expected-workspace-projects-undefined.json
@@ -1,0 +1,822 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "@test/backend@undefined",
+      "info": {
+        "name": "@test/backend",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/backend@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@undefined",
+        "pkgId": "@test/backend@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@undefined:pruned",
+        "pkgId": "@test/react@undefined",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/backend/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/backend/expected-workspace-projects-undefined.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0:pruned",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/react/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-cyclic/shared/react/expected-workspace-projects-undefined.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@undefined",
+      "info": {
+        "name": "@test/backend",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/backend@undefined",
+        "pkgId": "@test/backend@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-with-cross-ref/packages/pkgs/pkg-a/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v5/workspace-with-cross-ref/packages/pkgs/pkg-a/expected-workspace-projects-undefined.json
@@ -1,0 +1,1068 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "pkg-a@1.0.0",
+      "info": {
+        "name": "pkg-a",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "package-b@undefined",
+      "info": {
+        "name": "package-b",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "accepts@1.3.7",
+      "info": {
+        "name": "accepts",
+        "version": "1.3.7"
+      }
+    },
+    {
+      "id": "mime-types@2.1.35",
+      "info": {
+        "name": "mime-types",
+        "version": "2.1.35"
+      }
+    },
+    {
+      "id": "mime-db@1.52.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.52.0"
+      }
+    },
+    {
+      "id": "negotiator@0.6.2",
+      "info": {
+        "name": "negotiator",
+        "version": "0.6.2"
+      }
+    },
+    {
+      "id": "package-c@undefined",
+      "info": {
+        "name": "package-c",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.20.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.20.0"
+      }
+    },
+    {
+      "id": "bytes@3.1.2",
+      "info": {
+        "name": "bytes",
+        "version": "3.1.2"
+      }
+    },
+    {
+      "id": "content-type@1.0.5",
+      "info": {
+        "name": "content-type",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@2.0.0",
+      "info": {
+        "name": "depd",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "destroy@1.2.0",
+      "info": {
+        "name": "destroy",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "http-errors@2.0.0",
+      "info": {
+        "name": "http-errors",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.2.0",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "statuses@2.0.1",
+      "info": {
+        "name": "statuses",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.1",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.24",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.24"
+      }
+    },
+    {
+      "id": "safer-buffer@2.1.2",
+      "info": {
+        "name": "safer-buffer",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "on-finished@2.4.1",
+      "info": {
+        "name": "on-finished",
+        "version": "2.4.1"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "qs@6.10.3",
+      "info": {
+        "name": "qs",
+        "version": "6.10.3"
+      }
+    },
+    {
+      "id": "side-channel@1.0.6",
+      "info": {
+        "name": "side-channel",
+        "version": "1.0.6"
+      }
+    },
+    {
+      "id": "call-bind@1.0.7",
+      "info": {
+        "name": "call-bind",
+        "version": "1.0.7"
+      }
+    },
+    {
+      "id": "es-define-property@1.0.0",
+      "info": {
+        "name": "es-define-property",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "get-intrinsic@1.2.4",
+      "info": {
+        "name": "get-intrinsic",
+        "version": "1.2.4"
+      }
+    },
+    {
+      "id": "es-errors@1.3.0",
+      "info": {
+        "name": "es-errors",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "function-bind@1.1.2",
+      "info": {
+        "name": "function-bind",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "has-proto@1.0.3",
+      "info": {
+        "name": "has-proto",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "has-symbols@1.0.3",
+      "info": {
+        "name": "has-symbols",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "hasown@2.0.2",
+      "info": {
+        "name": "hasown",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "set-function-length@1.2.2",
+      "info": {
+        "name": "set-function-length",
+        "version": "1.2.2"
+      }
+    },
+    {
+      "id": "define-data-property@1.1.4",
+      "info": {
+        "name": "define-data-property",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "gopd@1.0.1",
+      "info": {
+        "name": "gopd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "has-property-descriptors@1.0.2",
+      "info": {
+        "name": "has-property-descriptors",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "object-inspect@1.13.1",
+      "info": {
+        "name": "object-inspect",
+        "version": "1.13.1"
+      }
+    },
+    {
+      "id": "raw-body@2.5.1",
+      "info": {
+        "name": "raw-body",
+        "version": "2.5.1"
+      }
+    },
+    {
+      "id": "unpipe@1.0.0",
+      "info": {
+        "name": "unpipe",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "type-is@1.6.18",
+      "info": {
+        "name": "type-is",
+        "version": "1.6.18"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "pkg-a@1.0.0",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          },
+          {
+            "nodeId": "package-b@undefined"
+          }
+        ]
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "package-b@undefined",
+        "pkgId": "package-b@undefined",
+        "deps": [
+          {
+            "nodeId": "accepts@1.3.7"
+          },
+          {
+            "nodeId": "package-c@undefined"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "accepts@1.3.7",
+        "pkgId": "accepts@1.3.7",
+        "deps": [
+          {
+            "nodeId": "mime-types@2.1.35"
+          },
+          {
+            "nodeId": "negotiator@0.6.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.1.35",
+        "pkgId": "mime-types@2.1.35",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.52.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.52.0",
+        "pkgId": "mime-db@1.52.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "negotiator@0.6.2",
+        "pkgId": "negotiator@0.6.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "package-c@undefined",
+        "pkgId": "package-c@undefined",
+        "deps": [
+          {
+            "nodeId": "body-parser@1.20.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.20.0",
+        "pkgId": "body-parser@1.20.0",
+        "deps": [
+          {
+            "nodeId": "bytes@3.1.2"
+          },
+          {
+            "nodeId": "content-type@1.0.5"
+          },
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@2.0.0"
+          },
+          {
+            "nodeId": "destroy@1.2.0"
+          },
+          {
+            "nodeId": "http-errors@2.0.0"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.24"
+          },
+          {
+            "nodeId": "on-finished@2.4.1"
+          },
+          {
+            "nodeId": "qs@6.10.3"
+          },
+          {
+            "nodeId": "raw-body@2.5.1"
+          },
+          {
+            "nodeId": "type-is@1.6.18"
+          },
+          {
+            "nodeId": "unpipe@1.0.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@3.1.2",
+        "pkgId": "bytes@3.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "content-type@1.0.5",
+        "pkgId": "content-type@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@2.0.0",
+        "pkgId": "depd@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.2.0",
+        "pkgId": "destroy@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@2.0.0",
+        "pkgId": "http-errors@2.0.0",
+        "deps": [
+          {
+            "nodeId": "depd@2.0.0:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.2.0"
+          },
+          {
+            "nodeId": "statuses@2.0.1"
+          },
+          {
+            "nodeId": "toidentifier@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@2.0.0:pruned",
+        "pkgId": "depd@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.2.0",
+        "pkgId": "setprototypeof@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@2.0.1",
+        "pkgId": "statuses@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.1",
+        "pkgId": "toidentifier@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.24",
+        "pkgId": "iconv-lite@0.4.24",
+        "deps": [
+          {
+            "nodeId": "safer-buffer@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "safer-buffer@2.1.2",
+        "pkgId": "safer-buffer@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.4.1",
+        "pkgId": "on-finished@2.4.1",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@6.10.3",
+        "pkgId": "qs@6.10.3",
+        "deps": [
+          {
+            "nodeId": "side-channel@1.0.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "side-channel@1.0.6",
+        "pkgId": "side-channel@1.0.6",
+        "deps": [
+          {
+            "nodeId": "call-bind@1.0.7"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "object-inspect@1.13.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "call-bind@1.0.7",
+        "pkgId": "call-bind@1.0.7",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "set-function-length@1.2.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-define-property@1.0.0",
+        "pkgId": "es-define-property@1.0.0",
+        "deps": [
+          {
+            "nodeId": "get-intrinsic@1.2.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "get-intrinsic@1.2.4",
+        "pkgId": "get-intrinsic@1.2.4",
+        "deps": [
+          {
+            "nodeId": "es-errors@1.3.0"
+          },
+          {
+            "nodeId": "function-bind@1.1.2"
+          },
+          {
+            "nodeId": "has-proto@1.0.3"
+          },
+          {
+            "nodeId": "has-symbols@1.0.3"
+          },
+          {
+            "nodeId": "hasown@2.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-errors@1.3.0",
+        "pkgId": "es-errors@1.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "function-bind@1.1.2",
+        "pkgId": "function-bind@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-proto@1.0.3",
+        "pkgId": "has-proto@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-symbols@1.0.3",
+        "pkgId": "has-symbols@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "hasown@2.0.2",
+        "pkgId": "hasown@2.0.2",
+        "deps": [
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "function-bind@1.1.2:pruned",
+        "pkgId": "function-bind@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "es-errors@1.3.0:pruned",
+        "pkgId": "es-errors@1.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "get-intrinsic@1.2.4:pruned",
+        "pkgId": "get-intrinsic@1.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "set-function-length@1.2.2",
+        "pkgId": "set-function-length@1.2.2",
+        "deps": [
+          {
+            "nodeId": "define-data-property@1.1.4"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "gopd@1.0.1:pruned"
+          },
+          {
+            "nodeId": "has-property-descriptors@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "define-data-property@1.1.4",
+        "pkgId": "define-data-property@1.1.4",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0:pruned"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "gopd@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-define-property@1.0.0:pruned",
+        "pkgId": "es-define-property@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "gopd@1.0.1",
+        "pkgId": "gopd@1.0.1",
+        "deps": [
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "gopd@1.0.1:pruned",
+        "pkgId": "gopd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "has-property-descriptors@1.0.2",
+        "pkgId": "has-property-descriptors@1.0.2",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object-inspect@1.13.1",
+        "pkgId": "object-inspect@1.13.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@2.5.1",
+        "pkgId": "raw-body@2.5.1",
+        "deps": [
+          {
+            "nodeId": "bytes@3.1.2:pruned"
+          },
+          {
+            "nodeId": "http-errors@2.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.24:pruned"
+          },
+          {
+            "nodeId": "unpipe@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@3.1.2:pruned",
+        "pkgId": "bytes@3.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@2.0.0:pruned",
+        "pkgId": "http-errors@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.24:pruned",
+        "pkgId": "iconv-lite@0.4.24",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "unpipe@1.0.0",
+        "pkgId": "unpipe@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.6.18",
+        "pkgId": "type-is@1.6.18",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "mime-types@2.1.35:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.1.35:pruned",
+        "pkgId": "mime-types@2.1.35",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "unpipe@1.0.0:pruned",
+        "pkgId": "unpipe@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/expected-workspace-projects-undefined.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/root@0.0.0:pruned",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/shared/react/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic-root/shared/react/expected-workspace-projects-undefined.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/root@undefined",
+      "info": {
+        "name": "@test/root",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/root@undefined",
+        "pkgId": "@test/root@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/expected-workspace-projects-undefined.json
@@ -1,0 +1,822 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "@test/backend@undefined",
+      "info": {
+        "name": "@test/backend",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/backend@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@undefined",
+        "pkgId": "@test/backend@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@undefined:pruned",
+        "pkgId": "@test/react@undefined",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/backend/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/backend/expected-workspace-projects-undefined.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0:pruned",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/react/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-cyclic/shared/react/expected-workspace-projects-undefined.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@undefined",
+      "info": {
+        "name": "@test/backend",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/backend@undefined",
+        "pkgId": "@test/backend@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-with-cross-ref/packages/pkgs/pkg-a/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-with-cross-ref/packages/pkgs/pkg-a/expected-workspace-projects-undefined.json
@@ -1,0 +1,1068 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "pkg-a@1.0.0",
+      "info": {
+        "name": "pkg-a",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "package-b@undefined",
+      "info": {
+        "name": "package-b",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "accepts@1.3.7",
+      "info": {
+        "name": "accepts",
+        "version": "1.3.7"
+      }
+    },
+    {
+      "id": "mime-types@2.1.35",
+      "info": {
+        "name": "mime-types",
+        "version": "2.1.35"
+      }
+    },
+    {
+      "id": "mime-db@1.52.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.52.0"
+      }
+    },
+    {
+      "id": "negotiator@0.6.2",
+      "info": {
+        "name": "negotiator",
+        "version": "0.6.2"
+      }
+    },
+    {
+      "id": "package-c@undefined",
+      "info": {
+        "name": "package-c",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.20.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.20.0"
+      }
+    },
+    {
+      "id": "bytes@3.1.2",
+      "info": {
+        "name": "bytes",
+        "version": "3.1.2"
+      }
+    },
+    {
+      "id": "content-type@1.0.5",
+      "info": {
+        "name": "content-type",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@2.0.0",
+      "info": {
+        "name": "depd",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "destroy@1.2.0",
+      "info": {
+        "name": "destroy",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "http-errors@2.0.0",
+      "info": {
+        "name": "http-errors",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.2.0",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "statuses@2.0.1",
+      "info": {
+        "name": "statuses",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.1",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.24",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.24"
+      }
+    },
+    {
+      "id": "safer-buffer@2.1.2",
+      "info": {
+        "name": "safer-buffer",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "on-finished@2.4.1",
+      "info": {
+        "name": "on-finished",
+        "version": "2.4.1"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "qs@6.10.3",
+      "info": {
+        "name": "qs",
+        "version": "6.10.3"
+      }
+    },
+    {
+      "id": "side-channel@1.0.6",
+      "info": {
+        "name": "side-channel",
+        "version": "1.0.6"
+      }
+    },
+    {
+      "id": "call-bind@1.0.7",
+      "info": {
+        "name": "call-bind",
+        "version": "1.0.7"
+      }
+    },
+    {
+      "id": "es-define-property@1.0.0",
+      "info": {
+        "name": "es-define-property",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "get-intrinsic@1.2.4",
+      "info": {
+        "name": "get-intrinsic",
+        "version": "1.2.4"
+      }
+    },
+    {
+      "id": "es-errors@1.3.0",
+      "info": {
+        "name": "es-errors",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "function-bind@1.1.2",
+      "info": {
+        "name": "function-bind",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "has-proto@1.0.3",
+      "info": {
+        "name": "has-proto",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "has-symbols@1.0.3",
+      "info": {
+        "name": "has-symbols",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "hasown@2.0.2",
+      "info": {
+        "name": "hasown",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "set-function-length@1.2.2",
+      "info": {
+        "name": "set-function-length",
+        "version": "1.2.2"
+      }
+    },
+    {
+      "id": "define-data-property@1.1.4",
+      "info": {
+        "name": "define-data-property",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "gopd@1.0.1",
+      "info": {
+        "name": "gopd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "has-property-descriptors@1.0.2",
+      "info": {
+        "name": "has-property-descriptors",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "object-inspect@1.13.1",
+      "info": {
+        "name": "object-inspect",
+        "version": "1.13.1"
+      }
+    },
+    {
+      "id": "raw-body@2.5.1",
+      "info": {
+        "name": "raw-body",
+        "version": "2.5.1"
+      }
+    },
+    {
+      "id": "unpipe@1.0.0",
+      "info": {
+        "name": "unpipe",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "type-is@1.6.18",
+      "info": {
+        "name": "type-is",
+        "version": "1.6.18"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "pkg-a@1.0.0",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          },
+          {
+            "nodeId": "package-b@undefined"
+          }
+        ]
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "package-b@undefined",
+        "pkgId": "package-b@undefined",
+        "deps": [
+          {
+            "nodeId": "accepts@1.3.7"
+          },
+          {
+            "nodeId": "package-c@undefined"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "accepts@1.3.7",
+        "pkgId": "accepts@1.3.7",
+        "deps": [
+          {
+            "nodeId": "mime-types@2.1.35"
+          },
+          {
+            "nodeId": "negotiator@0.6.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.1.35",
+        "pkgId": "mime-types@2.1.35",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.52.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.52.0",
+        "pkgId": "mime-db@1.52.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "negotiator@0.6.2",
+        "pkgId": "negotiator@0.6.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "package-c@undefined",
+        "pkgId": "package-c@undefined",
+        "deps": [
+          {
+            "nodeId": "body-parser@1.20.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.20.0",
+        "pkgId": "body-parser@1.20.0",
+        "deps": [
+          {
+            "nodeId": "bytes@3.1.2"
+          },
+          {
+            "nodeId": "content-type@1.0.5"
+          },
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@2.0.0"
+          },
+          {
+            "nodeId": "destroy@1.2.0"
+          },
+          {
+            "nodeId": "http-errors@2.0.0"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.24"
+          },
+          {
+            "nodeId": "on-finished@2.4.1"
+          },
+          {
+            "nodeId": "qs@6.10.3"
+          },
+          {
+            "nodeId": "raw-body@2.5.1"
+          },
+          {
+            "nodeId": "type-is@1.6.18"
+          },
+          {
+            "nodeId": "unpipe@1.0.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@3.1.2",
+        "pkgId": "bytes@3.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "content-type@1.0.5",
+        "pkgId": "content-type@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@2.0.0",
+        "pkgId": "depd@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.2.0",
+        "pkgId": "destroy@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@2.0.0",
+        "pkgId": "http-errors@2.0.0",
+        "deps": [
+          {
+            "nodeId": "depd@2.0.0:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.2.0"
+          },
+          {
+            "nodeId": "statuses@2.0.1"
+          },
+          {
+            "nodeId": "toidentifier@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@2.0.0:pruned",
+        "pkgId": "depd@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.2.0",
+        "pkgId": "setprototypeof@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@2.0.1",
+        "pkgId": "statuses@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.1",
+        "pkgId": "toidentifier@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.24",
+        "pkgId": "iconv-lite@0.4.24",
+        "deps": [
+          {
+            "nodeId": "safer-buffer@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "safer-buffer@2.1.2",
+        "pkgId": "safer-buffer@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.4.1",
+        "pkgId": "on-finished@2.4.1",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@6.10.3",
+        "pkgId": "qs@6.10.3",
+        "deps": [
+          {
+            "nodeId": "side-channel@1.0.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "side-channel@1.0.6",
+        "pkgId": "side-channel@1.0.6",
+        "deps": [
+          {
+            "nodeId": "call-bind@1.0.7"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "object-inspect@1.13.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "call-bind@1.0.7",
+        "pkgId": "call-bind@1.0.7",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "set-function-length@1.2.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-define-property@1.0.0",
+        "pkgId": "es-define-property@1.0.0",
+        "deps": [
+          {
+            "nodeId": "get-intrinsic@1.2.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "get-intrinsic@1.2.4",
+        "pkgId": "get-intrinsic@1.2.4",
+        "deps": [
+          {
+            "nodeId": "es-errors@1.3.0"
+          },
+          {
+            "nodeId": "function-bind@1.1.2"
+          },
+          {
+            "nodeId": "has-proto@1.0.3"
+          },
+          {
+            "nodeId": "has-symbols@1.0.3"
+          },
+          {
+            "nodeId": "hasown@2.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-errors@1.3.0",
+        "pkgId": "es-errors@1.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "function-bind@1.1.2",
+        "pkgId": "function-bind@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-proto@1.0.3",
+        "pkgId": "has-proto@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-symbols@1.0.3",
+        "pkgId": "has-symbols@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "hasown@2.0.2",
+        "pkgId": "hasown@2.0.2",
+        "deps": [
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "function-bind@1.1.2:pruned",
+        "pkgId": "function-bind@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "es-errors@1.3.0:pruned",
+        "pkgId": "es-errors@1.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "get-intrinsic@1.2.4:pruned",
+        "pkgId": "get-intrinsic@1.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "set-function-length@1.2.2",
+        "pkgId": "set-function-length@1.2.2",
+        "deps": [
+          {
+            "nodeId": "define-data-property@1.1.4"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "gopd@1.0.1:pruned"
+          },
+          {
+            "nodeId": "has-property-descriptors@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "define-data-property@1.1.4",
+        "pkgId": "define-data-property@1.1.4",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0:pruned"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "gopd@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-define-property@1.0.0:pruned",
+        "pkgId": "es-define-property@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "gopd@1.0.1",
+        "pkgId": "gopd@1.0.1",
+        "deps": [
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "gopd@1.0.1:pruned",
+        "pkgId": "gopd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "has-property-descriptors@1.0.2",
+        "pkgId": "has-property-descriptors@1.0.2",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object-inspect@1.13.1",
+        "pkgId": "object-inspect@1.13.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@2.5.1",
+        "pkgId": "raw-body@2.5.1",
+        "deps": [
+          {
+            "nodeId": "bytes@3.1.2:pruned"
+          },
+          {
+            "nodeId": "http-errors@2.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.24:pruned"
+          },
+          {
+            "nodeId": "unpipe@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@3.1.2:pruned",
+        "pkgId": "bytes@3.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@2.0.0:pruned",
+        "pkgId": "http-errors@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.24:pruned",
+        "pkgId": "iconv-lite@0.4.24",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "unpipe@1.0.0",
+        "pkgId": "unpipe@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.6.18",
+        "pkgId": "type-is@1.6.18",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "mime-types@2.1.35:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.1.35:pruned",
+        "pkgId": "mime-types@2.1.35",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "unpipe@1.0.0:pruned",
+        "pkgId": "unpipe@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/expected-workspace-projects-undefined.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/root@0.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/root@0.0.0:pruned",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/shared/react/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic-root/shared/react/expected-workspace-projects-undefined.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/root@undefined",
+      "info": {
+        "name": "@test/root",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/root@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/root@undefined",
+        "pkgId": "@test/root@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/expected-workspace-projects-undefined.json
@@ -1,0 +1,822 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/root@0.0.0",
+      "info": {
+        "name": "@test/root",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "@test/backend@undefined",
+      "info": {
+        "name": "@test/backend",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "send@0.17.1",
+      "info": {
+        "name": "send",
+        "version": "0.17.1"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@1.1.2",
+      "info": {
+        "name": "depd",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "destroy@1.0.4",
+      "info": {
+        "name": "destroy",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "encodeurl@1.0.2",
+      "info": {
+        "name": "encodeurl",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "escape-html@1.0.3",
+      "info": {
+        "name": "escape-html",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "etag@1.8.1",
+      "info": {
+        "name": "etag",
+        "version": "1.8.1"
+      }
+    },
+    {
+      "id": "fresh@0.5.2",
+      "info": {
+        "name": "fresh",
+        "version": "0.5.2"
+      }
+    },
+    {
+      "id": "http-errors@1.7.3",
+      "info": {
+        "name": "http-errors",
+        "version": "1.7.3"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.1.1",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "statuses@1.5.0",
+      "info": {
+        "name": "statuses",
+        "version": "1.5.0"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.0",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "mime@1.6.0",
+      "info": {
+        "name": "mime",
+        "version": "1.6.0"
+      }
+    },
+    {
+      "id": "ms@2.1.1",
+      "info": {
+        "name": "ms",
+        "version": "2.1.1"
+      }
+    },
+    {
+      "id": "on-finished@2.3.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.3.0"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "range-parser@1.2.1",
+      "info": {
+        "name": "range-parser",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/root@0.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "send@0.17.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/backend@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@undefined",
+        "pkgId": "@test/backend@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@undefined:pruned",
+        "pkgId": "@test/react@undefined",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "send@0.17.1",
+        "pkgId": "send@0.17.1",
+        "deps": [
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@1.1.2"
+          },
+          {
+            "nodeId": "destroy@1.0.4"
+          },
+          {
+            "nodeId": "encodeurl@1.0.2"
+          },
+          {
+            "nodeId": "escape-html@1.0.3"
+          },
+          {
+            "nodeId": "etag@1.8.1"
+          },
+          {
+            "nodeId": "fresh@0.5.2"
+          },
+          {
+            "nodeId": "http-errors@1.7.3"
+          },
+          {
+            "nodeId": "mime@1.6.0"
+          },
+          {
+            "nodeId": "ms@2.1.1"
+          },
+          {
+            "nodeId": "on-finished@2.3.0"
+          },
+          {
+            "nodeId": "range-parser@1.2.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.0.4",
+        "pkgId": "destroy@1.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "encodeurl@1.0.2",
+        "pkgId": "encodeurl@1.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "escape-html@1.0.3",
+        "pkgId": "escape-html@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "etag@1.8.1",
+        "pkgId": "etag@1.8.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "fresh@0.5.2",
+        "pkgId": "fresh@0.5.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@1.7.3",
+        "pkgId": "http-errors@1.7.3",
+        "deps": [
+          {
+            "nodeId": "depd@1.1.2:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.1.1"
+          },
+          {
+            "nodeId": "statuses@1.5.0"
+          },
+          {
+            "nodeId": "toidentifier@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.1.2:pruned",
+        "pkgId": "depd@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.1.1",
+        "pkgId": "setprototypeof@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.0",
+        "pkgId": "toidentifier@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime@1.6.0",
+        "pkgId": "mime@1.6.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.1",
+        "pkgId": "ms@2.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.3.0",
+        "pkgId": "on-finished@2.3.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "range-parser@1.2.1",
+        "pkgId": "range-parser@1.2.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@1.5.0:pruned",
+        "pkgId": "statuses@1.5.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/backend/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/backend/expected-workspace-projects-undefined.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/backend@1.0.0",
+      "info": {
+        "name": "@test/backend",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/react@undefined",
+      "info": {
+        "name": "@test/react",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/react@undefined"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/react@undefined",
+        "pkgId": "@test/react@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/backend@1.0.0:pruned"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/backend@1.0.0:pruned",
+        "pkgId": "@test/backend@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/react/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-cyclic/shared/react/expected-workspace-projects-undefined.json
@@ -1,0 +1,389 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "@test/react@1.0.0",
+      "info": {
+        "name": "@test/react",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@test/backend@undefined",
+      "info": {
+        "name": "@test/backend",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.9.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.9.0"
+      }
+    },
+    {
+      "id": "bytes@1.0.0",
+      "info": {
+        "name": "bytes",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "depd@1.0.1",
+      "info": {
+        "name": "depd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.4",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.4"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    },
+    {
+      "id": "on-finished@2.1.0",
+      "info": {
+        "name": "on-finished",
+        "version": "2.1.0"
+      }
+    },
+    {
+      "id": "ee-first@1.0.5",
+      "info": {
+        "name": "ee-first",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "qs@2.2.4",
+      "info": {
+        "name": "qs",
+        "version": "2.2.4"
+      }
+    },
+    {
+      "id": "raw-body@1.3.0",
+      "info": {
+        "name": "raw-body",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "type-is@1.5.7",
+      "info": {
+        "name": "type-is",
+        "version": "1.5.7"
+      }
+    },
+    {
+      "id": "mime-types@2.0.14",
+      "info": {
+        "name": "mime-types",
+        "version": "2.0.14"
+      }
+    },
+    {
+      "id": "mime-db@1.12.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.12.0"
+      }
+    },
+    {
+      "id": "debug@4.3.1",
+      "info": {
+        "name": "debug",
+        "version": "4.3.1"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@test/backend@undefined"
+          },
+          {
+            "nodeId": "debug@4.3.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "@test/backend@undefined",
+        "pkgId": "@test/backend@undefined",
+        "deps": [
+          {
+            "nodeId": "@test/react@1.0.0:pruned"
+          },
+          {
+            "nodeId": "body-parser@1.9.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@test/react@1.0.0:pruned",
+        "pkgId": "@test/react@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.9.0",
+        "pkgId": "body-parser@1.9.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0"
+          },
+          {
+            "nodeId": "depd@1.0.1"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4"
+          },
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "on-finished@2.1.0"
+          },
+          {
+            "nodeId": "qs@2.2.4"
+          },
+          {
+            "nodeId": "raw-body@1.3.0"
+          },
+          {
+            "nodeId": "type-is@1.5.7"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@1.0.1",
+        "pkgId": "depd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.1.0",
+        "pkgId": "on-finished@2.1.0",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.0.5"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.0.5",
+        "pkgId": "ee-first@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@2.2.4",
+        "pkgId": "qs@2.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@1.3.0",
+        "pkgId": "raw-body@1.3.0",
+        "deps": [
+          {
+            "nodeId": "bytes@1.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@1.0.0:pruned",
+        "pkgId": "bytes@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.4:pruned",
+        "pkgId": "iconv-lite@0.4.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.5.7",
+        "pkgId": "type-is@1.5.7",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0:pruned"
+          },
+          {
+            "nodeId": "mime-types@2.0.14"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0:pruned",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.0.14",
+        "pkgId": "mime-types@2.0.14",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.12.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.12.0",
+        "pkgId": "mime-db@1.12.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@4.3.1",
+        "pkgId": "debug@4.3.1",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-with-cross-ref/packages/pkgs/pkg-a/expected-workspace-projects-undefined.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v9/workspace-with-cross-ref/packages/pkgs/pkg-a/expected-workspace-projects-undefined.json
@@ -1,0 +1,1068 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "pnpm"
+  },
+  "pkgs": [
+    {
+      "id": "pkg-a@1.0.0",
+      "info": {
+        "name": "pkg-a",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "ms@2.1.2",
+      "info": {
+        "name": "ms",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "package-b@undefined",
+      "info": {
+        "name": "package-b",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "accepts@1.3.7",
+      "info": {
+        "name": "accepts",
+        "version": "1.3.7"
+      }
+    },
+    {
+      "id": "mime-types@2.1.35",
+      "info": {
+        "name": "mime-types",
+        "version": "2.1.35"
+      }
+    },
+    {
+      "id": "mime-db@1.52.0",
+      "info": {
+        "name": "mime-db",
+        "version": "1.52.0"
+      }
+    },
+    {
+      "id": "negotiator@0.6.2",
+      "info": {
+        "name": "negotiator",
+        "version": "0.6.2"
+      }
+    },
+    {
+      "id": "package-c@undefined",
+      "info": {
+        "name": "package-c",
+        "version": "undefined"
+      }
+    },
+    {
+      "id": "body-parser@1.20.0",
+      "info": {
+        "name": "body-parser",
+        "version": "1.20.0"
+      }
+    },
+    {
+      "id": "bytes@3.1.2",
+      "info": {
+        "name": "bytes",
+        "version": "3.1.2"
+      }
+    },
+    {
+      "id": "content-type@1.0.5",
+      "info": {
+        "name": "content-type",
+        "version": "1.0.5"
+      }
+    },
+    {
+      "id": "debug@2.6.9",
+      "info": {
+        "name": "debug",
+        "version": "2.6.9"
+      }
+    },
+    {
+      "id": "ms@2.0.0",
+      "info": {
+        "name": "ms",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "depd@2.0.0",
+      "info": {
+        "name": "depd",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "destroy@1.2.0",
+      "info": {
+        "name": "destroy",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "http-errors@2.0.0",
+      "info": {
+        "name": "http-errors",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "inherits@2.0.4",
+      "info": {
+        "name": "inherits",
+        "version": "2.0.4"
+      }
+    },
+    {
+      "id": "setprototypeof@1.2.0",
+      "info": {
+        "name": "setprototypeof",
+        "version": "1.2.0"
+      }
+    },
+    {
+      "id": "statuses@2.0.1",
+      "info": {
+        "name": "statuses",
+        "version": "2.0.1"
+      }
+    },
+    {
+      "id": "toidentifier@1.0.1",
+      "info": {
+        "name": "toidentifier",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "iconv-lite@0.4.24",
+      "info": {
+        "name": "iconv-lite",
+        "version": "0.4.24"
+      }
+    },
+    {
+      "id": "safer-buffer@2.1.2",
+      "info": {
+        "name": "safer-buffer",
+        "version": "2.1.2"
+      }
+    },
+    {
+      "id": "on-finished@2.4.1",
+      "info": {
+        "name": "on-finished",
+        "version": "2.4.1"
+      }
+    },
+    {
+      "id": "ee-first@1.1.1",
+      "info": {
+        "name": "ee-first",
+        "version": "1.1.1"
+      }
+    },
+    {
+      "id": "qs@6.10.3",
+      "info": {
+        "name": "qs",
+        "version": "6.10.3"
+      }
+    },
+    {
+      "id": "side-channel@1.0.6",
+      "info": {
+        "name": "side-channel",
+        "version": "1.0.6"
+      }
+    },
+    {
+      "id": "call-bind@1.0.7",
+      "info": {
+        "name": "call-bind",
+        "version": "1.0.7"
+      }
+    },
+    {
+      "id": "es-define-property@1.0.0",
+      "info": {
+        "name": "es-define-property",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "get-intrinsic@1.2.4",
+      "info": {
+        "name": "get-intrinsic",
+        "version": "1.2.4"
+      }
+    },
+    {
+      "id": "es-errors@1.3.0",
+      "info": {
+        "name": "es-errors",
+        "version": "1.3.0"
+      }
+    },
+    {
+      "id": "function-bind@1.1.2",
+      "info": {
+        "name": "function-bind",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "has-proto@1.0.3",
+      "info": {
+        "name": "has-proto",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "has-symbols@1.0.3",
+      "info": {
+        "name": "has-symbols",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "hasown@2.0.2",
+      "info": {
+        "name": "hasown",
+        "version": "2.0.2"
+      }
+    },
+    {
+      "id": "set-function-length@1.2.2",
+      "info": {
+        "name": "set-function-length",
+        "version": "1.2.2"
+      }
+    },
+    {
+      "id": "define-data-property@1.1.4",
+      "info": {
+        "name": "define-data-property",
+        "version": "1.1.4"
+      }
+    },
+    {
+      "id": "gopd@1.0.1",
+      "info": {
+        "name": "gopd",
+        "version": "1.0.1"
+      }
+    },
+    {
+      "id": "has-property-descriptors@1.0.2",
+      "info": {
+        "name": "has-property-descriptors",
+        "version": "1.0.2"
+      }
+    },
+    {
+      "id": "object-inspect@1.13.1",
+      "info": {
+        "name": "object-inspect",
+        "version": "1.13.1"
+      }
+    },
+    {
+      "id": "raw-body@2.5.1",
+      "info": {
+        "name": "raw-body",
+        "version": "2.5.1"
+      }
+    },
+    {
+      "id": "unpipe@1.0.0",
+      "info": {
+        "name": "unpipe",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "type-is@1.6.18",
+      "info": {
+        "name": "type-is",
+        "version": "1.6.18"
+      }
+    },
+    {
+      "id": "media-typer@0.3.0",
+      "info": {
+        "name": "media-typer",
+        "version": "0.3.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "pkg-a@1.0.0",
+        "deps": [
+          {
+            "nodeId": "ms@2.1.2"
+          },
+          {
+            "nodeId": "package-b@undefined"
+          }
+        ]
+      },
+      {
+        "nodeId": "ms@2.1.2",
+        "pkgId": "ms@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "package-b@undefined",
+        "pkgId": "package-b@undefined",
+        "deps": [
+          {
+            "nodeId": "accepts@1.3.7"
+          },
+          {
+            "nodeId": "package-c@undefined"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "accepts@1.3.7",
+        "pkgId": "accepts@1.3.7",
+        "deps": [
+          {
+            "nodeId": "mime-types@2.1.35"
+          },
+          {
+            "nodeId": "negotiator@0.6.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.1.35",
+        "pkgId": "mime-types@2.1.35",
+        "deps": [
+          {
+            "nodeId": "mime-db@1.52.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-db@1.52.0",
+        "pkgId": "mime-db@1.52.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "negotiator@0.6.2",
+        "pkgId": "negotiator@0.6.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "package-c@undefined",
+        "pkgId": "package-c@undefined",
+        "deps": [
+          {
+            "nodeId": "body-parser@1.20.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "body-parser@1.20.0",
+        "pkgId": "body-parser@1.20.0",
+        "deps": [
+          {
+            "nodeId": "bytes@3.1.2"
+          },
+          {
+            "nodeId": "content-type@1.0.5"
+          },
+          {
+            "nodeId": "debug@2.6.9"
+          },
+          {
+            "nodeId": "depd@2.0.0"
+          },
+          {
+            "nodeId": "destroy@1.2.0"
+          },
+          {
+            "nodeId": "http-errors@2.0.0"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.24"
+          },
+          {
+            "nodeId": "on-finished@2.4.1"
+          },
+          {
+            "nodeId": "qs@6.10.3"
+          },
+          {
+            "nodeId": "raw-body@2.5.1"
+          },
+          {
+            "nodeId": "type-is@1.6.18"
+          },
+          {
+            "nodeId": "unpipe@1.0.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@3.1.2",
+        "pkgId": "bytes@3.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "content-type@1.0.5",
+        "pkgId": "content-type@1.0.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "debug@2.6.9",
+        "pkgId": "debug@2.6.9",
+        "deps": [
+          {
+            "nodeId": "ms@2.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ms@2.0.0",
+        "pkgId": "ms@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@2.0.0",
+        "pkgId": "depd@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "destroy@1.2.0",
+        "pkgId": "destroy@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@2.0.0",
+        "pkgId": "http-errors@2.0.0",
+        "deps": [
+          {
+            "nodeId": "depd@2.0.0:pruned"
+          },
+          {
+            "nodeId": "inherits@2.0.4"
+          },
+          {
+            "nodeId": "setprototypeof@1.2.0"
+          },
+          {
+            "nodeId": "statuses@2.0.1"
+          },
+          {
+            "nodeId": "toidentifier@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "depd@2.0.0:pruned",
+        "pkgId": "depd@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "inherits@2.0.4",
+        "pkgId": "inherits@2.0.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "setprototypeof@1.2.0",
+        "pkgId": "setprototypeof@1.2.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "statuses@2.0.1",
+        "pkgId": "statuses@2.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "toidentifier@1.0.1",
+        "pkgId": "toidentifier@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.24",
+        "pkgId": "iconv-lite@0.4.24",
+        "deps": [
+          {
+            "nodeId": "safer-buffer@2.1.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "safer-buffer@2.1.2",
+        "pkgId": "safer-buffer@2.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "on-finished@2.4.1",
+        "pkgId": "on-finished@2.4.1",
+        "deps": [
+          {
+            "nodeId": "ee-first@1.1.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "ee-first@1.1.1",
+        "pkgId": "ee-first@1.1.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "qs@6.10.3",
+        "pkgId": "qs@6.10.3",
+        "deps": [
+          {
+            "nodeId": "side-channel@1.0.6"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "side-channel@1.0.6",
+        "pkgId": "side-channel@1.0.6",
+        "deps": [
+          {
+            "nodeId": "call-bind@1.0.7"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "object-inspect@1.13.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "call-bind@1.0.7",
+        "pkgId": "call-bind@1.0.7",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "set-function-length@1.2.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-define-property@1.0.0",
+        "pkgId": "es-define-property@1.0.0",
+        "deps": [
+          {
+            "nodeId": "get-intrinsic@1.2.4"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "get-intrinsic@1.2.4",
+        "pkgId": "get-intrinsic@1.2.4",
+        "deps": [
+          {
+            "nodeId": "es-errors@1.3.0"
+          },
+          {
+            "nodeId": "function-bind@1.1.2"
+          },
+          {
+            "nodeId": "has-proto@1.0.3"
+          },
+          {
+            "nodeId": "has-symbols@1.0.3"
+          },
+          {
+            "nodeId": "hasown@2.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-errors@1.3.0",
+        "pkgId": "es-errors@1.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "function-bind@1.1.2",
+        "pkgId": "function-bind@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-proto@1.0.3",
+        "pkgId": "has-proto@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "has-symbols@1.0.3",
+        "pkgId": "has-symbols@1.0.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "hasown@2.0.2",
+        "pkgId": "hasown@2.0.2",
+        "deps": [
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "function-bind@1.1.2:pruned",
+        "pkgId": "function-bind@1.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "es-errors@1.3.0:pruned",
+        "pkgId": "es-errors@1.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "get-intrinsic@1.2.4:pruned",
+        "pkgId": "get-intrinsic@1.2.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "set-function-length@1.2.2",
+        "pkgId": "set-function-length@1.2.2",
+        "deps": [
+          {
+            "nodeId": "define-data-property@1.1.4"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "function-bind@1.1.2:pruned"
+          },
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          },
+          {
+            "nodeId": "gopd@1.0.1:pruned"
+          },
+          {
+            "nodeId": "has-property-descriptors@1.0.2"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "define-data-property@1.1.4",
+        "pkgId": "define-data-property@1.1.4",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0:pruned"
+          },
+          {
+            "nodeId": "es-errors@1.3.0:pruned"
+          },
+          {
+            "nodeId": "gopd@1.0.1"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "es-define-property@1.0.0:pruned",
+        "pkgId": "es-define-property@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "gopd@1.0.1",
+        "pkgId": "gopd@1.0.1",
+        "deps": [
+          {
+            "nodeId": "get-intrinsic@1.2.4:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "gopd@1.0.1:pruned",
+        "pkgId": "gopd@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "has-property-descriptors@1.0.2",
+        "pkgId": "has-property-descriptors@1.0.2",
+        "deps": [
+          {
+            "nodeId": "es-define-property@1.0.0:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "object-inspect@1.13.1",
+        "pkgId": "object-inspect@1.13.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "raw-body@2.5.1",
+        "pkgId": "raw-body@2.5.1",
+        "deps": [
+          {
+            "nodeId": "bytes@3.1.2:pruned"
+          },
+          {
+            "nodeId": "http-errors@2.0.0:pruned"
+          },
+          {
+            "nodeId": "iconv-lite@0.4.24:pruned"
+          },
+          {
+            "nodeId": "unpipe@1.0.0"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "bytes@3.1.2:pruned",
+        "pkgId": "bytes@3.1.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "http-errors@2.0.0:pruned",
+        "pkgId": "http-errors@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "iconv-lite@0.4.24:pruned",
+        "pkgId": "iconv-lite@0.4.24",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "unpipe@1.0.0",
+        "pkgId": "unpipe@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "type-is@1.6.18",
+        "pkgId": "type-is@1.6.18",
+        "deps": [
+          {
+            "nodeId": "media-typer@0.3.0"
+          },
+          {
+            "nodeId": "mime-types@2.1.35:pruned"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "media-typer@0.3.0",
+        "pkgId": "media-typer@0.3.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "mime-types@2.1.35:pruned",
+        "pkgId": "mime-types@2.1.35",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "unpipe@1.0.0:pruned",
+        "pkgId": "unpipe@1.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "pruned": "true"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/pnpm-workspace-singe-project.test.ts
+++ b/test/jest/dep-graph-builders/pnpm-workspace-singe-project.test.ts
@@ -1,0 +1,479 @@
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import { parsePnpmWorkspaceProject } from '../../../lib/dep-graph-builders';
+
+describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
+  'pnpm workspaces dep-graph-builder %s',
+  (lockFileVersionPath) => {
+    describe('[workspaces tests]', () => {
+      it('isolated packages in workspaces - test workspace root package.json', async () => {
+        const fixtureName = 'workspace-with-isolated-pkgs';
+        const rootPkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/package.json`,
+          ),
+          'utf8',
+        );
+        const pkgLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+
+        const result = await parsePnpmWorkspaceProject(
+          rootPkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          '.',
+        );
+
+        const expectedRootDepGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/expected.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(Buffer.from(JSON.stringify(result)).toString('base64')).toBe(
+          Buffer.from(JSON.stringify(expectedRootDepGraphJson)).toString(
+            'base64',
+          ),
+        );
+      });
+
+      it('isolated packages in workspaces - test workspace non-root package.json', async () => {
+        const fixtureName = 'workspace-with-isolated-pkgs';
+        const pkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/packages/pkg-b/package.json`,
+          ),
+          'utf8',
+        );
+        const pkgLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+
+        const result = await parsePnpmWorkspaceProject(
+          pkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          'packages/pkg-b',
+        );
+
+        const expectedBDepGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/packages/pkg-b/expected.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(Buffer.from(JSON.stringify(result)).toString('base64')).toBe(
+          Buffer.from(JSON.stringify(expectedBDepGraphJson)).toString('base64'),
+        );
+      });
+
+      it('cross ref packages in workspaces', async () => {
+        const fixtureName = 'workspace-with-cross-ref';
+        const pkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/packages/pkgs/pkg-a/package.json`,
+          ),
+          'utf8',
+        );
+        const pkgLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+
+        const result = await parsePnpmWorkspaceProject(
+          pkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          'packages/pkgs/pkg-a',
+        );
+
+        const expectedDepGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/packages/pkgs/pkg-a/expected-workspace-projects-undefined.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(Buffer.from(JSON.stringify(result)).toString('base64')).toBe(
+          Buffer.from(JSON.stringify(expectedDepGraphJson)).toString('base64'),
+        );
+      });
+
+      it('undefined versions in cross ref packages in workspaces', async () => {
+        const fixtureName = 'workspace-undefined-versions';
+        const pkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/packages/pkgs/pkg-a/package.json`,
+          ),
+          'utf8',
+        );
+        const pkgLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+
+        const result = await parsePnpmWorkspaceProject(
+          pkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          'packages/pkgs/pkg-a',
+        );
+        const expectedDepGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/packages/pkgs/pkg-a/expected.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(Buffer.from(JSON.stringify(result)).toString('base64')).toBe(
+          Buffer.from(JSON.stringify(expectedDepGraphJson)).toString('base64'),
+        );
+      });
+
+      it('cyclic workspace projects including root', async () => {
+        const fixtureName = 'workspace-cyclic-root';
+        const rootPkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/package.json`,
+          ),
+          'utf8',
+        );
+        const secondPkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/react/package.json`,
+          ),
+          'utf8',
+        );
+        const pkgLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+
+        const result = await parsePnpmWorkspaceProject(
+          rootPkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          '.',
+        );
+
+        const expectedDepGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/expected-workspace-projects-undefined.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(Buffer.from(JSON.stringify(result)).toString('base64')).toBe(
+          Buffer.from(JSON.stringify(expectedDepGraphJson)).toString('base64'),
+        );
+
+        const sharedPkgResult = await parsePnpmWorkspaceProject(
+          secondPkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          'shared/react',
+        );
+
+        const expectedSecondDepGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/react/expected-workspace-projects-undefined.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(
+          Buffer.from(JSON.stringify(sharedPkgResult)).toString('base64'),
+        ).toBe(
+          Buffer.from(JSON.stringify(expectedSecondDepGraphJson)).toString(
+            'base64',
+          ),
+        );
+      });
+      it('cycle in workspace projects starting from the second level projects', async () => {
+        const fixtureName = 'workspace-cyclic';
+        const rootPkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/package.json`,
+          ),
+          'utf8',
+        );
+        const backendPkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/backend/package.json`,
+          ),
+          'utf8',
+        );
+        const reactPkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/react/package.json`,
+          ),
+          'utf8',
+        );
+        const pkgLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+
+        const result = await parsePnpmWorkspaceProject(
+          rootPkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          '.',
+        );
+
+        const expectedRootGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/expected-workspace-projects-undefined.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(Buffer.from(JSON.stringify(result)).toString('base64')).toBe(
+          Buffer.from(JSON.stringify(expectedRootGraphJson)).toString('base64'),
+        );
+
+        const backendResult = await parsePnpmWorkspaceProject(
+          backendPkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          'shared/backend',
+        );
+        const expectedBackendGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/backend/expected-workspace-projects-undefined.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(
+          Buffer.from(JSON.stringify(backendResult)).toString('base64'),
+        ).toBe(
+          Buffer.from(JSON.stringify(expectedBackendGraphJson)).toString(
+            'base64',
+          ),
+        );
+
+        const reactResult = await parsePnpmWorkspaceProject(
+          reactPkgJsonContent,
+          pkgLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: true,
+            includePeerDeps: true,
+            pruneWithinTopLevelDeps: true,
+            strictOutOfSync: true,
+          },
+          'shared/react',
+        );
+        const expectedReactGraphJson = JSON.parse(
+          readFileSync(
+            join(
+              __dirname,
+              `./fixtures/${lockFileVersionPath}/${fixtureName}/shared/react/expected-workspace-projects-undefined.json`,
+            ),
+            'utf8',
+          ),
+        );
+
+        expect(
+          Buffer.from(JSON.stringify(reactResult)).toString('base64'),
+        ).toBe(
+          Buffer.from(JSON.stringify(expectedReactGraphJson)).toString(
+            'base64',
+          ),
+        );
+      });
+    });
+  },
+);
+
+describe('pnpm-lock-v9 catalogs support tests', () => {
+  it('returns correctly resolved catalog references', async () => {
+    const lockFileVersionPath = 'pnpm-lock-v9';
+    const fixtureName = 'workspace-catalogs';
+
+    const rootPkgJsonContent = readFileSync(
+      join(
+        __dirname,
+        `./fixtures/${lockFileVersionPath}/${fixtureName}/package.json`,
+      ),
+      'utf8',
+    );
+    const secondPkgJsonContent = readFileSync(
+      join(
+        __dirname,
+        `./fixtures/${lockFileVersionPath}/${fixtureName}/packages/example-components/package.json`,
+      ),
+      'utf8',
+    );
+    const pkgLockContent = readFileSync(
+      join(
+        __dirname,
+        `./fixtures/${lockFileVersionPath}/${fixtureName}/pnpm-lock.yaml`,
+      ),
+      'utf8',
+    );
+
+    const result = await parsePnpmWorkspaceProject(
+      rootPkgJsonContent,
+      pkgLockContent,
+      {
+        includeDevDeps: false,
+        includeOptionalDeps: true,
+        includePeerDeps: true,
+        pruneWithinTopLevelDeps: true,
+        strictOutOfSync: true,
+      },
+      '.',
+    );
+
+    const expectedRootDepGraphJson = JSON.parse(
+      readFileSync(
+        join(
+          __dirname,
+          `./fixtures/${lockFileVersionPath}/${fixtureName}/expected.json`,
+        ),
+        'utf8',
+      ),
+    );
+
+    const componentResult = await parsePnpmWorkspaceProject(
+      secondPkgJsonContent,
+      pkgLockContent,
+      {
+        includeDevDeps: false,
+        includeOptionalDeps: true,
+        includePeerDeps: true,
+        pruneWithinTopLevelDeps: true,
+        strictOutOfSync: true,
+      },
+      'packages/example-components',
+    );
+
+    const expectedComponentDepGraphJson = JSON.parse(
+      readFileSync(
+        join(
+          __dirname,
+          `./fixtures/${lockFileVersionPath}/${fixtureName}/packages/example-components/expected.json`,
+        ),
+        'utf8',
+      ),
+    );
+
+    expect(Buffer.from(JSON.stringify(result)).toString('base64')).toBe(
+      Buffer.from(JSON.stringify(expectedRootDepGraphJson)).toString('base64'),
+    );
+
+    expect(
+      Buffer.from(JSON.stringify(componentResult)).toString('base64'),
+    ).toBe(
+      Buffer.from(JSON.stringify(expectedComponentDepGraphJson)).toString(
+        'base64',
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Added function for parsing a single package.json within a workspace. Expected input : package.json file content, pnpm-lock.yaml file content, options, importer (the relative path to the package.json file)
Unfortunately, if there's no context/access to the other package.json files, we can't determine the versions of the referenced local projects - hence the added expected outputs in tests.