### PR TITLE
fix: update cross-spawn vuln by updating package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ windows_defaults: &windows_defaults
     name: win/default
 
 test_matrix: &test_matrix
-  node_version: ['18.18.1', '16.20.2']
+  node_version: ['18.18.1', '22.11.0']
 
 commands:
   install_deps:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "files": [
     "bin",
@@ -31,10 +31,10 @@
   ],
   "homepage": "https://github.com/snyk/nodejs-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/error-catalog-nodejs-public": "^5.16.0",
     "@snyk/dep-graph": "^2.3.0",
+    "@snyk/error-catalog-nodejs-public": "^5.16.0",
     "@snyk/graphlib": "2.1.9-patch.3",
-    "@yarnpkg/core": "^2.4.0",
+    "@yarnpkg/core": "^4.4.1",
     "@yarnpkg/lockfile": "^1.1.0",
     "dependency-path": "^9.2.8",
     "event-loop-spinner": "^2.0.0",
@@ -50,9 +50,6 @@
     "tslib": "^1.9.3",
     "uuid": "^8.3.0"
   },
-  "overrides": {
-    "cross-spawn": "^7.0.5"
-  },
   "devDependencies": {
     "@types/jest": "^28.1.3",
     "@types/node": "^16.11.66",
@@ -67,7 +64,7 @@
     "tap": "^15.0.4",
     "ts-jest": "^28.0.8",
     "ts-node": "^8.10.2",
-    "typescript": "4.8.4"
+    "typescript": "^5.4.5"
   },
   "packageManager": "yarn@2.4.1"
 }

--- a/test/jest/dep-graph-builders/npm-lock-v2.test.ts
+++ b/test/jest/dep-graph-builders/npm-lock-v2.test.ts
@@ -402,6 +402,16 @@ describe('dep-graph-builder npm-lock-v2', () => {
         'utf8',
       );
       const npmLockContent = '';
+
+      const nodeMajorVersion = parseInt(
+        process.version.substring(1).split('.')[0],
+        10,
+      );
+      const expectedErrorMessage =
+        nodeMajorVersion >= 22
+          ? 'package.json parsing failed with error Expected double-quoted property name in JSON at position 100 (line 6 column 3)'
+          : 'package.json parsing failed with error Unexpected token } in JSON at position 100';
+
       await expect(
         parseNpmLockV2Project(pkgJsonContent, npmLockContent, {
           includeDevDeps: false,
@@ -409,11 +419,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
           pruneCycles: true,
           strictOutOfSync: false,
         }),
-      ).rejects.toThrow(
-        new InvalidUserInputError(
-          'package.json parsing failed with error Unexpected token } in JSON at position 100',
-        ),
-      );
+      ).rejects.toThrow(new InvalidUserInputError(expectedErrorMessage));
     });
 
     it('project: simple-non-top-level-out-of-sync -> throws OutOfSyncError', async () => {

--- a/test/jest/dep-graph-builders/pnpm-lock.test.ts
+++ b/test/jest/dep-graph-builders/pnpm-lock.test.ts
@@ -182,6 +182,16 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
           'utf8',
         );
         const pnpmLockContent = '';
+
+        const nodeMajorVersion = parseInt(
+          process.version.substring(1).split('.')[0],
+          10,
+        );
+        const expectedErrorMessage =
+          nodeMajorVersion >= 22
+            ? 'package.json parsing failed with error Expected double-quoted property name in JSON at position 100 (line 6 column 3)'
+            : 'package.json parsing failed with error Unexpected token } in JSON at position 100';
+
         await expect(
           parsePnpmProject(pkgJsonContent, pnpmLockContent, {
             includeDevDeps: false,
@@ -189,11 +199,7 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
             pruneWithinTopLevelDeps: true,
             strictOutOfSync: false,
           }),
-        ).rejects.toThrow(
-          new InvalidUserInputError(
-            'package.json parsing failed with error Unexpected token } in JSON at position 100',
-          ),
-        );
+        ).rejects.toThrow(new InvalidUserInputError(expectedErrorMessage));
       });
       it('project: simple-non-top-level-out-of-sync -> throws OutOfSyncError', async () => {
         const fixtureName = 'missing-non-top-level-deps';

--- a/test/jest/dep-graph-builders/yarn-lock-v1-realistic-fixtures.test.ts
+++ b/test/jest/dep-graph-builders/yarn-lock-v1-realistic-fixtures.test.ts
@@ -311,6 +311,16 @@ describe('Unhappy path tests', () => {
       'utf8',
     );
     const yarnLockContent = '';
+
+    const nodeMajorVersion = parseInt(
+      process.version.substring(1).split('.')[0],
+      10,
+    );
+    const expectedErrorMessage =
+      nodeMajorVersion >= 22
+        ? 'package.json parsing failed with error Expected double-quoted property name in JSON at position 100 (line 6 column 3)'
+        : 'package.json parsing failed with error Unexpected token } in JSON at position 100';
+
     await expect(
       parseYarnLockV1Project(pkgJsonContent, yarnLockContent, {
         includeDevDeps: false,
@@ -319,11 +329,7 @@ describe('Unhappy path tests', () => {
         pruneLevel: 'cycles',
         strictOutOfSync: false,
       }),
-    ).rejects.toThrow(
-      new InvalidUserInputError(
-        'package.json parsing failed with error Unexpected token } in JSON at position 100',
-      ),
-    );
+    ).rejects.toThrow(new InvalidUserInputError(expectedErrorMessage));
   });
 
   it('project: simple-top-level-out-of-sync -> throws OutOfSyncError', async () => {


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

Updates @yarnpkg/core to fix cross-spawn vulns. : This bumps it 2 major versions https://www.npmjs.com/package/@yarnpkg/core/v/2.4.0?activeTab=versions

Updates the typescript dev dep to `"^5.4.5"` This was required to get the build passing as older versions couldn't interpret the type definitions correctly 

Updates the minimum supported node version to 18 

