### PR TITLE
fix: yarn-lock-v2 parsing with absent dependencies field in package.json

### DIFF
--- a/lib/aliasesPreprocessors/yarn-lock-v2.ts
+++ b/lib/aliasesPreprocessors/yarn-lock-v2.ts
@@ -12,7 +12,7 @@ export const rewriteAliasesInYarnLockV2 = (
     string,
     string
   >;
-  const topLevelAliasedPkgs = Object.entries(topLevelPkgs)
+  const topLevelAliasedPkgs = Object.entries(topLevelPkgs || {})
     .filter((entry) => {
       return entry[1].startsWith('npm:');
     })

--- a/test/jest/dep-graph-builders/aliases.test.ts
+++ b/test/jest/dep-graph-builders/aliases.test.ts
@@ -204,6 +204,34 @@ describe('Testing aliases for yarn', () => {
     expect(pkgs.some((x) => x.name === 'pkg')).toBeFalsy();
     expect(pkgs.some((x) => x.name === '@yao-pkg/pkg')).toBeTruthy();
   });
+
+  it('handle missing dependencies field - yarn-lock-v2', async () => {
+    const pkgJsonContent = JSON.stringify({
+      name: 'test-missing-deps',
+      version: '1.0.0',
+      // No dependencies field
+    });
+    const yarnLockContent = readFileSync(
+      join(__dirname, `./fixtures/aliases/yarn-lock-v2/yarn.lock`),
+      'utf8',
+    );
+
+    const newDepGraph = await parseYarnLockV2Project(
+      pkgJsonContent,
+      yarnLockContent,
+      {
+        includeDevDeps: true,
+        includeOptionalDeps: true,
+        strictOutOfSync: false,
+        pruneWithinTopLevelDeps: true,
+        honorAliases: true,
+      },
+    );
+
+    expect(newDepGraph).toBeDefined();
+    const pkgs = newDepGraph.getPkgs();
+    expect(pkgs).toBeDefined();
+  });
 });
 describe('Testing aliases for npm', () => {
   it('match aliased package - npm-lock-v1', async () => {


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

_Explain why this PR exists_
To fix bug explained in #276 

### Notes for the reviewer

-

### More information

- #276 

### Screenshots

-