### PR TITLE
fix: add missing alias labels in yarn [SOSE-22]

### DIFF
--- a/lib/dep-graph-builders/util.ts
+++ b/lib/dep-graph-builders/util.ts
@@ -163,6 +163,7 @@ export const getChildNode = (
         dependencies: {},
         isDev: depInfo.isDev,
         missingLockFileEntry: true,
+        alias: depInfo.alias,
       };
     }
   } else {
@@ -180,6 +181,7 @@ export const getChildNode = (
       version: depData.version,
       dependencies: { ...dependencies, ...optionalDependencies },
       isDev: depInfo.isDev,
+      alias: depInfo.alias,
     };
   }
 

--- a/lib/dep-graph-builders/yarn-lock-v1/build-depgraph-simple.ts
+++ b/lib/dep-graph-builders/yarn-lock-v1/build-depgraph-simple.ts
@@ -109,6 +109,9 @@ const dfsVisit = async (
               ...(node.missingLockFileEntry && {
                 missingLockFileEntry: 'true',
               }),
+              ...(childNode.alias && {
+                alias: `${childNode.alias.aliasName}=>${childNode.alias.aliasTargetDepName}@${childNode.version}`,
+              }),
             },
           },
         );
@@ -127,6 +130,9 @@ const dfsVisit = async (
           scope: node.isDev ? 'dev' : 'prod',
           ...(node.missingLockFileEntry && {
             missingLockFileEntry: 'true',
+          }),
+          ...(childNode.alias && {
+            alias: `${childNode.alias.aliasName}=>${childNode.alias.aliasTargetDepName}@${childNode.version}`,
           }),
         },
       },

--- a/lib/dep-graph-builders/yarn-lock-v2/build-depgraph-simple.ts
+++ b/lib/dep-graph-builders/yarn-lock-v2/build-depgraph-simple.ts
@@ -123,6 +123,9 @@ const dfsVisit = async (
               ...(node.missingLockFileEntry && {
                 missingLockFileEntry: 'true',
               }),
+              ...(childNode.alias && {
+                alias: `${childNode.alias.aliasName}=>${childNode.alias.aliasTargetDepName}@${childNode.version}`,
+              }),
             },
           },
         );
@@ -141,6 +144,9 @@ const dfsVisit = async (
           scope: node.isDev ? 'dev' : 'prod',
           ...(node.missingLockFileEntry && {
             missingLockFileEntry: 'true',
+          }),
+          ...(childNode.alias && {
+            alias: `${childNode.alias.aliasName}=>${childNode.alias.aliasTargetDepName}@${childNode.version}`,
           }),
         },
       },

--- a/test/jest/dep-graph-builders/aliases.test.ts
+++ b/test/jest/dep-graph-builders/aliases.test.ts
@@ -36,6 +36,9 @@ describe('Testing aliases for yarn', () => {
     const pkgs = newDepGraph.getPkgs();
     expect(pkgs.some((x) => x.name === 'pkg')).toBeFalsy();
     expect(pkgs.some((x) => x.name === '@yao-pkg/pkg')).toBeTruthy();
+    expect(JSON.stringify(newDepGraph)).toContain(
+      '"alias":"pkg=>@yao-pkg/pkg@6.5.0"',
+    );
   });
 
   it('match aliased package also used in transitive deps - yarn-lock-v1', async () => {
@@ -170,6 +173,9 @@ describe('Testing aliases for yarn', () => {
     const pkgs = newDepGraph.getPkgs();
     expect(pkgs.some((x) => x.name === 'pkg')).toBeFalsy();
     expect(pkgs.some((x) => x.name === '@yao-pkg/pkg')).toBeTruthy();
+    expect(JSON.stringify(newDepGraph)).toContain(
+      '"alias":"pkg=>@yao-pkg/pkg@6.5.0"',
+    );
   });
 
   it('match aliased package also used in transitive deps - yarn-lock-v2', async () => {

--- a/test/jest/dep-graph-builders/fixtures/yarn-lock-v2/real/git-remote-url/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/yarn-lock-v2/real/git-remote-url/expected.json
@@ -1330,7 +1330,8 @@
         "deps": [],
         "info": {
           "labels": {
-            "scope": "prod"
+            "scope": "prod",
+            "alias": "ms=>ms@2.1.3"
           }
         }
       },


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

Adds missing alias label to nodes for yarn v1 and yarn v2.

### Notes for the reviewer

Miss from #281, impacting the print-deps display in CLI.