### PR TITLE
feat: override vulnerable 'tar' transitive dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "ts-node": "^8.10.2",
     "typescript": "^5.4.5"
   },
+  "overrides": {
+    "tar": "7.5.9"
+  },
   "packageManager": "yarn@2.4.1"
 }


### PR DESCRIPTION
### What this does

Forces an override on the `tar` transitive dependency - from `6.2.1` to `7.5.9` - to fix a vulnerability. 
The direct dependency `@yarnpkg/core` doesn't yet have a fixed version.

This is critically blocking the CLI relelase. Refer to #incident-2818-high-vulnerabilities-blocking-cli-stable-release for more details.
