### PR TITLE
fix: [OSM-3624] Support pnpm v6 lockfile for workspaces

### DIFF
--- a/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v6.ts
+++ b/lib/dep-graph-builders/pnpm/lockfile-parser/lockfile-v6.ts
@@ -99,7 +99,20 @@ export class LockfileV6Parser extends PnpmLockfileParser {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public normaliseImporters(rawPnpmLock: any): PnpmImporters {
     if (!('importers' in rawPnpmLock)) {
-      return {};
+      // Some pnpm versions embed the root importer as '.' inside the
+      // top-level dependencies map instead of using an importers section.
+      // Synthesize an importers entry so the workspace machinery can handle it.
+      const dotEntry = rawPnpmLock.dependencies?.['.'];
+      if (
+        dotEntry &&
+        typeof dotEntry === 'object' &&
+        'dependencies' in dotEntry
+      ) {
+        rawPnpmLock.importers = { '.': dotEntry };
+        delete rawPnpmLock.dependencies['.'];
+      } else {
+        return {};
+      }
     }
 
     const rawImporters = rawPnpmLock.importers as Record<

--- a/lib/dep-graph-builders/pnpm/parse-project.ts
+++ b/lib/dep-graph-builders/pnpm/parse-project.ts
@@ -28,8 +28,10 @@ export const parsePnpmProject = async (
     lockfileVersion,
   );
 
-  // Lockfile V9 simple project has the root importer
-  if (lockFileParser.lockFileVersion.startsWith('9')) {
+  // Lockfile V9 simple project has the root importer.
+  // Some V6 lockfiles also embed the root importer as '.' inside the
+  // top-level dependencies map (normaliseImporters moves it to importers).
+  if (lockFileParser.rawPnpmLock.importers?.['.']) {
     importer = '.';
     lockFileParser.workspaceArgs = {
       projectsVersionMap: {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "^5.4.5"
   },
   "overrides": {
-    "tar": "7.5.9"
+    "tar": "7.5.11"
   },
   "packageManager": "yarn@2.4.1"
 }

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-with-dot-dep/package.json
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-with-dot-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dot-dep-project",
+  "version": "1.0.0",
+  "dependencies": {
+    "ms": "2.1.2",
+    "debug": "4.3.1"
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-with-dot-dep/pnpm-lock.yaml
+++ b/test/jest/dep-graph-builders/fixtures/pnpm-lock-v6/workspace-with-dot-dep/pnpm-lock.yaml
@@ -1,0 +1,45 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  ms:
+    specifier: 2.1.2
+    version: 2.1.2
+
+  .:
+    dependencies:
+      ms:
+        specifier: 2.1.2
+        version: 2.1.2
+      debug:
+        specifier: 4.3.1
+        version: 4.3.1
+    devDependencies:
+      sass:
+        specifier: 1.77.8
+        version: 1.77.8
+
+packages:
+
+  /debug@4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
+  /ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: false
+
+  /sass@1.77.8:
+    resolution: {integrity: sha512-abcdefg==}
+    dev: true

--- a/test/jest/dep-graph-builders/pnpm-lock.test.ts
+++ b/test/jest/dep-graph-builders/pnpm-lock.test.ts
@@ -285,6 +285,43 @@ describe.each(['pnpm-lock-v5', 'pnpm-lock-v6', 'pnpm-lock-v9'])(
         expect(deGraph).toBeDefined();
       });
 
+      it('project: dot-as-dependency does not crash and processes nested deps when "." appears in root dependencies', async () => {
+        const fixtureName = 'workspace-with-dot-dep';
+        const pkgJsonContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/pnpm-lock-v6/${fixtureName}/package.json`,
+          ),
+          'utf8',
+        );
+        const pnpmLockContent = readFileSync(
+          join(
+            __dirname,
+            `./fixtures/pnpm-lock-v6/${fixtureName}/pnpm-lock.yaml`,
+          ),
+          'utf8',
+        );
+        const depGraph = await parsePnpmProject(
+          pkgJsonContent,
+          pnpmLockContent,
+          {
+            includeDevDeps: false,
+            includeOptionalDeps: false,
+            strictOutOfSync: true,
+            pruneWithinTopLevelDeps: false,
+          },
+        );
+        expect(depGraph).toBeDefined();
+        expect(depGraph.rootPkg.name).toEqual('dot-dep-project');
+
+        // '.' should not appear as a dependency
+        const depPkgNames = depGraph.getDepPkgs().map((pkg) => pkg.name);
+        expect(depPkgNames).not.toContain('.');
+        // deps from the '.' nested block should be resolved
+        expect(depPkgNames).toContain('ms');
+        expect(depPkgNames).toContain('debug');
+      });
+
       it('project: simple-top-level-out-of-sync does not throws OutOfSyncError for strictOutOfSync=false', async () => {
         const fixtureName = 'missing-top-level-deps';
         const pkgJsonContent = readFileSync(


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

We've found PNPM v6 lockfiles where the importers `.` dependency list is directly inside the top-level dependency list, rather than under `importers` like in v9 lockfiles. This PR normalises this scenario so it can be handled like v9 lockfiles.

### Notes for the reviewer


### More information

- [Jira OSM-3624](https://snyksec.atlassian.net/browse/OSM-3624)