### PR TITLE
fix: use actual package name from lockfile for aliased packages

### DIFF
--- a/lib/dep-graph-builders/npm-lock-v2/index.ts
+++ b/lib/dep-graph-builders/npm-lock-v2/index.ts
@@ -96,16 +96,25 @@ export const buildDepGraphNpmLockV2 = async (
 
   const pkgKeysByName: Map<string, string[]> = Object.keys(npmLockPkgs).reduce(
     (acc, key) => {
-      const name = key.replace(/.*node_modules\//, '');
-      if (!name) {
+      const folderName = key.replace(/.*node_modules\//, '');
+      if (!folderName) {
         return acc;
       }
 
-      if (!acc.has(name)) {
-        acc.set(name, []);
+      // Add entry for folder name
+      if (!acc.has(folderName)) {
+        acc.set(folderName, []);
       }
+      acc.get(folderName)!.push(key);
 
-      acc.get(name)!.push(key);
+      // Also add entry for actual package name if it differs from folder name (aliased packages)
+      const actualName = npmLockPkgs[key].name;
+      if (actualName && actualName !== folderName) {
+        if (!acc.has(actualName)) {
+          acc.set(actualName, []);
+        }
+        acc.get(actualName)!.push(key);
+      }
 
       return acc;
     },
@@ -379,9 +388,14 @@ const getChildNode = (
       })
     : {};
 
+  // Use the actual package name from the lockfile entry if it exists (for aliased packages),
+  // otherwise use the aliasInfo target name if available, otherwise use the dependency name
+  const actualPackageName =
+    depData.name ?? aliasInfo?.aliasTargetDepName ?? name;
+
   return {
-    id: `${name}@${depData.version}`,
-    name: aliasInfo?.aliasTargetDepName ?? name,
+    id: `${actualPackageName}@${depData.version}`,
+    name: actualPackageName,
     version: depData.version,
     dependencies: {
       ...dependencies,

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/alias-with-nested-deps/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/alias-with-nested-deps/expected.json
@@ -41,12 +41,12 @@
         "pkgId": "alias-nested-deps-test@1.0.0",
         "deps": [
           {
-            "nodeId": "lib-v3@3.0.0"
+            "nodeId": "@example/component-lib@3.0.0"
           }
         ]
       },
       {
-        "nodeId": "lib-v3@3.0.0",
+        "nodeId": "@example/component-lib@3.0.0",
         "pkgId": "@example/component-lib@3.0.0",
         "deps": [
           {

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/dist-tag-sub-dependency/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/dist-tag-sub-dependency/expected.json
@@ -5474,19 +5474,19 @@
             "nodeId": "string-width@5.1.2"
           },
           {
-            "nodeId": "string-width-cjs@4.2.3"
+            "nodeId": "string-width@4.2.3"
           },
           {
             "nodeId": "strip-ansi@7.1.0"
           },
           {
-            "nodeId": "strip-ansi-cjs@6.0.1"
+            "nodeId": "strip-ansi@6.0.1"
           },
           {
             "nodeId": "wrap-ansi@8.1.0"
           },
           {
-            "nodeId": "wrap-ansi-cjs@7.0.0"
+            "nodeId": "wrap-ansi@7.0.0"
           }
         ],
         "info": {
@@ -5560,7 +5560,7 @@
         }
       },
       {
-        "nodeId": "string-width-cjs@4.2.3",
+        "nodeId": "string-width@4.2.3",
         "pkgId": "string-width@4.2.3",
         "deps": [
           {
@@ -5601,21 +5601,6 @@
         }
       },
       {
-        "nodeId": "strip-ansi-cjs@6.0.1",
-        "pkgId": "strip-ansi@6.0.1",
-        "deps": [
-          {
-            "nodeId": "ansi-regex@5.0.1"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod",
-            "alias": "strip-ansi-cjs=>strip-ansi@6.0.1"
-          }
-        }
-      },
-      {
         "nodeId": "wrap-ansi@8.1.0",
         "pkgId": "wrap-ansi@8.1.0",
         "deps": [
@@ -5646,7 +5631,7 @@
         }
       },
       {
-        "nodeId": "wrap-ansi-cjs@7.0.0",
+        "nodeId": "wrap-ansi@7.0.0",
         "pkgId": "wrap-ansi@7.0.0",
         "deps": [
           {
@@ -5698,26 +5683,6 @@
         "nodeId": "color-name@1.1.4",
         "pkgId": "color-name@1.1.4",
         "deps": [],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "string-width@4.2.3",
-        "pkgId": "string-width@4.2.3",
-        "deps": [
-          {
-            "nodeId": "emoji-regex@8.0.0"
-          },
-          {
-            "nodeId": "is-fullwidth-code-point@3.0.0"
-          },
-          {
-            "nodeId": "strip-ansi@6.0.1"
-          }
-        ],
         "info": {
           "labels": {
             "scope": "prod"
@@ -6379,26 +6344,6 @@
           },
           {
             "nodeId": "wrap-ansi@7.0.0"
-          }
-        ],
-        "info": {
-          "labels": {
-            "scope": "prod"
-          }
-        }
-      },
-      {
-        "nodeId": "wrap-ansi@7.0.0",
-        "pkgId": "wrap-ansi@7.0.0",
-        "deps": [
-          {
-            "nodeId": "ansi-styles@4.3.0"
-          },
-          {
-            "nodeId": "string-width@4.2.3"
-          },
-          {
-            "nodeId": "strip-ansi@6.0.1"
           }
         ],
         "info": {

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/transitive-resolves-to-alias/expected.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/transitive-resolves-to-alias/expected.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "1.3.0",
+  "pkgManager": {
+    "name": "npm"
+  },
+  "pkgs": [
+    {
+      "id": "transitive-resolves-to-alias@1.0.0",
+      "info": {
+        "name": "transitive-resolves-to-alias",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "parent-with-alias@1.0.0",
+      "info": {
+        "name": "parent-with-alias",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "@scoped/shared-dep@",
+      "info": {
+        "name": "@scoped/shared-dep"
+      }
+    },
+    {
+      "id": "parent-without-alias@1.0.0",
+      "info": {
+        "name": "parent-without-alias",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "shared-dep@",
+      "info": {
+        "name": "shared-dep"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "transitive-resolves-to-alias@1.0.0",
+        "deps": [
+          {
+            "nodeId": "parent-with-alias@1.0.0"
+          },
+          {
+            "nodeId": "parent-without-alias@1.0.0"
+          }
+        ]
+      },
+      {
+        "nodeId": "parent-with-alias@1.0.0",
+        "pkgId": "parent-with-alias@1.0.0",
+        "deps": [
+          {
+            "nodeId": "@scoped/shared-dep@undefined"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "@scoped/shared-dep@undefined",
+        "pkgId": "@scoped/shared-dep@",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod",
+            "alias": "shared-dep=>@scoped/shared-dep@undefined"
+          }
+        }
+      },
+      {
+        "nodeId": "parent-without-alias@1.0.0",
+        "pkgId": "parent-without-alias@1.0.0",
+        "deps": [
+          {
+            "nodeId": "shared-dep@undefined"
+          }
+        ],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      },
+      {
+        "nodeId": "shared-dep@undefined",
+        "pkgId": "shared-dep@",
+        "deps": [],
+        "info": {
+          "labels": {
+            "scope": "prod"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/transitive-resolves-to-alias/package-lock.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/transitive-resolves-to-alias/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "transitive-resolves-to-alias",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transitive-resolves-to-alias",
+      "version": "1.0.0",
+      "dependencies": {
+        "parent-with-alias": "1.0.0",
+        "parent-without-alias": "1.0.0"
+      }
+    },
+    "node_modules/@scoped/shared-dep": {
+      "name": "@scoped/shared-dep",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@scoped/shared-dep/-/shared-dep-1.0.0.tgz",
+      "integrity": "sha512-..."
+    },
+    "node_modules/parent-with-alias": {
+      "version": "1.0.0",
+      "resolved": "file:parent-with-alias",
+      "dependencies": {
+        "shared-dep": "npm:@scoped/shared-dep@^1.0.0"
+      }
+    },
+    "node_modules/parent-without-alias": {
+      "version": "1.0.0",
+      "resolved": "file:parent-without-alias",
+      "dependencies": {
+        "shared-dep": "^1.0.0"
+      }
+    },
+    "node_modules/shared-dep": {
+      "resolved": "node_modules/@scoped/shared-dep"
+    },
+    "parent-with-alias": {
+      "version": "1.0.0",
+      "hasInstallScript": true
+    },
+    "parent-without-alias": {
+      "version": "1.0.0",
+      "hasInstallScript": true
+    }
+  }
+}

--- a/test/jest/dep-graph-builders/fixtures/npm-lock-v2/transitive-resolves-to-alias/package.json
+++ b/test/jest/dep-graph-builders/fixtures/npm-lock-v2/transitive-resolves-to-alias/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "transitive-resolves-to-alias",
+  "version": "1.0.0",
+  "dependencies": {
+    "parent-with-alias": "1.0.0",
+    "parent-without-alias": "1.0.0"
+  }
+}

--- a/test/jest/dep-graph-builders/npm-lock-v2.test.ts
+++ b/test/jest/dep-graph-builders/npm-lock-v2.test.ts
@@ -26,6 +26,7 @@ describe('dep-graph-builder npm-lock-v2', () => {
         'missing-optional-dep-minimal',
         'workspace-nested-deps',
         'nested-non-alias-with-top-level-alias',
+        'transitive-resolves-to-alias',
       ])('[simple tests] project: %s ', (fixtureName) => {
         it('matches expected', async () => {
           const pkgJsonContent = readFileSync(


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [ ] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [ ] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

## Problem

When a transitive dependency resolves to an aliased package in node_modules,
the parser was incorrectly using the folder name (alias) instead of the actual
package name from the lockfile.

Example scenario:
- `plotly.js` declares: `"regl": "npm:@plotly/regl@^2.1.2"` (explicit alias)
- `gl-text` declares: `"regl": "^2.0.0"` (regular dependency, not an alias)
- Both resolve to `node_modules/regl` which contains `@plotly/regl`

The parser was returning `regl@2.1.2` instead of `@plotly/regl@2.1.2` for
the `gl-text` dependency, causing:
- Incorrect vulnerability scanning (checking wrong package)
- Incorrect SBOM generation (reporting wrong package)
- Incorrect license compliance (checking wrong package)

## Solution

Use the `name` field from the lockfile entry as the authoritative source for
the actual package name. According to npm lockfile v2/v3 specification, the
`name` field contains the actual package name, which may differ from the
installation path for aliased packages.
