### PR TITLE
fix: surface underlying npm lockfile JSON parse errors [OSM-3753]

### DIFF
--- a/lib/dep-graph-builders/npm-lock-v2/extract-npm-lock-v2-pkgs.ts
+++ b/lib/dep-graph-builders/npm-lock-v2/extract-npm-lock-v2-pkgs.ts
@@ -1,3 +1,5 @@
+import { parseJsonFile } from '../../utils';
+
 // Values from the packages key on Npm Lock V2+
 export type NpmLockPkg = {
   name?: string;
@@ -18,5 +20,8 @@ export type NpmLockPkg = {
 export const extractPkgsFromNpmLockV2 = (
   pkgLockContent: string,
 ): Record<string, NpmLockPkg> => {
-  return JSON.parse(pkgLockContent).packages;
+  return parseJsonFile<{ packages: Record<string, NpmLockPkg> }>(
+    pkgLockContent,
+    'package-lock.json',
+  ).packages;
 };

--- a/lib/dep-graph-builders/util.ts
+++ b/lib/dep-graph-builders/util.ts
@@ -1,9 +1,9 @@
 import { DepGraphBuildOptions, PackageJsonBase } from './types';
 import { DepGraphBuilder } from '@snyk/dep-graph';
 import type { NodeInfo } from '@snyk/dep-graph/dist/core/types';
-import { InvalidUserInputError } from '../errors';
 import { NormalisedPkgs } from './types';
 import { OutOfSyncError } from '../errors';
+import { parseJsonFile } from '../utils';
 import { LockfileType } from '../parsers';
 import { parseNpmAlias } from '../aliasesPreprocessors/pkgJson';
 
@@ -193,17 +193,14 @@ export const getGraphDependencies = (
 };
 
 export function parsePkgJson(pkgJsonContent: string): PackageJsonBase {
-  try {
-    const parsedPkgJson = JSON.parse(pkgJsonContent);
-    if (!parsedPkgJson.name) {
-      parsedPkgJson.name = 'package.json';
-    }
-    return parsedPkgJson;
-  } catch (e) {
-    throw new InvalidUserInputError(
-      'package.json parsing failed with error ' + (e as Error).message,
-    );
+  const parsedPkgJson = parseJsonFile<PackageJsonBase>(
+    pkgJsonContent,
+    'package.json',
+  );
+  if (!parsedPkgJson.name) {
+    parsedPkgJson.name = 'package.json';
   }
+  return parsedPkgJson;
 }
 
 export const getChildNode = (

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -3,6 +3,7 @@ import { YarnLock } from './yarn-lock-parser';
 import { InvalidUserInputError } from '../errors';
 import { Yarn2Lock } from './yarn2-lock-parser';
 import { load, FAILSAFE_SCHEMA } from 'js-yaml';
+import { parseJsonFile } from '../utils';
 
 export interface Dep {
   name: string;
@@ -115,13 +116,7 @@ export interface LockfileParser {
 export type Lockfile = PackageLock | YarnLock | Yarn2Lock;
 
 export function parseManifestFile(manifestFileContents: string): ManifestFile {
-  try {
-    return JSON.parse(manifestFileContents);
-  } catch (e) {
-    throw new InvalidUserInputError(
-      'package.json parsing failed with error ' + (e as Error).message,
-    );
-  }
+  return parseJsonFile<ManifestFile>(manifestFileContents, 'package.json');
 }
 
 export function getTopLevelDeps({

--- a/lib/parsers/package-lock-parser.ts
+++ b/lib/parsers/package-lock-parser.ts
@@ -7,9 +7,9 @@ import {
   PkgTree,
   Scope,
 } from './index';
-import { InvalidUserInputError } from '../errors';
 import { DepMap, DepMapItem, LockParserBase } from './lock-parser-base';
 import { config } from '../config';
+import { parseJsonFile } from '../utils';
 
 export interface PackageLock {
   name: string;
@@ -38,20 +38,14 @@ export class PackageLockParser extends LockParserBase {
   }
 
   public parseLockFile(lockFileContents: string): PackageLock {
-    try {
-      const packageLock: PackageLock = JSON.parse(lockFileContents);
-      packageLock.type =
-        packageLock.lockfileVersion === 1
-          ? LockfileType.npm
-          : LockfileType.npm7;
-      this.type = packageLock.type;
-      return packageLock;
-    } catch (e) {
-      throw new InvalidUserInputError(
-        'package-lock.json parsing failed with ' +
-          `error ${(e as Error).message}`,
-      );
-    }
+    const packageLock: PackageLock = parseJsonFile<PackageLock>(
+      lockFileContents,
+      'package-lock.json',
+    );
+    packageLock.type =
+      packageLock.lockfileVersion === 1 ? LockfileType.npm : LockfileType.npm7;
+    this.type = packageLock.type;
+    return packageLock;
   }
 
   public async getDependencyTree(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -72,27 +72,70 @@ export function getNpmLockfileVersion(
   | NodeLockfileVersion.NpmLockV1
   | NodeLockfileVersion.NpmLockV2
   | NodeLockfileVersion.NpmLockV3 {
-  try {
-    const lockfileJson = JSON.parse(lockFileContents);
-    const lockfileVersion: number | null = lockfileJson.lockfileVersion || null;
+  // Parse first; surfacing the real JSON error happens inside parseJsonFile.
+  const lockfileJson = parseJsonFile(lockFileContents, 'package-lock.json');
 
-    switch (lockfileVersion) {
-      case null:
-      case 1:
-        return NodeLockfileVersion.NpmLockV1;
-      case 2:
-        return NodeLockfileVersion.NpmLockV2;
-      case 3:
-        return NodeLockfileVersion.NpmLockV3;
-      default:
-        throw new InvalidUserInputError(
-          `Unsupported npm lockfile version in package-lock.json. ` +
-            'Please provide a package-lock.json with lockfileVersion 1, 2 or 3',
-        );
-    }
+  // The version check runs *outside* the parse try/catch so that an
+  // unsupported (but otherwise valid JSON) lockfile is not mis-reported as a
+  // JSON syntax error.
+  const lockfileVersion: number | null = lockfileJson.lockfileVersion || null;
+  switch (lockfileVersion) {
+    case null:
+    case 1:
+      return NodeLockfileVersion.NpmLockV1;
+    case 2:
+      return NodeLockfileVersion.NpmLockV2;
+    case 3:
+      return NodeLockfileVersion.NpmLockV3;
+    default:
+      throw new InvalidUserInputError(
+        `Unsupported npm lockfile version "${lockfileVersion}" in package-lock.json. ` +
+          'Please provide a package-lock.json with lockfileVersion 1, 2 or 3',
+      );
+  }
+}
+
+/**
+ * Parse JSON from a manifest or lockfile. On failure throws an
+ * InvalidUserInputError that preserves the underlying parser message
+ * (including the position of the syntax error) and appends a best-effort hint
+ * about the likely cause.
+ *
+ * `fileLabel` is the file kind shown in the error, e.g. 'package.json' or
+ * 'package-lock.json'.
+ */
+export function parseJsonFile<T = any>(content: string, fileLabel: string): T {
+  try {
+    return JSON.parse(content);
   } catch (e) {
     throw new InvalidUserInputError(
-      `Problem parsing package-lock.json - make sure the package-lock.json is a valid JSON file`,
+      `${fileLabel} parsing failed with error ${(e as Error).message}` +
+        describeLikelyJsonCause(content),
     );
   }
+}
+
+/**
+ * Best-effort, allocation-light hint describing the most likely reason a JSON
+ * parse failed. Inspects only the leading characters of the content, never
+ * throws, and returns '' when nothing recognisable is found - so it is always
+ * safe to append to a parse-error message.
+ */
+export function describeLikelyJsonCause(content: string): string {
+  if (!content) {
+    return ' The file is empty.';
+  }
+  // A byte-order mark (UTF-8/UTF-16/UTF-32) decoded into the string.
+  if (content.charCodeAt(0) === 0xfeff) {
+    return ' The file begins with a byte-order mark (BOM); re-save it as UTF-8 without a BOM.';
+  }
+  // NUL bytes strongly suggest the file is UTF-16/UTF-32 encoded.
+  if (content.includes('\x00')) {
+    return ' The file contains NUL bytes; it may be UTF-16/UTF-32 encoded. Re-save it as UTF-8.';
+  }
+  // Unresolved git merge-conflict markers.
+  if (/^(<{7}|={7}|>{7})( |$)/m.test(content)) {
+    return ' The file appears to contain unresolved git merge-conflict markers.';
+  }
+  return '';
 }

--- a/test/jest/utils/get-npm-lockfile-version.test.ts
+++ b/test/jest/utils/get-npm-lockfile-version.test.ts
@@ -1,0 +1,110 @@
+// Import from the narrow modules (not the package index) so this focused unit
+// test does not pull in the whole dep-graph-builder import graph.
+import { getNpmLockfileVersion, NodeLockfileVersion } from '../../../lib/utils';
+import { InvalidUserInputError } from '../../../lib/errors';
+
+describe('getNpmLockfileVersion', () => {
+  const validV1 = JSON.stringify({ name: 'fixture', lockfileVersion: 1 });
+  const validV2 = JSON.stringify({
+    name: 'fixture',
+    lockfileVersion: 2,
+    packages: {},
+  });
+  const validV3 = JSON.stringify({
+    name: 'fixture',
+    lockfileVersion: 3,
+    packages: {},
+  });
+  const noVersion = JSON.stringify({ name: 'fixture' });
+
+  describe('valid lockfiles (regression)', () => {
+    it('detects V1 when lockfileVersion is 1', () => {
+      expect(getNpmLockfileVersion(validV1)).toBe(
+        NodeLockfileVersion.NpmLockV1,
+      );
+    });
+
+    it('detects V1 when lockfileVersion is absent', () => {
+      expect(getNpmLockfileVersion(noVersion)).toBe(
+        NodeLockfileVersion.NpmLockV1,
+      );
+    });
+
+    it('detects V2', () => {
+      expect(getNpmLockfileVersion(validV2)).toBe(
+        NodeLockfileVersion.NpmLockV2,
+      );
+    });
+
+    it('detects V3', () => {
+      expect(getNpmLockfileVersion(validV3)).toBe(
+        NodeLockfileVersion.NpmLockV3,
+      );
+    });
+  });
+
+  describe('surfaces the underlying parse error (Defect 1)', () => {
+    it('preserves the JSON syntax error instead of the old generic message', () => {
+      let message = '';
+      try {
+        // truncated JSON
+        getNpmLockfileVersion('{ "lockfileVersion": 3, ');
+      } catch (e) {
+        message = (e as Error).message;
+      }
+      expect(message).toContain('package-lock.json parsing failed with error');
+      // the underlying SyntaxError text must come through...
+      expect(message.length).toBeGreaterThan(
+        'package-lock.json parsing failed with error'.length,
+      );
+      // ...and the old, unhelpful message must be gone
+      expect(message).not.toContain(
+        'make sure the package-lock.json is a valid JSON file',
+      );
+    });
+
+    it('throws an InvalidUserInputError', () => {
+      expect(() => getNpmLockfileVersion('not json')).toThrow(
+        InvalidUserInputError,
+      );
+    });
+
+    it('hints at a leading byte-order mark (BOM)', () => {
+      expect(() => getNpmLockfileVersion('﻿' + validV3)).toThrow(
+        /byte-order mark/i,
+      );
+    });
+
+    it('hints at NUL bytes / wide (UTF-16) encoding', () => {
+      // a UTF-16LE buffer decoded as UTF-8 interleaves NUL bytes
+      const utf16Decoded = Buffer.from(validV3, 'utf16le').toString('utf-8');
+      expect(() => getNpmLockfileVersion(utf16Decoded)).toThrow(/UTF-16/i);
+    });
+
+    it('hints at unresolved git merge-conflict markers', () => {
+      const conflicted = `<<<<<<< HEAD\n${validV3}\n=======\n{}\n>>>>>>> branch\n`;
+      expect(() => getNpmLockfileVersion(conflicted)).toThrow(
+        /merge-conflict markers/i,
+      );
+    });
+
+    it('hints at an empty file', () => {
+      expect(() => getNpmLockfileVersion('')).toThrow(/empty/i);
+    });
+  });
+
+  describe('does not mask an unsupported version (Defect 2)', () => {
+    it('reports the unsupported version, not a JSON parse error', () => {
+      const unsupported = JSON.stringify({
+        name: 'fixture',
+        lockfileVersion: 99,
+      });
+      expect(() => getNpmLockfileVersion(unsupported)).toThrow(
+        /Unsupported npm lockfile version "99"/,
+      );
+      expect(() => getNpmLockfileVersion(unsupported)).not.toThrow(
+        /parsing failed/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
getNpmLockfileVersion() wrapped JSON.parse in a try/catch that discarded the underlying SyntaxError and always threw a generic "Problem parsing package-lock.json - make sure it is a valid JSON file" message. This made real causes (a leading BOM, UTF-16 encoding, unresolved merge-conflict markers, truncation) impossible to diagnose. The same catch also enclosed the "unsupported lockfile version" throw, so a valid-JSON file with an unsupported version was mis-reported as malformed JSON.

Changes:
- Introduce a shared parseJsonFile(content, fileLabel) helper that throws an InvalidUserInputError preserving the underlying parser message (with position) plus a best-effort describeLikelyJsonCause() hint (BOM, NUL/ UTF-16, merge-conflict markers, empty file).
- Restructure getNpmLockfileVersion so the version switch runs outside the parse try/catch, no longer masking unsupported-version errors.
- Route parseManifestFile, parsePkgJson, PackageLockParser.parseLockFile and the previously unguarded extractPkgsFromNpmLockV2 through the shared helper, preserving their existing message formats.
- Add focused unit tests for getNpmLockfileVersion.

No error class / HTTP code changes (still InvalidUserInputError / 422), so this is non-breaking. Adopting the Error Catalog classes is left as a separate, coordinated change.

- [X] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [X] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [X] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

Improves the error handling so the error with the right context is forwarded to logs/ui.

### Notes for the reviewer

### More information

OSM-3753

### Screenshots

